### PR TITLE
Simplified example env and created full example copy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,11 @@
 APP_KEY=SomeRandomString
 
 # Application URL
+# Remove the hash below and set a URL if using BookStack behind
+# a proxy, if using a third-party authentication option.
 # This must be the root URL that you want to host BookStack on.
 # All URL's in BookStack will be generated using this value.
-APP_URL=https://example.com
+#APP_URL=https://example.com
 
 # Database details
 DB_HOST=localhost

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,12 @@
-# Environment
-APP_ENV=production
-APP_DEBUG=false
+# Application key
+# Used for encryption where needed.
+# Run `php artisan key:generate` to generate a valid key.
 APP_KEY=SomeRandomString
 
-# The below url has to be set if using social auth options
-# or if you are not using BookStack at the root path of your domain.
-# APP_URL=http://bookstack.dev
+# Application URL
+# This must be the root URL that you want to host BookStack on.
+# All URL's in BookStack will be generated using this value.
+APP_URL=https://example.com
 
 # Database details
 DB_HOST=localhost
@@ -13,84 +14,16 @@ DB_DATABASE=database_database
 DB_USERNAME=database_username
 DB_PASSWORD=database_user_password
 
-# Cache and session
-CACHE_DRIVER=file
-SESSION_DRIVER=file
-# If using Memcached, comment the above and uncomment these
-#CACHE_DRIVER=memcached
-#SESSION_DRIVER=memcached
-QUEUE_DRIVER=sync
-# A different prefix is useful when multiple BookStack instances use the same caching server
-CACHE_PREFIX=bookstack
-
-# Memcached settings
-# If using a UNIX socket path for the host, set the port to 0
-# This follows the following format: HOST:PORT:WEIGHT
-# For multiple servers separate with a comma
-MEMCACHED_SERVERS=127.0.0.1:11211:100
-
-# Storage
-STORAGE_TYPE=local
-# Amazon S3 Config
-STORAGE_S3_KEY=false
-STORAGE_S3_SECRET=false
-STORAGE_S3_REGION=false
-STORAGE_S3_BUCKET=false
-# Storage URL
-# Used to prefix image urls for when using custom domains/cdns
-STORAGE_URL=false
-
-# General auth
-AUTH_METHOD=standard
-
-# Social Authentication information. Defaults as off.
-GITHUB_APP_ID=false
-GITHUB_APP_SECRET=false
-GOOGLE_APP_ID=false
-GOOGLE_APP_SECRET=false
-GOOGLE_SELECT_ACCOUNT=false
-OKTA_BASE_URL=false
-OKTA_APP_ID=false
-OKTA_APP_SECRET=false
-TWITCH_APP_ID=false
-TWITCH_APP_SECRET=false
-GITLAB_APP_ID=false
-GITLAB_APP_SECRET=false
-GITLAB_BASE_URI=false
-DISCORD_APP_ID=false
-DISCORD_APP_SECRET=false
-
-
-# Disable default services such as Gravatar and Draw.IO
-DISABLE_EXTERNAL_SERVICES=false
-# Use custom avatar service, Sets fetch URL
-# Possible placeholders: ${hash} ${size} ${email}
-# If set, Avatars will be fetched regardless of DISABLE_EXTERNAL_SERVICES option.
-# AVATAR_URL=https://seccdn.libravatar.org/avatar/${hash}?s=${size}&d=identicon
-
-# LDAP Settings
-LDAP_SERVER=false
-LDAP_BASE_DN=false
-LDAP_DN=false
-LDAP_PASS=false
-LDAP_USER_FILTER=false
-LDAP_VERSION=false
-# Do you want to sync LDAP groups to BookStack roles for a user
-LDAP_USER_TO_GROUPS=false
-# What is the LDAP attribute for group memberships
-LDAP_GROUP_ATTRIBUTE="memberOf"
-# Would you like to remove users from roles on BookStack if they do not match on LDAP
-# If false, the ldap groups-roles sync will only add users to roles
-LDAP_REMOVE_FROM_GROUPS=false
-# Set this option to disable LDAPS Certificate Verification
-LDAP_TLS_INSECURE=false
-
-# Mail settings
+# Mail system to use
+# Can be 'smtp', 'mail' or 'sendmail'
 MAIL_DRIVER=smtp
+
+# SMTP mail options
 MAIL_HOST=localhost
 MAIL_PORT=1025
 MAIL_USERNAME=null
 MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null
-MAIL_FROM=null
-MAIL_FROM_NAME=null
+
+
+# A full list of options can be found in the '.env.example.complete' file.

--- a/.env.example.complete
+++ b/.env.example.complete
@@ -1,0 +1,211 @@
+# Full list of environment variables that can be used with BookStack.
+# Selectively copy these to your '.env' file as required.
+# Each option is shown with it's default value.
+# Do not copy this whole file to use as your '.env' file.
+
+# Application environment
+# Can be 'production', 'development', 'testing' or 'demo'
+APP_ENV=production
+
+# Enable debug mode
+# Shows advanced debug information and errors.
+# CAN EXPOSE OTHER VARIABLES, LEAVE DISABLED
+APP_DEBUG=false
+
+# Application key
+# Used for encryption where needed.
+# Run `php artisan key:generate` to generate a valid key.
+APP_KEY=SomeRandomString
+
+# Application URL
+# This must be the root URL that you want to host BookStack on.
+# All URL's in BookStack will be generated using this value.
+APP_URL=https://example.com
+
+# Application default language
+# The default language choice to show.
+# May be overridden by user-preference or visitor browser settings.
+APP_LANG=en
+
+# Auto-detect language for public visitors.
+# Uses browser-sent headers to infer a language.
+# APP_LANG will be used if such a header is not provided.
+APP_AUTO_LANG_PUBLIC=true
+
+# Database details
+# Host can contain a port (localhost:3306) or a separate DB_PORT option can be used.
+DB_HOST=localhost
+DB_PORT=3306
+DB_DATABASE=database_database
+DB_USERNAME=database_username
+DB_PASSWORD=database_user_password
+
+# Mail system to use
+# Can be 'smtp', 'mail' or 'sendmail'
+MAIL_DRIVER=smtp
+
+# Mail sending options
+MAIL_FROM=mail@bookstackapp.com
+MAIL_FROM_NAME=BookStack
+
+# SMTP mail options
+MAIL_HOST=localhost
+MAIL_PORT=1025
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_ENCRYPTION=null
+
+# Cache & Session driver to use
+# Can be 'file', 'database', 'memcached' or 'redis'
+CACHE_DRIVER=file
+SESSION_DRIVER=file
+
+# Session configuration
+SESSION_LIFETIME=120
+SESSION_COOKIE_NAME=bookstack_session
+SESSION_SECURE_COOKIE=false
+
+# Cache key prefix
+# Can be used to prevent conflicts multiple BookStack instances use the same store.
+CACHE_PREFIX=bookstack
+
+# Memcached server configuration
+# If using a UNIX socket path for the host, set the port to 0
+# This follows the following format: HOST:PORT:WEIGHT
+# For multiple servers separate with a comma
+MEMCACHED_SERVERS=127.0.0.1:11211:100
+
+# Queue driver to use
+# Queue not really currently used but may be configurable in the future.
+# Would advise not to change this for now.
+QUEUE_DRIVER=sync
+
+# Storage system to use
+# Can be 'local', 'local_secure' or 's3'
+STORAGE_TYPE=local
+
+# Amazon S3 storage configuration
+STORAGE_S3_KEY=your-s3-key
+STORAGE_S3_SECRET=your-s3-secret
+STORAGE_S3_BUCKET=s3-bucket-name
+STORAGE_S3_REGION=s3-bucket-region
+
+# Storage URL prefix
+# Used as a base for any generated image urls.
+# An s3-format URL will be generated if not set.
+STORAGE_URL=false
+
+# Authentication method to use
+# Can be 'standard' or 'ldap'
+AUTH_METHOD=standard
+
+# Social authentication configuration
+# All disabled by default.
+# Refer to https://www.bookstackapp.com/docs/admin/third-party-auth/
+
+AZURE_APP_ID=false
+AZURE_APP_SECRET=false
+AZURE_TENANT=false
+AZURE_AUTO_REGISTER=false
+AZURE_AUTO_CONFIRM_EMAIL=false
+
+DISCORD_APP_ID=false
+DISCORD_APP_SECRET=false
+DISCORD_AUTO_REGISTER=false
+DISCORD_AUTO_CONFIRM_EMAIL=false
+
+FACEBOOK_APP_ID=false
+FACEBOOK_APP_SECRET=false
+FACEBOOK_AUTO_REGISTER=false
+FACEBOOK_AUTO_CONFIRM_EMAIL=false
+
+GITHUB_APP_ID=false
+GITHUB_APP_SECRET=false
+GITHUB_AUTO_REGISTER=false
+GITHUB_AUTO_CONFIRM_EMAIL=false
+
+GITLAB_APP_ID=false
+GITLAB_APP_SECRET=false
+GITLAB_BASE_URI=false
+GITLAB_AUTO_REGISTER=false
+GITLAB_AUTO_CONFIRM_EMAIL=false
+
+GOOGLE_APP_ID=false
+GOOGLE_APP_SECRET=false
+GOOGLE_SELECT_ACCOUNT=false
+GOOGLE_AUTO_REGISTER=false
+GOOGLE_AUTO_CONFIRM_EMAIL=false
+
+OKTA_BASE_URL=false
+OKTA_APP_ID=false
+OKTA_APP_SECRET=false
+OKTA_AUTO_REGISTER=false
+OKTA_AUTO_CONFIRM_EMAIL=false
+
+SLACK_APP_ID=false
+SLACK_APP_SECRET=false
+SLACK_AUTO_REGISTER=false
+SLACK_AUTO_CONFIRM_EMAIL=false
+
+TWITCH_APP_ID=false
+TWITCH_APP_SECRET=false
+TWITCH_AUTO_REGISTER=false
+TWITCH_AUTO_CONFIRM_EMAIL=false
+
+TWITTER_APP_ID=false
+TWITTER_APP_SECRET=false
+TWITTER_AUTO_REGISTER=false
+TWITTER_AUTO_CONFIRM_EMAIL=false
+
+# LDAP authentication configuration
+# Refer to https://www.bookstackapp.com/docs/admin/ldap-auth/
+LDAP_SERVER=false
+LDAP_BASE_DN=false
+LDAP_DN=false
+LDAP_PASS=false
+LDAP_USER_FILTER=false
+LDAP_VERSION=false
+LDAP_TLS_INSECURE=false
+LDAP_EMAIL_ATTRIBUTE=mail
+LDAP_FOLLOW_REFERRALS=true
+
+# LDAP group sync configuration
+# Refer to https://www.bookstackapp.com/docs/admin/ldap-auth/
+LDAP_USER_TO_GROUPS=false
+LDAP_GROUP_ATTRIBUTE="memberOf"
+LDAP_REMOVE_FROM_GROUPS=false
+
+# Disable default third-party services such as Gravatar and Draw.IO
+# Service-specific options will override this option
+DISABLE_EXTERNAL_SERVICES=false
+
+# Use custom avatar service, Sets fetch URL
+# Possible placeholders: ${hash} ${size} ${email}
+# If set, Avatars will be fetched regardless of DISABLE_EXTERNAL_SERVICES option.
+# Example: AVATAR_URL=https://seccdn.libravatar.org/avatar/${hash}?s=${size}&d=identicon
+AVATAR_URL=
+
+# Enable Draw.io integration
+DRAWIO=true
+
+# Default item listing view
+# Used for public visitors and user's without a preference
+# Can be 'list' or 'grid'
+APP_VIEWS_BOOKS=list
+APP_VIEWS_BOOKSHELVES=grid
+
+# Page revision limit
+# Number of page revisions to keep in the system before deleting old revisions.
+# If set to 'false' a limit will not be enforced.
+REVISION_LIMIT=50
+
+# Allow <script> tags in page content
+# Note, if set to 'true' the page editor may still escape scripts.
+ALLOW_CONTENT_SCRIPTS=false
+
+# Indicate if robots/crawlers should crawl your instance.
+# Can be 'true', 'false' or 'null'.
+# The behaviour of the default 'null' option will depend on the 'app-public' admin setting.
+# Contents of the robots.txt file can be overridden, making this option obsolete.
+ALLOW_ROBOTS=null
+

--- a/config/app.php
+++ b/config/app.php
@@ -22,7 +22,8 @@ return [
     // Set the default view type for various lists. Can be overridden by user preferences.
     // These will be used for public viewers and users that have not set a preference.
     'views' => [
-        'books' => env('APP_VIEWS_BOOKS', 'list')
+        'books' => env('APP_VIEWS_BOOKS', 'list'),
+        'bookshelves' => env('APP_VIEWS_BOOKSHELVES', 'grid'),
     ],
 
     // The number of revisions to keep in the database.

--- a/config/session.php
+++ b/config/session.php
@@ -14,7 +14,6 @@ return [
     // Options: file, cookie, database, redis, memcached, array
     'driver' => env('SESSION_DRIVER', 'file'),
 
-
     // Session lifetime, in minutes
     'lifetime' => env('SESSION_LIFETIME', 120),
 


### PR DESCRIPTION
Cleanup of the `.env.example` since it was getting messy.
This simplifies the file to only show what's fully needed.

A `.env.example.complete` contains all possible options with comments for each.

Will need to review docs to see where variables are mentioned as may have to change wording from `set` to `add` in some areas where old variables have been removed. 