### PR TITLE
Update search.js

### DIFF
--- a/resources/assets/js/vues/search.js
+++ b/resources/assets/js/vues/search.js
@@ -149,7 +149,7 @@ let methods = {
 
     updateSearch(e) {
         e.preventDefault();
-        window.location = '/search?term=' + encodeURIComponent(this.termString);
+        window.location = window.baseUrl('/search?term=' + encodeURIComponent(this.termString));
     },
 
     enableDate(optionName) {


### PR DESCRIPTION
Trying to apply an exact match or tag on the search page would previously redirect to /search, regardless of the installation path.