### PR TITLE
Add option to disable LDAPS Certificate Validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,8 @@ LDAP_GROUP_ATTRIBUTE="memberOf"
 # Would you like to remove users from roles on BookStack if they do not match on LDAP
 # If false, the ldap groups-roles sync will only add users to roles
 LDAP_REMOVE_FROM_GROUPS=false
+# Set this option to disable LDAPS Certificate Verification
+LDAP_TLS_INSECURE=false
 
 # Mail settings
 MAIL_DRIVER=smtp

--- a/app/Auth/Access/LdapService.php
+++ b/app/Auth/Access/LdapService.php
@@ -170,12 +170,16 @@ class LdapService
         $hostName = $ldapServer[0] . ($hasProtocol?':':'') . $ldapServer[1];
         $defaultPort = $ldapServer[0] === 'ldaps' ? 636 : 389;
 
-        $ldapConnection = $this->ldap->connect($hostName, count($ldapServer) > 2 ? intval($ldapServer[2]) : $defaultPort);
-
-        // Check if TLS_INSECURE is set
+        /*
+         * Check if TLS_INSECURE is set. The handle is set to NULL due to the nature of
+         * the LDAP_OPT_X_TLS_REQUIRE_CERT option. It can only be set globally and not
+         * per handle.
+         */
         if($this->config['tls_insecure']) {
-            $this->ldap->setOption($ldapConnection, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_NEVER);
+            $this->ldap->setOption(NULL, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_NEVER);
         }
+
+        $ldapConnection = $this->ldap->connect($hostName, count($ldapServer) > 2 ? intval($ldapServer[2]) : $defaultPort);
 
         if ($ldapConnection === false) {
             throw new LdapException(trans('errors.ldap_cannot_connect'));

--- a/app/Auth/Access/LdapService.php
+++ b/app/Auth/Access/LdapService.php
@@ -169,7 +169,13 @@ class LdapService
         }
         $hostName = $ldapServer[0] . ($hasProtocol?':':'') . $ldapServer[1];
         $defaultPort = $ldapServer[0] === 'ldaps' ? 636 : 389;
+
         $ldapConnection = $this->ldap->connect($hostName, count($ldapServer) > 2 ? intval($ldapServer[2]) : $defaultPort);
+
+        // Check if TLS_INSECURE is set
+        if($this->config['tls_insecure']) {
+            $this->ldap->setOption($ldapConnection, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_NEVER);
+        }
 
         if ($ldapConnection === false) {
             throw new LdapException(trans('errors.ldap_cannot_connect'));

--- a/config/services.php
+++ b/config/services.php
@@ -148,7 +148,7 @@ return [
 		'user_to_groups' => env('LDAP_USER_TO_GROUPS',false),
 		'group_attribute' => env('LDAP_GROUP_ATTRIBUTE', 'memberOf'),
 		'remove_from_groups' => env('LDAP_REMOVE_FROM_GROUPS',false),
-        'tls_insecure' => env('LDAP_TLS_INSECURE', false),
+		'tls_insecure' => env('LDAP_TLS_INSECURE', false),
 	]
 
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -148,6 +148,7 @@ return [
 		'user_to_groups' => env('LDAP_USER_TO_GROUPS',false),
 		'group_attribute' => env('LDAP_GROUP_ATTRIBUTE', 'memberOf'),
 		'remove_from_groups' => env('LDAP_REMOVE_FROM_GROUPS',false),
+        'tls_insecure' => env('LDAP_TLS_INSECURE', false),
 	]
 
 ];


### PR DESCRIPTION
This PR allows users to set `LDAP_TLS_INSECURE` in their `.env` to bypass LDAP TLS Certificate Verification. This is useful for development environments that may not have a trusted CA certificate for LDAP functionality.