### PR TITLE
Updated BookController:store method to sanitize input

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -72,7 +72,7 @@ class BookController extends Controller
     {
         $this->checkPermission('book-create-all');
         $this->validate($request, [
-            'name' => 'required|string|max:255',
+            'name' => 'required|alpha_dash|notIn:create|max:255',
             'description' => 'string|max:1000'
         ]);
         $book = $this->entityRepo->createFromInput('book', $request->all());


### PR DESCRIPTION
Fixed a bug where a person could mess up the router by having books with slashes in the name as well as create books with the name of the `create`, which makes a book that is totally accessible since the route `/books/create` is already used for the book creation view.