### PR TITLE
Dynamic Links and Editor Integration

### DIFF
--- a/app/Entities/Repos/EntityRepo.php
+++ b/app/Entities/Repos/EntityRepo.php
@@ -18,6 +18,7 @@ use BookStack\Uploads\ImageRepo;
 use DOMDocument;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\URL;
 
 class EntityRepo
 {
@@ -664,9 +665,9 @@ class EntityRepo
         $matches = [];
         preg_match_all('/bookstackapp:([a-z]+):([0-9]+)/', $content, $matches);
 
-        if (count($matches[0]) === 0) {
+        /*if (count($matches[0]) === 0) {
             return $content;
-        }
+        }*/
 
         foreach($matches[1] as $index => $matchedType){
             $entityId = $matches[2][$index];
@@ -689,6 +690,13 @@ class EntityRepo
                 $newLink = ($matchedImage === null) ? '#' : $matchedImage->getThumb(840, 0, true);
                 $content = str_replace($fullMatch, $newLink, $content);
             }
+        }
+
+        preg_match_all('/bookstackapp:ref:([a-z\-\/]+)/', $content, $matches);
+
+        foreach($matches[1] as $index => $refURL) {
+            $fullMatch = $matches[0][$index];
+            $content = str_replace($fullMatch, url()->to($refURL), $content);
         }
 
         return $content;

--- a/app/Entities/Repos/EntityRepo.php
+++ b/app/Entities/Repos/EntityRepo.php
@@ -640,7 +640,7 @@ class EntityRepo
     {
         $html = $this->renderInternalLinks($html);
         $html = $this->renderTransclusions($html);
-        
+
         return $html;
     }
 
@@ -657,13 +657,14 @@ class EntityRepo
         if (count($matches[0]) === 0) {
             return $content;
         }
-        
+
         foreach($matches[1] as $index => $entityId){
             preg_match('/href=".*"/', $matches[0][$index], $hrefMatches);
             $hrefAttribute = $hrefMatches[0];
             $openBracketCount = substr_count($hrefAttribute, '{', 6);
             $closeBracketCount = substr_count($hrefAttribute, '}', 6);
-            
+
+            $matchedEntity = null;
             if ($openBracketCount === $closeBracketCount){
                 if ($openBracketCount === 2){
                     $matchedEntity = $this->getById('page', $entityId, false, $ignorePermissions);
@@ -671,20 +672,18 @@ class EntityRepo
                     $matchedEntity = $this->getById('chapter', $entityId, false, $ignorePermissions);
                 }elseif ($openBracketCount === 4){
                     $matchedEntity = $this->getById('book', $entityId, false, $ignorePermissions);
-                }else{
-                    $matchedEntity = null;
-                }
-                
-                if ($matchedEntity === null) {
-                    $emptyLink = preg_replace('/href=".*"/', 'href="#"', $matches[0][$index]);
-                    $content = str_replace($matches[0][$index], $emptyLink, $content);
-                } else {
-                    $newLink = preg_replace('/href=".*"/', 'href="'.$matchedEntity->getUrl().'"', $matches[0][$index]);
-                    $content = str_replace($matches[0][$index], $newLink, $content);
                 }
             }
+
+            if ($matchedEntity === null) {
+                $emptyLink = preg_replace('/href=".*"/', 'href="#"', $matches[0][$index]);
+                $content = str_replace($matches[0][$index], $emptyLink, $content);
+            } else {
+                $newLink = preg_replace('/href=".*"/', 'href="'.$matchedEntity->getUrl().'"', $matches[0][$index]);
+                $content = str_replace($matches[0][$index], $newLink, $content);
+            }
         }
-        
+
         return $content;
     }
 
@@ -738,7 +737,7 @@ class EntityRepo
 
         return $html;
     }
-    
+
     /**
      * Escape script tags within HTML content.
      * @param string $html

--- a/app/Entities/Repos/EntityRepo.php
+++ b/app/Entities/Repos/EntityRepo.php
@@ -653,34 +653,19 @@ class EntityRepo
     public function renderInternalLinks($content, $ignorePermissions = false)
     {
         $matches = [];
-        preg_match_all('/<a .*href\="{{{*@([0-9]*)}}}*"/', $content, $matches);
+        preg_match_all('/{{([a-z]+)@([0-9]+)}}"/', $content, $matches);
         if (count($matches[0]) === 0) {
             return $content;
         }
 
-        foreach($matches[1] as $index => $entityId){
-            preg_match('/href=".*"/', $matches[0][$index], $hrefMatches);
-            $hrefAttribute = $hrefMatches[0];
-            $openBracketCount = substr_count($hrefAttribute, '{', 6);
-            $closeBracketCount = substr_count($hrefAttribute, '}', 6);
+        foreach($matches[1] as $index => $matchedType){
+            $entityId = $matches[2][$index];
+            $fullMatch = $matches[0][$index];
 
-            $matchedEntity = null;
-            if ($openBracketCount === $closeBracketCount){
-                if ($openBracketCount === 2){
-                    $matchedEntity = $this->getById('page', $entityId, false, $ignorePermissions);
-                }elseif ($openBracketCount === 3){
-                    $matchedEntity = $this->getById('chapter', $entityId, false, $ignorePermissions);
-                }elseif ($openBracketCount === 4){
-                    $matchedEntity = $this->getById('book', $entityId, false, $ignorePermissions);
-                }
-            }
-
-            if ($matchedEntity === null) {
-                $emptyLink = preg_replace('/href=".*"/', 'href="#"', $matches[0][$index]);
-                $content = str_replace($matches[0][$index], $emptyLink, $content);
-            } else {
-                $newLink = preg_replace('/href=".*"/', 'href="'.$matchedEntity->getUrl().'"', $matches[0][$index]);
-                $content = str_replace($matches[0][$index], $newLink, $content);
+            if (in_array($matchedType, ['page', 'chapter', 'book'])) {
+                $matchedEntity = $this->getById($matchedType, $entityId, false, $ignorePermissions);
+                $newLink = ($matchedEntity === null) ? '#' : $matchedEntity->getUrl();
+                $content = str_replace($fullMatch, $newLink, $content);
             }
         }
 

--- a/resources/assets/js/components/entity-selector.js
+++ b/resources/assets/js/components/entity-selector.js
@@ -99,7 +99,7 @@ class EntitySelector {
 
         let link = item.querySelector('.entity-list-item-link').getAttribute('href');
         let name = item.querySelector('.entity-list-item-name').textContent;
-        let data = {id: Number(id), name: name, link: link};
+        let data = {id: Number(id), name: name, link: link, type: type};
 
         if (isDblClick) window.$events.emit('entity-select-confirm', data);
         if (isSelected) window.$events.emit('entity-select-change', data);

--- a/resources/assets/js/components/wysiwyg-editor.js
+++ b/resources/assets/js/components/wysiwyg-editor.js
@@ -454,7 +454,7 @@ class WysiwygEditor {
                 if (type === 'file') {
                     window.EntitySelectorPopup.show(function(entity) {
                         let originalField = win.document.getElementById(field_name);
-                        originalField.value = entity.link;
+                        originalField.value = 'bookstackapp:' + entity.type + ':' + entity.id;
                         $(originalField).closest('.mce-form').find('input').eq(2).val(entity.name);
                     });
                 }


### PR DESCRIPTION
This PR is to provide an implementation for the seemingly abandoned #737. It also includes some changes to the Markdown and WYSIWYG editor, to use the new syntax by default.

I'll provide more details later, but I chose a custom URI as the most appropriate solution to implement this feature, as it works nicely alongside other link-schemes, does not produce URL-encoded characters, wherever it is used. I'll also submit a pull-request for another branch, which does not touch the editors at all, making this feature entirely optional for the user.