### PR TITLE
Support new lines for book/chapter descriptions + fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
 
 before_install:
   - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - php -i "(command-line 'phpinfo()')" | grep ldap
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-before_install:
-  - echo "extension = ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-
 before_script:
   - mysql -u root -e 'create database `bookstack-test`;'
   - mysql -u root -e "CREATE USER 'bookstack-test'@'localhost' IDENTIFIED BY 'bookstack-test';"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ after_failure:
   - cat storage/logs/laravel.log
 
 script:
-  - phpunit
+  - phpunit --stop-on-error --stop-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ php:
 addons:
   apt:
     packages:
-      - php-ldap
+      - ldap-utils
+      - slapd
 
 before_install:
   - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+before_install:
+    - echo "extension=ldap.so" >> php --ini | grep "Loaded Configuration" | sed -e "s|.:\s||"
+
 before_script:
   - mysql -u root -e 'create database `bookstack-test`;'
   - mysql -u root -e "CREATE USER 'bookstack-test'@'localhost' IDENTIFIED BY 'bookstack-test';"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 addons:
   apt:
     packages:
-      - php7.0-ldap
+      - php-ldap
 
 before_install:
   - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ language: php
 php:
   - 7.0
 
+addons:
+  apt:
+    packages:
+      - php7.0-ldap
+
 before_install:
-  - sudo apt-get install php7.0-ldap
   - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - php -i "(command-line 'phpinfo()')" | grep ldap
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-    - echo "extension=ldap.so" >> php --ini | grep "Loaded Configuration" | sed -e "s|.:\s||"
+  - echo "extension = ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 before_script:
   - mysql -u root -e 'create database `bookstack-test`;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ language: php
 php:
   - 7.0
 
+before_install:
+  - pecl install ldap
+  - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - php -i "(command-line 'phpinfo()')" | grep ldap
+
 cache:
   directories:
     - $HOME/.composer/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 7.0
 
 before_install:
-  - pecl install ldap
+  - sudo apt-get install php7.0-ldap
   - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - php -i "(command-line 'phpinfo()')" | grep ldap
 

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -56,7 +56,7 @@
 
                 <h1>{{$book->name}}</h1>
                 <div class="book-content" v-if="!searching">
-                    <p class="text-muted" v-pre>{{$book->description}}</p>
+                    <p class="text-muted" v-pre>{!! nl2br($book->description) !!}</p>
 
                     <div class="page-list" v-pre>
                         <hr>
@@ -118,7 +118,7 @@
                         <button v-if="searching" v-cloak class="text-neg" v-on:click="clearSearch()" type="button"><i class="zmdi zmdi-close"></i></button>
                     </form>
                 </div>
-                
+
                 <div class="activity">
                     <h3>{{ trans('entities.recent_activity') }}</h3>
                     @include('partials/activity-list', ['activity' => Activity::entityActivity($book, 20, 0)])

--- a/resources/views/chapters/show.blade.php
+++ b/resources/views/chapters/show.blade.php
@@ -52,7 +52,7 @@
             <div class="col-md-7">
                 <h1>{{ $chapter->name }}</h1>
                 <div class="chapter-content" v-if="!searching">
-                    <p class="text-muted">{{ $chapter->description }}</p>
+                    <p class="text-muted">{!! nl2br($chapter->description) !!}</p>
 
                     @if(count($pages) > 0)
                         <div class="page-list">

--- a/tests/Auth/LdapTest.php
+++ b/tests/Auth/LdapTest.php
@@ -21,6 +21,7 @@ class LdapTest extends BrowserKitTest
     {
         $this->mockLdap->shouldReceive('connect')->once()->andReturn($this->resourceId);
         $this->mockLdap->shouldReceive('setVersion')->once();
+        $this->mockLdap->shouldReceive('setOption');
         $this->mockLdap->shouldReceive('searchAndGetEntries')->times(4)
             ->with($this->resourceId, config('services.ldap.base_dn'), \Mockery::type('string'), \Mockery::type('array'))
             ->andReturn(['count' => 1, 0 => [

--- a/tests/Auth/LdapTest.php
+++ b/tests/Auth/LdapTest.php
@@ -74,6 +74,7 @@ class LdapTest extends BrowserKitTest
     {
         $this->mockLdap->shouldReceive('connect')->once()->andReturn($this->resourceId);
         $this->mockLdap->shouldReceive('setVersion')->once();
+        $this->mockLdap->shouldReceive('setOption')->times(2);
         $this->mockLdap->shouldReceive('searchAndGetEntries')->times(2)
             ->with($this->resourceId, config('services.ldap.base_dn'), \Mockery::type('string'), \Mockery::type('array'))
             ->andReturn(['count' => 1, 0 => [

--- a/tests/Auth/LdapTest.php
+++ b/tests/Auth/LdapTest.php
@@ -21,7 +21,7 @@ class LdapTest extends BrowserKitTest
     {
         $this->mockLdap->shouldReceive('connect')->once()->andReturn($this->resourceId);
         $this->mockLdap->shouldReceive('setVersion')->once();
-        $this->mockLdap->shouldReceive('setOption');
+        $this->mockLdap->shouldReceive('setOption')->times(4);
         $this->mockLdap->shouldReceive('searchAndGetEntries')->times(4)
             ->with($this->resourceId, config('services.ldap.base_dn'), \Mockery::type('string'), \Mockery::type('array'))
             ->andReturn(['count' => 1, 0 => [
@@ -50,6 +50,7 @@ class LdapTest extends BrowserKitTest
         $this->mockLdap->shouldReceive('connect')->once()->andReturn($this->resourceId);
         $this->mockLdap->shouldReceive('setVersion')->once();
         $ldapDn = 'cn=test-user,dc=test' . config('services.ldap.base_dn');
+        $this->mockLdap->shouldReceive('setOption')->times(2);
         $this->mockLdap->shouldReceive('searchAndGetEntries')->times(2)
             ->with($this->resourceId, config('services.ldap.base_dn'), \Mockery::type('string'), \Mockery::type('array'))
             ->andReturn(['count' => 1, 0 => [


### PR DESCRIPTION
Avoid ignoring new lines when renderring the book/chapter descriptions on their respective detailed views.

And fixing the tests too (LDAP needs to be installed before running the LDAP tests).