### PR TITLE
implement social auto registration feature

### DIFF
--- a/app/Repos/UserRepo.php
+++ b/app/Repos/UserRepo.php
@@ -76,7 +76,7 @@ class UserRepo
         return $query->paginate($count);
     }
 
-        /**
+     /**
      * Creates a new user and attaches a role to them.
      * @param array $data
      * @param boolean autoVerifyEmail

--- a/app/Repos/UserRepo.php
+++ b/app/Repos/UserRepo.php
@@ -76,14 +76,15 @@ class UserRepo
         return $query->paginate($count);
     }
 
-    /**
+        /**
      * Creates a new user and attaches a role to them.
      * @param array $data
+     * @param boolean autoVerifyEmail
      * @return User
      */
-    public function registerNew(array $data)
+    public function registerNew(array $data, $autoVerifyEmail=false)
     {
-        $user = $this->create($data);
+        $user = $this->create($data, $autoVerifyEmail);
         $this->attachDefaultRole($user);
 
         // Get avatar from gravatar and save
@@ -143,13 +144,14 @@ class UserRepo
      * @param array $data
      * @return User
      */
-    public function create(array $data)
+    public function create(array $data, $autoVerifyEmail)
     {
+
         return $this->user->forceCreate([
             'name'     => $data['name'],
             'email'    => $data['email'],
             'password' => bcrypt($data['password']),
-            'email_confirmed' => false
+            'email_confirmed' => $autoVerifyEmail
         ]);
     }
 

--- a/app/Repos/UserRepo.php
+++ b/app/Repos/UserRepo.php
@@ -142,6 +142,7 @@ class UserRepo
     /**
      * Create a new basic instance of user.
      * @param array $data
+     * @param boolean $autoVerifyEmail
      * @return User
      */
     public function create(array $data, $autoVerifyEmail=false)

--- a/app/Repos/UserRepo.php
+++ b/app/Repos/UserRepo.php
@@ -144,7 +144,7 @@ class UserRepo
      * @param array $data
      * @return User
      */
-    public function create(array $data, $autoVerifyEmail)
+    public function create(array $data, $autoVerifyEmail=false)
     {
 
         return $this->user->forceCreate([

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -44,6 +44,8 @@ return [
 
     'reg_settings' => 'Registration Settings',
     'reg_allow' => 'Allow registration?',
+    'reg_auto_social_allow'  => 'Allow auto social registration?',
+    'reg_auto_social_allow_desc' => 'If the social user doesn\'t exist, automatically sign him up. Domain restriction is respected if set. Email is also automatically validated for this kind of social registration.',
     'reg_default_role' => 'Default user role after registration',
     'reg_confirm_email' => 'Require email confirmation?',
     'reg_confirm_email_desc' => 'If domain restriction is used then email confirmation will be required and the below value will be ignored.',
@@ -148,7 +150,7 @@ return [
         'it' => 'Italian',
         'ru' => 'Русский',
         'zh_CN' => '简体中文',
-	    'zh_TW' => '繁體中文'
+        'zh_TW' => '繁體中文'
     ]
     ///////////////////////////////////
 ];

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -127,6 +127,11 @@
                             </select>
                         </div>
                         <div class="form-group">
+                            <label for="setting-autosocialregistration-confirmation">{{ trans('settings.reg_auto_social_allow') }}</label>
+                            <p class="small">{{ trans('settings.reg_auto_social_allow_desc') }}</p>
+                            @include('components.toggle-switch', ['name' => 'setting-autosocialregistration-confirmation', 'value' => setting('autosocialregistration-confirmation')])
+                        </div>
+                        <div class="form-group">
                             <label for="setting-registration-confirmation">{{ trans('settings.reg_confirm_email') }}</label>
                             <p class="small">{{ trans('settings.reg_confirm_email_desc') }}</p>
                             @include('components.toggle-switch', ['name' => 'setting-registration-confirmation', 'value' => setting('registration-confirmation')])


### PR DESCRIPTION
Related to #574 

I added a setting to allow auto silent registration of user when social auth is used.

Few things to be aware of:
- enabling this setting would disable email verification for social auth but it's described under the setting + I think email verification for social auth is useless.
- if domain restriction is enabled => the auto social registration process respect it.
Missing: translation & probably better wording (my english is not perfect)

Missing: check of wording + translations