### PR TITLE
Fixes issue with code not wrapping on revision page.

### DIFF
--- a/resources/assets/sass/_pages.scss
+++ b/resources/assets/sass/_pages.scss
@@ -89,6 +89,12 @@
   del {
     background: #FFECEC;
   }
+
+  &.page-revision {
+    pre code {
+      white-space: pre-wrap;
+    }
+  }
 }
 
 // Page content pointers

--- a/resources/views/pages/revision.blade.php
+++ b/resources/views/pages/revision.blade.php
@@ -14,7 +14,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-9">
-                <div class="page-content">
+                <div class="page-content page-revision">
                     @include('pages.page-display')
                 </div>
             </div>


### PR DESCRIPTION
Closes #888

See image below,

![image](https://user-images.githubusercontent.com/1685517/42121359-277e2c04-7c4b-11e8-8675-971a5d5da262.png)

Also tested PDF export and HTML export. The same CSS are applied to the `pre code` section but Dompdf does not seem to support `white-space: pre-wrap` whereas wkhtmltopdf does.

- wkhtmltopdf - [test-page-wkhtmltopdf.pdf](https://github.com/BookStackApp/BookStack/files/2151410/test-page-wkhtmltopdf.pdf)
- Dompdf - [test-page-dom-pdf.pdf](https://github.com/BookStackApp/BookStack/files/2151411/test-page-dom-pdf.pdf)


Signed-off-by: Abijeet <abijeetpatro@gmail.com>