### PR TITLE
POC: Dynamically Render Entity Links

### DIFF
--- a/app/Repos/EntityRepo.php
+++ b/app/Repos/EntityRepo.php
@@ -728,19 +728,35 @@ class EntityRepo
     public function renderInternalLinks($content, $ignorePermissions = false)
     {
         $matches = [];
-        preg_match_all('/<a .*href\="{{@([0-9]*)}}"/', $content, $matches);
+        preg_match_all('/<a .*href\="{{{*@([0-9]*)}}}*"/', $content, $matches);
         if (count($matches[0]) === 0) {
             return $content;
         }
         
-        foreach($matches[1] as $index => $pageId){
-            $matchedPage = $this->getById('page', $pageId, false, $ignorePermissions);
-            if ($matchedPage === null) {
-                $emptyLink = preg_replace('/href=".*"/', 'href="#"', $matches[0][$index]);
-                $content = str_replace($matches[0][$index], $emptyLink, $content);
-            } else {
-                $newLink = preg_replace('/href=".*"/', 'href="'.$matchedPage->getUrl().'"', $matches[0][$index]);
-                $content = str_replace($matches[0][$index], $newLink, $content);
+        foreach($matches[1] as $index => $entityId){
+            preg_match('/href=".*"/', $matches[0][$index], $hrefMatches);
+            $hrefAttribute = $hrefMatches[0];
+            $openBracketCount = substr_count($hrefAttribute, '{', 6);
+            $closeBracketCount = substr_count($hrefAttribute, '}', 6);
+            
+            if ($openBracketCount === $closeBracketCount){
+                if ($openBracketCount === 2){
+                    $matchedEntity = $this->getById('page', $entityId, false, $ignorePermissions);
+                }elseif ($openBracketCount === 3){
+                    $matchedEntity = $this->getById('chapter', $entityId, false, $ignorePermissions);
+                }elseif ($openBracketCount === 4){
+                    $matchedEntity = $this->getById('book', $entityId, false, $ignorePermissions);
+                }else{
+                    $matchedEntity = null;
+                }
+                
+                if ($matchedEntity === null) {
+                    $emptyLink = preg_replace('/href=".*"/', 'href="#"', $matches[0][$index]);
+                    $content = str_replace($matches[0][$index], $emptyLink, $content);
+                } else {
+                    $newLink = preg_replace('/href=".*"/', 'href="'.$matchedEntity->getUrl().'"', $matches[0][$index]);
+                    $content = str_replace($matches[0][$index], $newLink, $content);
+                }
             }
         }
         

--- a/app/Repos/EntityRepo.php
+++ b/app/Repos/EntityRepo.php
@@ -739,6 +739,7 @@ class EntityRepo
             $openBracketCount = substr_count($hrefAttribute, '{', 6);
             $closeBracketCount = substr_count($hrefAttribute, '}', 6);
             
+            $matchedEntity = null;
             if ($openBracketCount === $closeBracketCount){
                 if ($openBracketCount === 2){
                     $matchedEntity = $this->getById('page', $entityId, false, $ignorePermissions);
@@ -746,17 +747,15 @@ class EntityRepo
                     $matchedEntity = $this->getById('chapter', $entityId, false, $ignorePermissions);
                 }elseif ($openBracketCount === 4){
                     $matchedEntity = $this->getById('book', $entityId, false, $ignorePermissions);
-                }else{
-                    $matchedEntity = null;
                 }
+            }
                 
-                if ($matchedEntity === null) {
-                    $emptyLink = preg_replace('/href=".*"/', 'href="#"', $matches[0][$index]);
-                    $content = str_replace($matches[0][$index], $emptyLink, $content);
-                } else {
-                    $newLink = preg_replace('/href=".*"/', 'href="'.$matchedEntity->getUrl().'"', $matches[0][$index]);
-                    $content = str_replace($matches[0][$index], $newLink, $content);
-                }
+            if ($matchedEntity === null) {
+                $emptyLink = preg_replace('/href=".*"/', 'href="#"', $matches[0][$index]);
+                $content = str_replace($matches[0][$index], $emptyLink, $content);
+            } else {
+                $newLink = preg_replace('/href=".*"/', 'href="'.$matchedEntity->getUrl().'"', $matches[0][$index]);
+                $content = str_replace($matches[0][$index], $newLink, $content);
             }
         }
         


### PR DESCRIPTION
Example render code for #732.

This will transform any link that has the HTML code like the following code block to the pages actual URL using page->getUrl(): `<a <a title="Test Link" href="{{@page-id}}">Link Text</a>`

Added support for Chapters and Books as well.
Chapters: `<a <a title="Test Link" href="{{{@chapter-id}}}">Link Text</a>`
Books: `<a <a title="Test Link" href="{{{{@book-id}}}}">Link Text</a>`

Incomplete Solution
This only handles the page rendering. The editors and link selection screens will not support this (yet). I modified the page's html in the database for testing the render functionality.

This also does not currently have a way to handle links to Chapters/Books, but I just wanted to put out a proof of concept.