### PR TITLE
Fixes tooltip on the image manager.

### DIFF
--- a/resources/assets/sass/_components.scss
+++ b/resources/assets/sass/_components.scss
@@ -210,7 +210,6 @@ body.flexbox-support #entity-selector-wrap .popup-body .form-group {
 
 .image-manager-sidebar {
   width: 300px;
-  margin-left: 1px;
   overflow-y: auto;
   overflow-x: hidden;
   border-left: 1px solid #DDD;
@@ -524,8 +523,8 @@ body.flexbox-support #entity-selector-wrap .popup-body .form-group {
   font-size: 12px;
   line-height: 1.2;
   top: 88px;
-  left: -26px;
-  width: 148px;
+  left: -12px;
+  width: 160px;
   background: $negative;
   padding: $-xs;
   color: white;
@@ -535,7 +534,7 @@ body.flexbox-support #entity-selector-wrap .popup-body .form-group {
   content: '';
   position: absolute;
   top: -6px;
-  left: 64px;
+  left: 52px;
   width: 0;
   height: 0;
   border-left: 6px solid transparent;

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -69,6 +69,7 @@ return [
     'timezone'             => 'The :attribute must be a valid zone.',
     'unique'               => 'The :attribute has already been taken.',
     'url'                  => 'The :attribute format is invalid.',
+    'is_image'             => 'The :attribute must be a valid image.',
 
     // Custom validation lines
     'custom' => [


### PR DESCRIPTION
Fixes #1186

![image](https://user-images.githubusercontent.com/1685517/51802027-79b10480-226b-11e9-8431-28fa458f3e74.png)
---
![image](https://user-images.githubusercontent.com/1685517/51802034-8f262e80-226b-11e9-9035-b2ac83ba9fbf.png)

1. I've added a message.
2. The tooltip arrow now appears slightly off-center. I think that's an acceptable trade-off.
