### PR TITLE
Add markdown-it-deflist for <dl> in markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6501,6 +6501,11 @@
         "uc.micro": "^1.0.3"
       }
     },
+    "markdown-it-deflist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-2.0.3.tgz",
+      "integrity": "sha512-/BNZ8ksW42bflm1qQLnRI09oqU2847Z7MVavrR0MORyKLtiUYOMpwtlAfMSZAQU9UCvaUZMpgVAqoS3vpToJxw=="
+    },
     "markdown-it-task-lists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "jquery-sortable": "^0.9.13",
     "markdown-it": "^8.3.1",
     "markdown-it-task-lists": "^2.0.0",
+    "markdown-it-deflist": "^2.0.0",
     "vue": "^2.2.6",
     "vuedraggable": "^2.14.1"
   },

--- a/resources/assets/js/components/markdown-editor.js
+++ b/resources/assets/js/components/markdown-editor.js
@@ -1,5 +1,6 @@
 const MarkdownIt = require("markdown-it");
 const mdTasksLists = require('markdown-it-task-lists');
+const mdDefList = require('markdown-it-deflist');
 const code = require('../services/code');
 
 const DrawIO = require('../services/drawio');
@@ -11,6 +12,7 @@ class MarkdownEditor {
         this.textDirection = document.getElementById('page-editor').getAttribute('text-direction');
         this.markdown = new MarkdownIt({html: true});
         this.markdown.use(mdTasksLists, {label: true});
+        this.markdown.use(mdDefList);
 
         this.display = this.elem.querySelector('.markdown-display');
         this.input = this.elem.querySelector('textarea');

--- a/resources/assets/js/components/page-comments.js
+++ b/resources/assets/js/components/page-comments.js
@@ -1,5 +1,7 @@
 const MarkdownIt = require("markdown-it");
+const mdDefList = require("markdown-it-deflist");
 const md = new MarkdownIt({ html: false });
+md.use(mdDefList);
 
 class PageComments {
 

--- a/resources/assets/sass/_text.scss
+++ b/resources/assets/sass/_text.scss
@@ -343,7 +343,7 @@ span.highlight {
 /*
  * Lists
  */
-ul, ol {
+ul, ol, dl {
   overflow: hidden;
   p {
     margin: 0;
@@ -374,6 +374,16 @@ li.checkbox-item, li.task-list-item {
   margin-left: - ($-m * 1.3);
   input[type="checkbox"] {
     margin-right: $-xs;
+  }
+}
+
+dl {
+  dt {
+    font-weight: bold;
+  }
+  dd {
+    padding-left: $-m * 1.3;
+    padding-right: $-m * 1.3;
   }
 }
 


### PR DESCRIPTION
This adds the markdown-it-deflist extension for markdown-it to support definition lists in the Markdown editor. In addition, there's some basic styling added to definition lists to make terms bold and indent their definitions.

Ideally this should have no negative impact on existing markdown held by a BookStack instance, but I can only speak for my team's use of BookStack. So, if this seems like something that could be merged, it might be good to hear from anyone else using BookStack if this would affect their pages.

This is intended to help with keeping glossaries and other things that fit the mold of a definition list (my team does both). That sort of formatting can always be worked around with some careful HTML, but figured I'd put this together and see if it's worth considering. Happy to make any changes if there's anything off about this, or I can close it if it doesn't seem like a good fit for BookStack.