### PR TITLE
Fixes image deletion failing in subdirectory.

### DIFF
--- a/resources/assets/js/vues/image-manager.js
+++ b/resources/assets/js/vues/image-manager.js
@@ -159,8 +159,8 @@ const methods = {
             });
             return;
         }
-
-        this.$http.delete(`/images/${this.selectedImage.id}`).then(resp => {
+        let url = window.baseUrl(`/images/${this.selectedImage.id}`);
+        this.$http.delete(url).then(resp => {
             this.images.splice(this.images.indexOf(this.selectedImage), 1);
             this.selectedImage = false;
             this.$events.emit('success', trans('components.image_delete_success'));


### PR DESCRIPTION
Fixes #1092

I was unable to test it on a sub-directory, since while setting up was getting an issue stating - 

```
[Sun Nov 25 00:14:25.175814 2018] [core:error] [pid 30398] [client ::1:50186] AH00124: Request exceeded the limit of 10 internal redirects due to probable configuration error. Use 'LimitInternalRecursion' to increase the limit if necessary. Use 'LogLevel debug' to get a backtrace.
```
But I'm fairly certain that this will fix the issue. Tested on the PHP localhost server.

Signed-off-by: Abijeet <abijeetpatro@gmail.com>