### PR TITLE
fix markdown editor resizing with long strings

### DIFF
--- a/resources/assets/sass/_forms.scss
+++ b/resources/assets/sass/_forms.scss
@@ -58,6 +58,7 @@
     flex-direction: column;
     border: 1px solid #DDD;
     width: 50%;
+    max-width: 50%;
   }
 }
 


### PR DESCRIPTION
This fixes #715 when I apply the change in my browser.