### PR TITLE
Adds missing pt_BR translation

### DIFF
--- a/resources/lang/pt_BR/activities.php
+++ b/resources/lang/pt_BR/activities.php
@@ -37,6 +37,14 @@ return [
     'book_sort'                   => 'livro classificado',
     'book_sort_notification'      => 'Livro reclassificado com sucesso',
 
+    // Bookshelves
+    'bookshelf_create'            => 'prateleira criada',
+    'bookshelf_create_notification'    => 'Prateleira criada com sucesso',
+    'bookshelf_update'                 => 'prateleira atualizada',
+    'bookshelf_update_notification'    => 'Prateleira atualizada com sucesso',
+    'bookshelf_delete'                 => 'prateleira excluída',
+    'bookshelf_delete_notification'    => 'Prateleira excluída com sucesso',    
+
     // Other
     'commented_on'                => 'comentou em',
 ];

--- a/resources/lang/pt_BR/activities.php
+++ b/resources/lang/pt_BR/activities.php
@@ -38,12 +38,12 @@ return [
     'book_sort_notification'      => 'Livro reclassificado com sucesso',
 
     // Bookshelves
-    'bookshelf_create'            => 'prateleira criada',
-    'bookshelf_create_notification'    => 'Prateleira criada com sucesso',
-    'bookshelf_update'                 => 'prateleira atualizada',
-    'bookshelf_update_notification'    => 'Prateleira atualizada com sucesso',
-    'bookshelf_delete'                 => 'prateleira excluída',
-    'bookshelf_delete_notification'    => 'Prateleira excluída com sucesso',    
+    'bookshelf_create'            => 'prateleira de livros criada',
+    'bookshelf_create_notification'    => 'Prateleira de Livros criada com sucesso',
+    'bookshelf_update'                 => 'prateleira de livros atualizada',
+    'bookshelf_update_notification'    => 'Prateleira de Livros atualizada com sucesso',
+    'bookshelf_delete'                 => 'prateleira de livros excluída',
+    'bookshelf_delete_notification'    => 'Prateleira de Livros excluída com sucesso',    
 
     // Other
     'commented_on'                => 'comentou em',

--- a/resources/lang/pt_BR/common.php
+++ b/resources/lang/pt_BR/common.php
@@ -52,6 +52,7 @@ return [
     'details' => 'Detalhes',
     'grid_view' => 'Visualização em Grade',
     'list_view' => 'Visualização em Lista',
+    'default' => 'Padrão',
 
     /**
      * Header

--- a/resources/lang/pt_BR/entities.php
+++ b/resources/lang/pt_BR/entities.php
@@ -52,17 +52,51 @@ return [
     'search_content_type' => 'Tipo de Conteúdo',
     'search_exact_matches' => 'Correspondências Exatas',
     'search_tags' => 'Tags',
+    'search_options' => 'Opções',
     'search_viewed_by_me' => 'Visto por mim',
     'search_not_viewed_by_me' => 'Não visto por mim',
     'search_permissions_set' => 'Permissão definida',
     'search_created_by_me' => 'Criado por mim',
     'search_updated_by_me' => 'Atualizado por mim',
+    'search_date_options' => 'Opções de Data',
     'search_updated_before' => 'Atualizado antes de',
     'search_updated_after' => 'Atualizado depois de',
     'search_created_before' => 'Criado antes de',
     'search_created_after' => 'Criado depois de',
     'search_set_date' => 'Definir data',
     'search_update' => 'Refazer Pesquisa',
+
+    /**
+     * Shelves
+     */
+    'shelf' => 'Prateleira',
+    'shelves' => 'Prateleiras',
+    'shelves_long' => 'Prateleiras de Livros',
+    'shelves_empty' => 'Nenhuma prateleira foi criada',
+    'shelves_create' => 'Criar nova Prateleira',
+    'shelves_popular' => 'Prateleiras populares',
+    'shelves_new' => 'Prateleiras novas',
+    'shelves_popular_empty' => 'As prateleiras mais populares aparecerão aqui.',
+    'shelves_new_empty' => 'As prateleiras criadas mais recentemente aparecerão aqui.',
+    'shelves_save' => 'Salvar Prateleira',
+    'shelves_books' => 'Livros nesta prateleira',
+    'shelves_add_books' => 'Adicionar livros a esta prateleira',
+    'shelves_drag_books' => 'Arraste livros aqui para adicioná-los a esta prateleira',
+    'shelves_empty_contents' => 'Esta prateleira não possui livros atribuídos a ela',
+    'shelves_edit_and_assign' => 'Edit shelf to assign books',
+    'shelves_edit_named' => 'Editar Prateleira de Livros :name',
+    'shelves_edit' => 'Edit Prateleira de Livros',
+    'shelves_delete' => 'Excluir Prateleira de Livros',
+    'shelves_delete_named' => 'Excluir Prateleira de Livros :name',
+    'shelves_delete_explain' => "A ação vai excluír a prateleira de livros com o nome ':name'. Livros contidos não serão excluídos",
+    'shelves_delete_confirmation' => 'Você tem certeza que quer excluir esta prateleira de livros?',
+    'shelves_permissions' => 'Permissões da Prateleira de Livros',
+    'shelves_permissions_updated' => 'Permissões da Prateleira de Livros Atualizada',
+    'shelves_permissions_active' => 'Permissões da Prateleira de Livros Ativadas',
+    'shelves_copy_permissions_to_books' => 'Copiar Permissões para Livros',
+    'shelves_copy_permissions' => 'Copiar Permissões',
+    'shelves_copy_permissions_explain' => 'Isto aplicará as configurações de permissões atuais desta prateleira de livros a todos os livros contidos nela. Antes de ativar, assegure-se de que quaisquer alterações nas permissões desta prateleira de livros tenham sido salvas.',
+    'shelves_copy_permission_success' => 'Permissões da prateleira de livros copiada para :count livros',
 
     /**
      * Books
@@ -199,6 +233,7 @@ return [
         'message' => ':start :time. Tome cuidado para não sobrescrever atualizações de outras pessoas!',
     ],
     'pages_draft_discarded' => 'Rascunho descartado. O editor foi atualizado com a página atualizada',
+    'pages_specific' => 'Página Específica',
 
     /**
      * Editor sidebar
@@ -206,6 +241,7 @@ return [
     'page_tags' => 'Tags de Página',
     'chapter_tags' => 'Tags de Capítulo',
     'book_tags' => 'Tags de Livro',
+    'shelf_tags' => 'Tags de Prateleira',
     'tag' => 'Tag',
     'tags' =>  '',
     'tag_value' => 'Valor da Tag (Opcional)',

--- a/resources/lang/pt_BR/errors.php
+++ b/resources/lang/pt_BR/errors.php
@@ -49,6 +49,7 @@ return [
 
     // Entities
     'entity_not_found' => 'Entidade não encontrada',
+    'bookshelf_not_found' => 'Prateleira de Livros não encontrada',
     'book_not_found' => 'Livro não encontrado',
     'page_not_found' => 'Página não encontrada',
     'chapter_not_found' => 'Capítulo não encontrado',

--- a/resources/lang/pt_BR/settings.php
+++ b/resources/lang/pt_BR/settings.php
@@ -33,9 +33,8 @@ return [
     'app_primary_color_desc' => 'Esse valor deverá ser Hexadecimal. <br>Deixe em branco para que o Bookstack assuma a cor padrão.',
     'app_homepage' => 'Página incial',
     'app_homepage_desc' => 'Selecione a página para ser usada como página inicial em vez da padrão. Permissões da página serão ignoradas.',
-    'app_homepage_default' => 'Escolhida página inicial padrão',
+    'app_homepage_select' => 'Selecione uma página',
     'app_disable_comments' => 'Desativar comentários',
-    'app_homepage_books' => 'Ou selecione a página de livros como sua página inicial. Isso substituirá qualquer página selecionada como sua página inicial.',
     'app_disable_comments_desc' => 'Desativar comentários em todas as páginas no aplicativo. Os comentários existentes não são exibidos.',
 
     /**
@@ -91,6 +90,7 @@ return [
     'role_manage_settings' => 'Gerenciar configurações de app',
     'role_asset' => 'Permissões de Ativos',
     'role_asset_desc' => 'Essas permissões controlam o acesso padrão para os ativos dentro do sistema. Permissões em Livros, Capítulos e Páginas serão sobrescritas por essas permissões.',
+    'role_asset_admins' => 'Administradores recebem automaticamente acesso a todo o conteúdo, mas essas opções podem mostrar ou ocultar as opções da UI.',
     'role_all' => 'Todos',
     'role_own' => 'Próprio',
     'role_controlled_by_asset' => 'Controlado pelos ativos que você fez upload',
@@ -111,7 +111,6 @@ return [
     'users_external_auth_id' => 'ID de Autenticação Externa',
     'users_password_warning' => 'Preencha os dados abaixo caso queira modificar a sua senha:',
     'users_system_public' => 'Esse usuário representa quaisquer convidados que visitam o aplicativo. Ele não pode ser usado para login.',
-    'users_books_view_type' => 'Layout preferido para mostrar livros',
     'users_delete' => 'Excluir Usuário',
     'users_delete_named' => 'Excluir :userName',
     'users_delete_warning' => 'A ação vai excluir completamente o usuário de nome \':userName\' do sistema.',


### PR DESCRIPTION
After update 0.24, several strings referencing the bookshelves feature were added, causing a lack of translation when the pt_BR locale is used. This pull request adds these missing strings.