### PR TITLE
Add select account parameter for google authorization

### DIFF
--- a/app/Auth/Access/SocialAuthService.php
+++ b/app/Auth/Access/SocialAuthService.php
@@ -40,6 +40,9 @@ class SocialAuthService
     public function startLogIn($socialDriver)
     {
         $driver = $this->validateDriver($socialDriver);
+        if ($socialDriver == 'google') {
+            return $this->socialite->driver($driver)->with('prompt' => 'select_account');
+        }
         return $this->socialite->driver($driver)->redirect();
     }
 


### PR DESCRIPTION
Useful for choosing an account if a default account is outside the scope of a G Suite organization.