### PR TITLE
Adds overflow:auto to popup content to allow it to scroll in lower res.

### DIFF
--- a/resources/assets/sass/_components.scss
+++ b/resources/assets/sass/_components.scss
@@ -102,6 +102,10 @@
     display: flex;
     align-self: flex-start;
   }
+
+  .popup-content {
+    overflow-y: auto;
+  }
 }
 
 .corner-button {

--- a/resources/views/components/code-editor.blade.php
+++ b/resources/views/components/code-editor.blade.php
@@ -7,7 +7,7 @@
                 <button class="overlay-close neg corner-button button" @click="hide()">x</button>
             </div>
 
-            <div class="padded">
+            <div class="padded popup-content">
                 <div class="form-group">
                     <label for="code-editor-language">{{ trans('components.code_language') }}</label>
                     <div class="lang-options">


### PR DESCRIPTION
Towards #650

Although adding a scroll-bar to the modal although is a fairly simple solution, it causes two scroll-bars to appear on the popup if the content in the code editor is more.

![screen shot 2018-01-06 at 01 38 23](https://user-images.githubusercontent.com/1685517/34626366-677a3e40-f282-11e7-9617-cd867121a01a.png)

@ssddanbrown - Any ideas?

Signed-off-by: Abijeet <abijeetpatro@gmail.com>
  