### PR TITLE
[WIP] Adds edit icon to each header in the page.

### DIFF
--- a/resources/assets/js/components/page-display.js
+++ b/resources/assets/js/components/page-display.js
@@ -11,6 +11,7 @@ class PageDisplay {
         this.setupPointer();
         this.setupStickySidebar();
         this.setupNavHighlighting();
+        this.setupEditOnHeader();
 
         // Check the hash on load
         if (window.location.hash) {
@@ -217,6 +218,30 @@ class PageDisplay {
                     anchorsToHighlight[i].classList.remove('current-heading');
                 }
             }
+        }
+    }
+    setupEditOnHeader() {
+        const headingEditIcon = document.querySelector('.heading-edit-icon');
+        if (headingEditIcon.length === 0) {
+            // user does not have permission to edit.
+            return;
+        }
+
+        // Create a clone of the edit icon without the hidden class
+        const visibleHeadingEditIcon = headingEditIcon.cloneNode(true);
+        visibleHeadingEditIcon.style.display = '';
+
+        const headings = document.querySelector('.page-content').querySelectorAll('h1, h2, h3, h4, h5, h6');
+
+        // add an edit icon to each header.
+        for (let i = 0; i !== headings.length; ++i) {
+            const currHeading = headings[i];
+            const headingId = currHeading.id;
+
+            let editIcon = visibleHeadingEditIcon.cloneNode(true);
+            editIcon.href += `#${headingId}`;
+
+            currHeading.appendChild(editIcon);
         }
     }
 

--- a/resources/assets/js/components/wysiwyg-editor.js
+++ b/resources/assets/js/components/wysiwyg-editor.js
@@ -497,6 +497,19 @@ class WysiwygEditor {
                     editorChange(html);
                 });
 
+                window.$events.listen('editor-scroll-to-text', textId => {
+                    const element = editor.dom.get(textId)
+                    if (!element) {
+                        return;
+                    }
+
+                    // scroll the element into the view and put the cursor at the end.
+                    element.scrollIntoView();
+                    editor.selection.select(element, true);
+                    editor.selection.collapse(false);
+                    editor.focus();
+                });
+
                 registerEditorShortcuts(editor);
 
                 let wrap;

--- a/resources/assets/js/vues/page-editor.js
+++ b/resources/assets/js/vues/page-editor.js
@@ -43,6 +43,13 @@ function mounted() {
     window.$events.listen('editor-markdown-change', markdown => {
         this.editorMarkdown = markdown;
     });
+
+    const scrollToText = window.location.hash ? window.location.hash.substr(1) : '';
+    if (scrollToText) {
+        setTimeout(() => {
+            window.$events.emit('editor-scroll-to-text', scrollToText);
+        }, 1000)
+    }
 }
 
 let data = {

--- a/resources/assets/sass/_pages.scss
+++ b/resources/assets/sass/_pages.scss
@@ -66,6 +66,17 @@
   }
   h1, h2, h3, h4, h5, h6, pre {
     clear: left;
+
+    .heading-edit-icon {
+      margin-left: 10px;
+      font-size: 0.7em;
+      display: none;
+      line-height: 1em;
+
+      .svg-icon {
+          bottom: 0px;
+      }
+    }
   }
   hr {
     clear: both;
@@ -88,6 +99,16 @@
   }
   del {
     background: #FFECEC;
+  }
+  h1:hover,
+  h2:hover,
+  h3:hover,
+  h4:hover,
+  h5:hover,
+  h6:hover {
+    .heading-edit-icon {
+      display: inline;
+    }
   }
 }
 

--- a/resources/views/pages/show.blade.php
+++ b/resources/views/pages/show.blade.php
@@ -132,6 +132,10 @@
         </div>
 
         @include('pages/page-display')
+
+        @if(userCan('page-update', $page))
+            <a href="{{ $page->getUrl('/edit') }}" class="text-primary text-button heading-edit-icon" style="display: none">@icon('edit')</a>
+        @endif
     </div>
 
     @if ($commentsEnabled)


### PR DESCRIPTION
Towards #618

This adds an edit icon next to each header in the page. On clicking of this edit icon, the editing window is opened and the header text is put in focus. This works on the WYSIWYG editor. 

Not sure how to implement it on the Makrdown editor as the headings in the markdown editor have no unique ID associated with them. One option is to disable the edit icon if the application editor is set to Markdown. Another not very flexible option is,

1. Recreate the heading text from the bookmark ID - #bkmrk-hello-world --> hello world
2. Fetch all the elements with class `cm-header`, and find the one that contains text that starts with the above.
3. With the help of this element, find the `CodeMirror-linenumber` element, which is sort of a cousin to this element. Get the line number inside it.
4. Use `scrollIntoView` (https://codemirror.net/doc/manual.html#scrollIntoView) to scroll the line into view.


 @ssddanbrown, What do you think?

# How does it look?
The edit icon appears only on hover.
![edit-icon-header](https://user-images.githubusercontent.com/1685517/40884737-f3ccf526-6736-11e8-96d7-916593bffd07.png)


Signed-off-by: Abijeet <abijeetpatro@gmail.com>