### PR TITLE
Update AttachmentService.php

### DIFF
--- a/app/Services/AttachmentService.php
+++ b/app/Services/AttachmentService.php
@@ -4,6 +4,7 @@ use BookStack\Exceptions\FileUploadException;
 use BookStack\Attachment;
 use Exception;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+ini_set(‘memory_limit’,’256M’);
 
 class AttachmentService extends UploadService
 {


### PR DESCRIPTION
Couldn't upload some large videos (60 - 100 MB). In the logs, I saw the errors:

[Mon Sep 03 12:21:08.799485 2018] [php7:notice] [pid 101] [client IP:PORT] [2018-09-03 12:21:08] production.ERROR: Allowed memory size of 134217728 bytes exhausted (tried to allocate 121655240 bytes) {"userId":1,"email":"admin@admin.com","exception":"[object] (Symfony\\\\Component\\\\Debug\\\\Exception\\\\FatalErrorException(code: 1): Allowed memory size of 134217728 bytes exhausted (tried to allocate 121655240 bytes) at /var/www/bookstack/app/Services/AttachmentService.php:185)"} [], referer: http://NAS_IP:PORT/books/learning-materials/page/pate-de-ficat-de-pui/edit

solved the issue by modifying  /var/www/bookstack/app/Services/AttachmentService.php, by adding ini_set(‘memory_limit’,’256MB’); after use Symfony\Component\HttpFoundation\File\UploadedFile;