### PR TITLE
Add CACHE_PREFIX to the .env.example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ SESSION_DRIVER=file
 #CACHE_DRIVER=memcached
 #SESSION_DRIVER=memcached
 QUEUE_DRIVER=sync
-# A different prefix is useful when multiple bookstack instances use the same caching server
+# A different prefix is useful when multiple BookStack instances use the same caching server
 CACHE_PREFIX=bookstack
 
 # Memcached settings

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ SESSION_DRIVER=file
 #CACHE_DRIVER=memcached
 #SESSION_DRIVER=memcached
 QUEUE_DRIVER=sync
+# A different prefix is useful when multiple bookstack instances use the same caching server
+CACHE_PREFIX=bookstack
 
 # Memcached settings
 # If using a UNIX socket path for the host, set the port to 0


### PR DESCRIPTION
We had some problems with multiple BookStack instances using the same caching server. Perhaps it's a good idea to have this available in the `.env.example` file.