### PR TITLE
Fixes issue with having to click the delete icon for attachment twice.

### DIFF
--- a/resources/assets/js/vues/attachment-manager.js
+++ b/resources/assets/js/vues/attachment-manager.js
@@ -52,7 +52,9 @@ let methods = {
     },
 
     deleteFile(file) {
-        if (!file.deleting) return file.deleting = true;
+        if (!file.deleting) {
+            return this.$set(file, 'deleting', true);
+        }
 
         this.$http.delete(window.baseUrl(`/attachments/${file.id}`)).then(resp => {
             this.$events.emit('success', resp.data.message);

--- a/resources/views/pages/form-toolbox.blade.php
+++ b/resources/views/pages/form-toolbox.blade.php
@@ -42,8 +42,8 @@
                                             <span class="text-primary small" @click="file.deleting = false;">{{ trans('common.cancel') }}</span>
                                         </div>
                                     </div>
-                                    <div @click="startEdit(file)" class="drag-card-action text-center text-primary" style="padding: 0;">@icon('edit')</div>
-                                    <div @click="deleteFile(file)" class="drag-card-action text-center text-neg" style="padding: 0;">@icon('close')</div>
+                                    <div @click="startEdit(file)" class="drag-card-action text-center text-primary">@icon('edit')</div>
+                                    <div @click="deleteFile(file)" class="drag-card-action text-center text-neg">@icon('close')</div>
                                 </div>
                             </draggable>
                             <p class="small muted" v-if="files.length === 0">


### PR DESCRIPTION
Fixes #884

This is happening because -

> Due to the limitations of modern JavaScript (and the abandonment of Object.observe), Vue cannot detect property addition or deletion. Since Vue performs the getter/setter conversion process during instance initialization, a property must be present in the data object in order for Vue to convert it and make it reactive.

Source: https://vuejs.org/v2/guide/reactivity.html

Also added padding to the icons in the attachment section.

**Before**
![attachment-edit-no-padding](https://user-images.githubusercontent.com/1685517/41506361-053ab8a8-723a-11e8-85fb-9a82332b48ca.png)

**After**
![attachment-edit-padding](https://user-images.githubusercontent.com/1685517/41506362-08391c7a-723a-11e8-84c6-11c686a17768.png)


Signed-off-by: Abijeet <abijeetpatro@gmail.com>