### PR TITLE
Fixes undefined error when clicking on link under page navigation.

### DIFF
--- a/resources/assets/js/components/page-display.js
+++ b/resources/assets/js/components/page-display.js
@@ -20,7 +20,7 @@ class PageDisplay {
 
         // Sidebar page nav click event
         $('.sidebar-page-nav').on('click', 'a', event => {
-            goToText(event.target.getAttribute('href').substr(1));
+            this.goToText(event.target.getAttribute('href').substr(1));
         });
     }
 


### PR DESCRIPTION
Fixes #873

Note that this does not need to be a hotfix because the navigation functionality still works, just the smooth scrolling effect has an issue.

Signed-off-by: Abijeet <abijeetpatro@gmail.com>