### PR TITLE
add German informal language

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -84,7 +84,7 @@ return [
     */
 
     'locale' => env('APP_LANG', 'en'),
-    'locales' => ['en', 'ar', 'de', 'es', 'es_AR', 'fr', 'nl', 'pt_BR', 'sk', 'sv', 'kr', 'ja', 'pl', 'it', 'ru', 'zh_CN', 'zh_TW'],
+    'locales' => ['en', 'ar', 'de', 'de_informal', 'es', 'es_AR', 'fr', 'nl', 'pt_BR', 'sk', 'sv', 'kr', 'ja', 'pl', 'it', 'ru', 'zh_CN', 'zh_TW'],
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/lang/de_informal/activities.php
+++ b/resources/lang/de_informal/activities.php
@@ -1,0 +1,23 @@
+<?php
+$de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
+
+$de_informal = [
+
+    /**
+     * Activity text strings.
+     * Is used for all the text within activity logs & notifications.
+     */
+
+    // Pages
+ 
+    // Chapters
+   
+    // Books
+    
+    // Bookshelves
+    
+    // Other
+    
+];
+
+return array_replace($de_formal, $de_informal);

--- a/resources/lang/de_informal/activities.php
+++ b/resources/lang/de_informal/activities.php
@@ -2,21 +2,6 @@
 $de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
 
 $de_informal = [
-
-    /**
-     * Activity text strings.
-     * Is used for all the text within activity logs & notifications.
-     */
-
-    // Pages
- 
-    // Chapters
-   
-    // Books
-    
-    // Bookshelves
-    
-    // Other
     
 ];
 

--- a/resources/lang/de_informal/auth.php
+++ b/resources/lang/de_informal/auth.php
@@ -1,0 +1,45 @@
+<?php
+$de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
+
+$de_informal = [
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+    'throttle' => 'Zu viele Anmeldeversuche. Bitte versuche es in :seconds Sekunden erneut.',
+    /**
+     * Login & Register
+     */
+    'ldap_email_hint' => 'Bitte gib eine E-Mail-Adresse ein, um diese mit dem Account zu nutzen.',
+    'register_confirm' => 'Bitte prüfe Deinen Posteingang und bestätig die Registrierung.',
+    'registration_email_domain_invalid' => 'Du kannst dich mit dieser E-Mail nicht registrieren.',
+    'register_success' => 'Vielen Dank für Deine Registrierung! Die Daten sind gespeichert und Du bist angemeldet.',
+    /**
+     * Password Reset
+     */
+    'reset_password_send_instructions' => 'Bitte gib Deine E-Mail-Adresse ein. Danach erhältst Du eine E-Mail mit einem Link zum Zurücksetzen Deines Passwortes.',
+    'reset_password_sent_success' => 'Eine E-Mail mit dem Link zum Zurücksetzen Deines Passwortes wurde an :email gesendet.',
+    'reset_password_success' => 'Dein Passwort wurde erfolgreich zurückgesetzt.',
+    'email_reset_text' => 'Du erhältsts diese E-Mail, weil jemand versucht hat, Dein Passwort zurückzusetzen.',
+    'email_reset_not_requested' => 'Wenn Du das nicht warst, brauchst Du nichts weiter zu tun.',
+    /**
+     * Email Confirmation
+     */
+    'email_confirm_subject' => 'Bestätige Deine E-Mail-Adresse für :appName',
+    'email_confirm_greeting' => 'Danke, dass Du dich für :appName registrierst hast!',
+    'email_confirm_text' => 'Bitte bestätige Deine E-Mail-Adresse, indem Du auf die Schaltfläche klickst:',
+    'email_confirm_send_error' => 'Leider konnte die für die Registrierung notwendige E-Mail zur Bestätigung Deine E-Mail-Adresse nicht versandt werden. Bitte kontaktiere den Systemadministrator!',
+    'email_confirm_success' => 'Deine E-Mail-Adresse wurde best&auml;tigt!',
+    'email_confirm_resent' => 'Bestätigungs-E-Mail wurde erneut versendet, bitte überprüfe Deinen Posteingang.',
+    'email_not_confirmed_text' => 'Deine E-Mail-Adresse ist bisher nicht bestätigt.',
+    'email_not_confirmed_click_link' => 'Bitte klicke auf den Link in der E-Mail, die Du nach der Registrierung erhalten hast.',
+    'email_not_confirmed_resend' => 'Wenn Du die E-Mail nicht erhalten hast, kannst Du die Nachricht erneut anfordern. Fülle hierzu bitte das folgende Formular aus:',
+];
+
+return array_replace($de_formal, $de_informal);

--- a/resources/lang/de_informal/common.php
+++ b/resources/lang/de_informal/common.php
@@ -1,0 +1,32 @@
+<?php
+$de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
+
+$de_informal = [
+
+    /**
+     * Buttons
+     */
+
+    /**
+     * Form Labels
+     */
+
+    /**
+     * Actions
+     */
+
+    /**
+     * Misc
+     */
+
+    /**
+     * Header
+     */
+
+    /**
+     * Email Content
+     */
+    'email_action_help' => 'Sollte es beim Anklicken der Schaltfläche ":action_text" Probleme geben, öffne die folgende URL in Deinem Browser:',
+];
+
+return array_replace($de_formal, $de_informal);

--- a/resources/lang/de_informal/common.php
+++ b/resources/lang/de_informal/common.php
@@ -2,27 +2,6 @@
 $de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
 
 $de_informal = [
-
-    /**
-     * Buttons
-     */
-
-    /**
-     * Form Labels
-     */
-
-    /**
-     * Actions
-     */
-
-    /**
-     * Misc
-     */
-
-    /**
-     * Header
-     */
-
     /**
      * Email Content
      */

--- a/resources/lang/de_informal/components.php
+++ b/resources/lang/de_informal/components.php
@@ -1,0 +1,15 @@
+<?php
+$de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
+
+$de_informal = [
+    /**
+     * Image Manager
+     */
+    'image_delete_confirm' => 'Bitte klicke erneut auf löschen, wenn Du dieses Bild wirklich entfernen möchtest.',
+    'image_dropzone' => 'Ziehe Bilder hierher oder klicke hier, um ein Bild auszuwählen',
+    /**
+     * Code editor
+     */
+];
+
+return array_replace($de_formal, $de_informal);

--- a/resources/lang/de_informal/components.php
+++ b/resources/lang/de_informal/components.php
@@ -7,9 +7,6 @@ $de_informal = [
      */
     'image_delete_confirm' => 'Bitte klicke erneut auf löschen, wenn Du dieses Bild wirklich entfernen möchtest.',
     'image_dropzone' => 'Ziehe Bilder hierher oder klicke hier, um ein Bild auszuwählen',
-    /**
-     * Code editor
-     */
 ];
 
 return array_replace($de_formal, $de_informal);

--- a/resources/lang/de_informal/entities.php
+++ b/resources/lang/de_informal/entities.php
@@ -9,14 +9,6 @@ $de_informal = [
     'no_pages_recently_created' => 'Du hast bisher keine Seiten angelegt.',
     'no_pages_recently_updated' => 'Du hast bisher keine Seiten aktualisiert.',
     /**
-     * Permissions and restrictions
-     */
-
-    /**
-     * Search
-     */
-
-    /**
      * Books
      */
     'books_delete_confirmation' => 'Bist Du sicher, dass Du dieses Buch löschen möchtest?',
@@ -48,15 +40,10 @@ $de_informal = [
     'attachments_explain_link' => 'Wenn Du keine Datei hochladen möchtest, kannst Du stattdessen einen Link hinzufügen. Dieser Link kann auf eine andere Seite oder eine Datei im Internet verweisen.',
     'attachments_edit_drop_upload' => 'Ziehe Dateien hierher, um diese hochzuladen und zu überschreiben',
     /**
-     * Profile View
-     */
-    
-    /**
      * Comments
      */
     'comment_placeholder' => 'Gib hier Deine Kommentare ein (Markdown unterstützt)',
     'comment_delete_confirm' => 'Möchtst Du diesen Kommentar wirklich löschen?',
-
     /**
      * Revision
      */

--- a/resources/lang/de_informal/entities.php
+++ b/resources/lang/de_informal/entities.php
@@ -1,0 +1,66 @@
+<?php
+$de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
+
+$de_informal = [
+    /**
+     * Shared
+     */
+    'no_pages_viewed' => 'Du hast bisher keine Seiten angesehen.',
+    'no_pages_recently_created' => 'Du hast bisher keine Seiten angelegt.',
+    'no_pages_recently_updated' => 'Du hast bisher keine Seiten aktualisiert.',
+    /**
+     * Permissions and restrictions
+     */
+
+    /**
+     * Search
+     */
+
+    /**
+     * Books
+     */
+    'books_delete_confirmation' => 'Bist Du sicher, dass Du dieses Buch löschen möchtest?',
+    /**
+     * Chapters
+     */
+    'chapters_delete_confirm' => 'Bist Du sicher, dass Du dieses Kapitel löschen möchtest?',
+    /**
+     * Pages
+     */
+    'pages_delete_confirm' => 'Bist Du sicher, dass Du diese Seite löschen möchtest?',
+    'pages_delete_draft_confirm' => 'Bist Du sicher, dass Du diesen Seitenentwurf löschen möchtest?',
+    'pages_edit_enter_changelog_desc' => 'Bitte gib eine kurze Zusammenfassung Deiner Änderungen ein',
+    'pages_editing_draft_notification' => 'Du bearbeitest momenten einen Entwurf, der zuletzt :timeDiff gespeichert wurde.',
+    'pages_draft_edit_active' => [
+        'start_a' => ':count Benutzer bearbeiten derzeit diese Seite.',
+        'start_b' => ':userName bearbeitet jetzt diese Seite.',
+        'time_a' => 'seit die Seiten zuletzt aktualisiert wurden.',
+        'time_b' => 'in den letzten :minCount Minuten',
+        'message' => ':start :time. Achte darauf, keine Änderungen von anderen Benutzern zu überschreiben!',
+    ],
+    /**
+     * Editor sidebar
+     */
+    'tags_explain' => "Füge Schlagwörter hinzu, um ihren Inhalt zu kategorisieren.\nDu kannst einen erklärenden Inhalt hinzufügen, um eine genauere Unterteilung vorzunehmen.",
+    'attachments_explain' => 'Du kannst auf Deiner Seite Dateien hochladen oder Links hinzufügen. Diese werden in der Seitenleiste angezeigt.',
+    'attachments_delete_confirm' => 'Klicke erneut auf löschen, um diesen Anhang zu entfernen.',
+    'attachments_dropzone' => 'Ziehe Dateien hierher oder klicke hier, um eine Datei auszuwählen',
+    'attachments_explain_link' => 'Wenn Du keine Datei hochladen möchtest, kannst Du stattdessen einen Link hinzufügen. Dieser Link kann auf eine andere Seite oder eine Datei im Internet verweisen.',
+    'attachments_edit_drop_upload' => 'Ziehe Dateien hierher, um diese hochzuladen und zu überschreiben',
+    /**
+     * Profile View
+     */
+    
+    /**
+     * Comments
+     */
+    'comment_placeholder' => 'Gib hier Deine Kommentare ein (Markdown unterstützt)',
+    'comment_delete_confirm' => 'Möchtst Du diesen Kommentar wirklich löschen?',
+
+    /**
+     * Revision
+     */
+    'revision_delete_confirm' => 'Bist Du sicher, dass Du diese Revision löschen möchtest?',
+];
+
+return array_replace($de_formal, $de_informal);

--- a/resources/lang/de_informal/errors.php
+++ b/resources/lang/de_informal/errors.php
@@ -2,9 +2,6 @@
 $de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
 
 $de_informal = [
-    /**
-     * Error text strings.
-     */
     // Pages
     'permission' => 'Du hast keine Berechtigung, auf diese Seite zuzugreifen.',
     'permissionJson' => 'Du hast keine Berechtigung, die angeforderte Aktion auszuführen.',
@@ -19,16 +16,12 @@ $de_informal = [
     'path_not_writable' => 'Die Datei kann nicht in den angegebenen Pfad :filePath hochgeladen werden. Stelle sicher, dass dieser Ordner auf dem Server beschreibbar ist.',
     'cannot_create_thumbs' => 'Der Server kann keine Vorschau-Bilder erzeugen. Bitte prüfe, ob die GD PHP-Erweiterung installiert ist.',
     'server_upload_limit' => 'Der Server verbietet das Hochladen von Dateien mit dieser Dateigröße. Bitte versuche es mit einer kleineren Datei.',
-    // Attachments
     // Pages
     'page_draft_autosave_fail' => 'Fehler beim Speichern des Entwurfs. Stelle sicher, dass Du mit dem Internet verbunden bist, bevor Du den Entwurf dieser Seite speicherst.',
     'page_custom_home_deletion' => 'Eine als Startseite gesetzte Seite kann nicht gelöscht werden.',
-    // Entities
     // Users
     'users_cannot_delete_only_admin' => 'Du kannst den einzigen Administrator nicht löschen.',
     'users_cannot_delete_guest' => 'Du kannst den Gast-Benutzer nicht löschen',
-    // Roles
-    // Comments
     // Error pages
     'sorry_page_not_found' => 'Entschuldigung. Die Seite, die Du angefordert hast, wurde nicht gefunden.',
 ];

--- a/resources/lang/de_informal/errors.php
+++ b/resources/lang/de_informal/errors.php
@@ -1,0 +1,36 @@
+<?php
+$de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
+
+$de_informal = [
+    /**
+     * Error text strings.
+     */
+    // Pages
+    'permission' => 'Du hast keine Berechtigung, auf diese Seite zuzugreifen.',
+    'permissionJson' => 'Du hast keine Berechtigung, die angeforderte Aktion auszuführen.',
+    // Auth
+    'email_already_confirmed' => 'Die E-Mail-Adresse ist bereits bestätigt. Bitte melde dich an.',
+    'email_confirmation_invalid' => 'Der Bestätigungslink ist nicht gültig oder wurde bereits verwendet. Bitte registriere dich erneut.',
+    'social_account_in_use' => 'Dieses :socialAccount-Konto wird bereits verwendet. Bitte melde dich mit dem :socialAccount-Konto an.',
+    'social_account_email_in_use' => 'Die E-Mail-Adresse ":email" ist bereits registriert. Wenn Du bereits registriert bist, kannst Du Dein :socialAccount-Konto in Deinen Profil-Einstellungen verknüpfen.',
+    'social_account_not_used' => 'Dieses :socialAccount-Konto ist bisher keinem Benutzer zugeordnet. Du kannst das in Deinen Profil-Einstellungen tun.',
+    'social_account_register_instructions' => 'Wenn Du bisher kein Social-Media Konto besitzt, kannst Du ein solches Konto mit der :socialAccount Option anlegen.',
+    // System
+    'path_not_writable' => 'Die Datei kann nicht in den angegebenen Pfad :filePath hochgeladen werden. Stelle sicher, dass dieser Ordner auf dem Server beschreibbar ist.',
+    'cannot_create_thumbs' => 'Der Server kann keine Vorschau-Bilder erzeugen. Bitte prüfe, ob die GD PHP-Erweiterung installiert ist.',
+    'server_upload_limit' => 'Der Server verbietet das Hochladen von Dateien mit dieser Dateigröße. Bitte versuche es mit einer kleineren Datei.',
+    // Attachments
+    // Pages
+    'page_draft_autosave_fail' => 'Fehler beim Speichern des Entwurfs. Stelle sicher, dass Du mit dem Internet verbunden bist, bevor Du den Entwurf dieser Seite speicherst.',
+    'page_custom_home_deletion' => 'Eine als Startseite gesetzte Seite kann nicht gelöscht werden.',
+    // Entities
+    // Users
+    'users_cannot_delete_only_admin' => 'Du kannst den einzigen Administrator nicht löschen.',
+    'users_cannot_delete_guest' => 'Du kannst den Gast-Benutzer nicht löschen',
+    // Roles
+    // Comments
+    // Error pages
+    'sorry_page_not_found' => 'Entschuldigung. Die Seite, die Du angefordert hast, wurde nicht gefunden.',
+];
+
+return array_replace($de_formal, $de_informal);

--- a/resources/lang/de_informal/pagination.php
+++ b/resources/lang/de_informal/pagination.php
@@ -1,0 +1,20 @@
+<?php
+$de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
+
+$de_informal = [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+
+];
+
+return array_replace($de_formal, $de_informal);

--- a/resources/lang/de_informal/pagination.php
+++ b/resources/lang/de_informal/pagination.php
@@ -3,18 +3,6 @@ $de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
 
 $de_informal = [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Pagination Language Lines
-    |--------------------------------------------------------------------------
-    |
-    | The following language lines are used by the paginator library to build
-    | the simple pagination links. You are free to change them to anything
-    | you want to customize your views to better match your application.
-    |
-    */
-
-
 ];
 
 return array_replace($de_formal, $de_informal);

--- a/resources/lang/de_informal/passwords.php
+++ b/resources/lang/de_informal/passwords.php
@@ -1,0 +1,19 @@
+<?php
+$de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
+
+$de_informal = [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reminder Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+];
+
+return array_replace($de_formal, $de_informal);

--- a/resources/lang/de_informal/passwords.php
+++ b/resources/lang/de_informal/passwords.php
@@ -3,17 +3,6 @@ $de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
 
 $de_informal = [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Password Reminder Language Lines
-    |--------------------------------------------------------------------------
-    |
-    | The following language lines are the default lines which match reasons
-    | that are given by the password broker for a password update attempt
-    | has failed, such as for an invalid token or invalid new password.
-    |
-    */
-
 ];
 
 return array_replace($de_formal, $de_informal);

--- a/resources/lang/de_informal/settings.php
+++ b/resources/lang/de_informal/settings.php
@@ -1,0 +1,41 @@
+<?php
+$de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
+
+$de_informal = [
+    /**
+     * Settings text strings
+     * Contains all text strings used in the general settings sections of BookStack
+     * including users and roles.
+     */
+    /**
+     * App settings
+     */
+    'app_editor_desc' => 'Wähle den Editor aus, der von allen Benutzern genutzt werden soll, um Seiten zu editieren.',
+    'app_primary_color_desc' => "Dies sollte ein HEX Wert sein.\nWenn Du nichts eingibst, wird die Anwendung auf die Standardfarbe zurückgesetzt.",
+    'app_homepage_desc' => 'Wähle eine Seite als Startseite aus, die statt der Standardansicht angezeigt werden soll. Seitenberechtigungen werden für die ausgewählten Seiten ignoriert.',
+    'app_homepage_books' => 'Oder wähle die Buch-Übersicht als Startseite. Das wird die Seiten-Auswahl überschreiben.',
+    /**
+     * Registration settings
+     */
+    
+    /**
+     * Maintenance settings
+     */
+    'maint_image_cleanup_desc' => 'Überprüft Seiten- und Versionsinhalte auf ungenutzte und mehrfach vorhandene Bilder. Erstelle vor dem Start ein Backup Deiner Datenbank und Bilder.',
+    'maint_image_cleanup_warning' => ':count eventuell unbenutze Bilder wurden gefunden. Möchtest Du diese Bilder löschen?',
+
+    /**
+     * Role settings
+     */
+    'role_delete_confirm' => 'Du möchtest die Rolle ":roleName" löschen.',
+    'role_delete_users_assigned' => 'Diese Rolle ist :userCount Benutzern zugeordnet. Du kannst unten eine neue Rolle auswählen, die Du diesen Benutzern zuordnen möchtest.',
+    'role_delete_sure' => 'Bist Du sicher, dass Du diese Rolle löschen möchtest?',
+    /**
+     * Users
+     */
+    'users_password_warning' => 'Fülle die folgenden Felder nur aus, wenn Du Dein Passwort ändern möchtest:',
+    'users_delete_confirm' => 'Bist Du sicher, dass Du diesen Benutzer löschen möchtest?',
+    'users_social_accounts_info' => 'Hier kannst Du andere Social-Media-Konten für eine schnellere und einfachere Anmeldung verknüpfen. Wenn Du ein Social-Media Konto löschst, bleibt der Zugriff erhalten. Entferne in diesem Falle die Berechtigung in Deinen Profil-Einstellungen des verknüpften Social-Media-Kontos.',
+];
+
+return array_replace($de_formal, $de_informal);

--- a/resources/lang/de_informal/settings.php
+++ b/resources/lang/de_informal/settings.php
@@ -15,15 +15,10 @@ $de_informal = [
     'app_homepage_desc' => 'Wähle eine Seite als Startseite aus, die statt der Standardansicht angezeigt werden soll. Seitenberechtigungen werden für die ausgewählten Seiten ignoriert.',
     'app_homepage_books' => 'Oder wähle die Buch-Übersicht als Startseite. Das wird die Seiten-Auswahl überschreiben.',
     /**
-     * Registration settings
-     */
-    
-    /**
      * Maintenance settings
      */
     'maint_image_cleanup_desc' => 'Überprüft Seiten- und Versionsinhalte auf ungenutzte und mehrfach vorhandene Bilder. Erstelle vor dem Start ein Backup Deiner Datenbank und Bilder.',
     'maint_image_cleanup_warning' => ':count eventuell unbenutze Bilder wurden gefunden. Möchtest Du diese Bilder löschen?',
-
     /**
      * Role settings
      */

--- a/resources/lang/de_informal/validation.php
+++ b/resources/lang/de_informal/validation.php
@@ -3,39 +3,6 @@ $de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
 
 $de_informal = [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Validation Language Lines
-    |--------------------------------------------------------------------------
-    |
-    | following language lines contain default error messages used by
-    | validator class. Some of these rules have multiple versions such
-    | as size rules. Feel free to tweak each of these messages here.
-    |
-    */
-
-    /*
-    |--------------------------------------------------------------------------
-    | Custom Validation Language Lines
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify custom validation messages for attributes using the
-    | convention "attribute.rule" to name lines. This makes it quick to
-    | specify a specific custom language line for a given attribute rule.
-    |
-    */
-
-    /*
-    |--------------------------------------------------------------------------
-    | Custom Validation Attributes
-    |--------------------------------------------------------------------------
-    |
-    | following language lines are used to swap attribute place-holders
-    | with something more reader friendly such as E-Mail Address instead
-    | of "email". This simply helps us make messages a little cleaner.
-    |
-    */
-
 ];
 
 return array_replace($de_formal, $de_informal);

--- a/resources/lang/de_informal/validation.php
+++ b/resources/lang/de_informal/validation.php
@@ -1,0 +1,41 @@
+<?php
+$de_formal = (include resource_path() . '/lang/de/' . basename(__FILE__));
+
+$de_informal = [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | following language lines contain default error messages used by
+    | validator class. Some of these rules have multiple versions such
+    | as size rules. Feel free to tweak each of these messages here.
+    |
+    */
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | following language lines are used to swap attribute place-holders
+    | with something more reader friendly such as E-Mail Address instead
+    | of "email". This simply helps us make messages a little cleaner.
+    |
+    */
+
+];
+
+return array_replace($de_formal, $de_informal);

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -136,7 +136,8 @@ return [
     'language_select' => [
         'en' => 'English',
         'ar' => 'العربية',
-        'de' => 'Deutsch',
+        'de' => 'Deutsch (Sie)',
+        'de_informal' => 'Deutsch (Du)',
         'es' => 'Español',
         'es_AR' => 'Español Argentina',
         'fr' => 'Français',


### PR DESCRIPTION
This commit adds German informal language ("Du" instead of "Sie") based on the current formal language files. Fixes this part of #890.