### PR TITLE
Fix ajax tag suggestion for subdir installs

### DIFF
--- a/resources/views/pages/form-toolbox.blade.php
+++ b/resources/views/pages/form-toolbox.blade.php
@@ -19,11 +19,11 @@
                 <div v-for="(tag, i) in tags" :key="tag.key" class="card drag-card">
                     <div class="handle" ><i class="zmdi zmdi-menu"></i></div>
                     <div>
-                        <autosuggest url="/ajax/tags/suggest/names" type="name" class="outline" :name="getTagFieldName(i, 'name')"
+                        <autosuggest url="{{ baseUrl('/ajax/tags/suggest/names') }}" type="name" class="outline" :name="getTagFieldName(i, 'name')"
                                      v-model="tag.name" @input="tagChange(tag)" @blur="tagBlur(tag)" placeholder="{{ trans('entities.tag') }}"/>
                     </div>
                     <div>
-                        <autosuggest url="/ajax/tags/suggest/values" type="value" class="outline" :name="getTagFieldName(i, 'value')"
+                        <autosuggest url="{{ baseUrl('/ajax/tags/suggest/values') }}" type="value" class="outline" :name="getTagFieldName(i, 'value')"
                                      v-model="tag.value" @change="tagChange(tag)" @blur="tagBlur(tag)" placeholder="{{ trans('entities.tag_value') }}"/>
                     </div>
                     <div v-show="tags.length !== 1" class="text-center drag-card-action text-neg" @click="removeTag(tag)"><i class="zmdi zmdi-close"></i></div>


### PR DESCRIPTION
Fixes #513. Tag suggest URLs were hardcoded to /ajax in blade template. Wrapped them in baseUrl()