### PR TITLE
[WIP] views: fix support of language in markdown fenced code block

### DIFF
--- a/resources/assets/js/directives.js
+++ b/resources/assets/js/directives.js
@@ -2,6 +2,10 @@
 import DropZone from "dropzone";
 import markdown from "marked";
 
+markdown.setOptions({
+    langPrefix: ''
+});
+
 export default function (ngApp, events) {
 
     /**

--- a/resources/views/partials/highlight.blade.php
+++ b/resources/views/partials/highlight.blade.php
@@ -2,9 +2,10 @@
 <script src="{{ baseUrl('/libs/highlightjs/highlight.min.js') }}"></script>
 <script>
     $(function() {
-        var aCodes = document.getElementsByTagName('pre');
-        for (var i=0; i < aCodes.length; i++) {
-            hljs.highlightBlock(aCodes[i]);
-        }
+        $(document).ready(function() {
+            $('pre code').each(function(i, block) {
+                hljs.highlightBlock(block);
+            });
+        });
     });
 </script>


### PR DESCRIPTION
This PR fixes the support of language in markdown fenced code blocks by calling `hljs.highlightBlock()` on `pre code` instead of `pre`.

Fixes #296 