### PR TITLE
Add Powershell Code Markup

### DIFF
--- a/resources/views/components/code-editor.blade.php
+++ b/resources/views/components/code-editor.blade.php
@@ -22,6 +22,7 @@
                             <a @click="updateLanguage('JavaScript')">JavaScript</a>
                             <a @click="updateLanguage('JSON')">JSON</a>
                             <a @click="updateLanguage('PHP')">PHP</a>
+                            <a @click="updateLanguage('Powershell')">Powershell</a>
                             <a @click="updateLanguage('MarkDown')">MarkDown</a>
                             <a @click="updateLanguage('Nginx')">Nginx</a>
                             <a @click="updateLanguage('Python')">Python</a>


### PR DESCRIPTION
Adds a Powershell link to the Code Editor component to utilize the syntax highlighting already built in by codemirror.

Closes #1040 