### PR TITLE
Corrected the keys for okta auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,8 +47,8 @@ GITHUB_APP_SECRET=false
 GOOGLE_APP_ID=false
 GOOGLE_APP_SECRET=false
 OKTA_BASE_URL=false
-OKTA_KEY=false
-OKTA_SECRET=false
+OKTA_APP_ID=false
+OKTA_APP_SECRET=false
 
 # External services such as Gravatar
 DISABLE_EXTERNAL_SERVICES=false


### PR DESCRIPTION
.env.example had wrong keys for okta from the original PR which where changed in ```config/services.php?```
This PR changes these keys in .env.example to the ones uses in config/services.php to match other auth services.