### PR TITLE
Adds ability to secure images behind auth

### DIFF
--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -1,6 +1,7 @@
 <?php namespace BookStack\Http\Controllers;
 
 use BookStack\Exceptions\ImageUploadException;
+use BookStack\Exceptions\NotFoundException;
 use BookStack\Repos\EntityRepo;
 use BookStack\Repos\ImageRepo;
 use Illuminate\Filesystem\Filesystem as File;
@@ -26,6 +27,21 @@ class ImageController extends Controller
         $this->file = $file;
         $this->imageRepo = $imageRepo;
         parent::__construct();
+    }
+
+    /**
+     * Provide an image file from storage.
+     * @param string $path
+     * @return mixed
+     */
+    public function showImage(string $path)
+    {
+        $path = storage_path('uploads/images/' . $path);
+        if (!file_exists($path)) {
+            abort(404);
+        }
+
+        return response()->file($path);
     }
 
     /**

--- a/app/Repos/ImageRepo.php
+++ b/app/Repos/ImageRepo.php
@@ -183,7 +183,6 @@ class ImageRepo
      * Get the thumbnail for an image.
      * If $keepRatio is true only the width will be used.
      * Checks the cache then storage to avoid creating / accessing the filesystem on every check.
-     *
      * @param Image $image
      * @param int $width
      * @param int $height
@@ -194,9 +193,9 @@ class ImageRepo
     {
         try {
             return $this->imageService->getThumbnail($image, $width, $height, $keepRatio);
-        } catch (FileNotFoundException $exception) {
-            $image->delete();
-            return [];
+        } catch (\Exception $exception) {
+            dd($exception);
+            return null;
         }
     }
 

--- a/app/Services/ImageService.php
+++ b/app/Services/ImageService.php
@@ -46,7 +46,6 @@ class ImageService extends UploadService
         return $this->saveNew($imageName, $imageData, $type, $uploadedTo);
     }
 
-
     /**
      * Gets an image from url and saves it to the database.
      * @param             $url
@@ -82,8 +81,6 @@ class ImageService extends UploadService
 
         $imagePath = '/uploads/images/' . $type . '/' . Date('Y-m-M') . '/';
 
-        if ($this->isLocal()) $imagePath = '/public' . $imagePath;
-
         while ($storage->exists($imagePath . $imageName)) {
             $imageName = str_random(3) . $imageName;
         }
@@ -95,8 +92,6 @@ class ImageService extends UploadService
         } catch (Exception $e) {
             throw new ImageUploadException(trans('errors.path_not_writable', ['filePath' => $fullPath]));
         }
-
-        if ($this->isLocal()) $fullPath = str_replace_first('/public', '', $fullPath);
 
         $imageDetails = [
             'name'       => $imageName,
@@ -112,8 +107,8 @@ class ImageService extends UploadService
             $imageDetails['updated_by'] = $userId;
         }
 
-        $image = Image::forceCreate($imageDetails);
-
+        $image = (new Image());
+        $image->forceFill($imageDetails)->save();
         return $image;
     }
 
@@ -124,14 +119,13 @@ class ImageService extends UploadService
      */
     protected function getPath(Image $image)
     {
-        return ($this->isLocal()) ? ('public/' . $image->path) : $image->path;
+        return $image->path;
     }
 
     /**
      * Get the thumbnail for an image.
      * If $keepRatio is true only the width will be used.
      * Checks the cache then storage to avoid creating / accessing the filesystem on every check.
-     *
      * @param Image $image
      * @param int $width
      * @param int $height
@@ -151,7 +145,6 @@ class ImageService extends UploadService
         }
 
         $storage = $this->getStorage();
-
         if ($storage->exists($thumbFilePath)) {
             return $this->getPublicUrl($thumbFilePath);
         }
@@ -161,9 +154,8 @@ class ImageService extends UploadService
         } catch (Exception $e) {
             if ($e instanceof \ErrorException || $e instanceof NotSupportedException) {
                 throw new ImageUploadException(trans('errors.cannot_create_thumbs'));
-            } else {
-                throw $e;
             }
+            throw $e;
         }
 
         if ($keepRatio) {
@@ -252,13 +244,11 @@ class ImageService extends UploadService
                     $storageUrl = 'https://s3-' . $storageDetails['region'] . '.amazonaws.com/' . $storageDetails['bucket'];
                 }
             }
-
             $this->storageUrl = $storageUrl;
         }
 
-        if ($this->isLocal()) $filePath = str_replace_first('public/', '', $filePath);
-
-        return ($this->storageUrl == false ? rtrim(baseUrl(''), '/') : rtrim($this->storageUrl, '/')) . $filePath;
+        $basePath = ($this->storageUrl == false) ? baseUrl('/') : $this->storageUrl;
+        return rtrim($basePath, '/') . $filePath;
     }
 
 

--- a/app/Services/UploadService.php
+++ b/app/Services/UploadService.php
@@ -40,7 +40,6 @@ class UploadService
         return $this->storageInstance;
     }
 
-
     /**
      * Check whether or not a folder is empty.
      * @param $path

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -56,7 +56,12 @@ return [
 
         'local' => [
             'driver' => 'local',
-            'root'   => base_path(),
+            'root' => public_path(),
+        ],
+
+        'local_secure' => [
+            'driver' => 'local',
+            'root'   => storage_path(),
         ],
 
         'ftp' => [

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,9 @@ Route::get('/translations', 'HomeController@getTranslations');
 // Authenticated routes...
 Route::group(['middleware' => 'auth'], function () {
 
+    Route::get('/uploads/images/{path}', 'ImageController@showImage')
+        ->where('path', '.*$');
+
     Route::group(['prefix' => 'pages'], function() {
         Route::get('/recently-created', 'PageController@showRecentlyCreated');
         Route::get('/recently-updated', 'PageController@showRecentlyUpdated');

--- a/storage/uploads/images/.gitignore
+++ b/storage/uploads/images/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This feature puts images behind the authentication barrier so they are only viewable by logged-in users. Permission levels not taken into account, It's simply based on 'Is user authed?'.

Cannot be used alongside public viewing.
Set to be opt-in for now.

Public image access should still be served by the webserver as before, Secure image access goes through the app so will have a performance penalty.

Still in testing. Would be great for folks to test on their setups for any issues. (Do not test on production instances though). I experienced issues doing something similar when initially creating BookStack but so far everything has been working without issue on my dev machine.

## Use Instructions

To use simply set `STORAGE_TYPE=local_secure` in your `.env` file.
Files will be stored in a `storage/uploads/images` folder similar to attachments.

If you are migrating to this option with existing images you will need to move all content in the folder `public/uploads/images` to `storage/uploads/images`.