### PR TITLE
Reject crawlers by default

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow:
+Disallow: /


### PR DESCRIPTION
Hi,

This PR modifies `robots.txt` file so that crawlers are rejected by default.
I think it's a more secure default setting.
One who is in an indexing process generally knows what he does,  and then modifies `robots.txt` accordingly.

Thank you 👍 

Ben