### PR TITLE
Dont require email confirmation for new users using google auth with …

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -158,7 +158,10 @@ class RegisterController extends Controller
             $newUser->socialAccounts()->save($socialAccount);
         }
 
-        if (setting('registration-confirmation') || setting('registration-restrict')) {
+        if (setting('registration-restrict') && $socialAccount && $socialAccount['driver'] === 'google') {
+            $newUser->email_confirmed = true;
+            $newUser->save();
+        } elseif (setting('registration-confirmation') || setting('registration-restrict')) {
             $newUser->save();
 
             try {


### PR DESCRIPTION
…domain restriction

We use G Suite for all our users, we have restricted logins to our own domain only via the "registration restrict" setting and so we don't want to use verification emails.

This is the most basic implementation (which we're now using), please let me know if there is any appetite for this change and if so, if you'd like any extra settings. For example perhaps we could just have an extra setting like "Don't use verification emails with Google login when using domain restriction" ?