### PR TITLE
Queue confirmation emails.

### DIFF
--- a/app/Notifications/ConfirmEmail.php
+++ b/app/Notifications/ConfirmEmail.php
@@ -2,6 +2,7 @@
 
 namespace BookStack\Notifications;
 
+use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;

--- a/app/Notifications/ConfirmEmail.php
+++ b/app/Notifications/ConfirmEmail.php
@@ -3,11 +3,14 @@
 namespace BookStack\Notifications;
 
 use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 
-class ConfirmEmail extends Notification
+class ConfirmEmail extends Notification implements ShouldQueue
 {
 
+    use Queueable;
+    
     public $token;
 
     /**


### PR DESCRIPTION
Implements Laravel's queue abilities into the email notification job. Should not affect existing installations that are not using queues as the environment file defaults to `sync`.