### PR TITLE
Bugfix: ldap_connect() ignores argument when given an URI

### DIFF
--- a/app/Auth/Access/Ldap.php
+++ b/app/Auth/Access/Ldap.php
@@ -17,7 +17,11 @@ class Ldap
      */
     public function connect($hostName, $port)
     {
-        return ldap_connect($hostName, $port);
+        if(strpos($hostName,":")===NULL) {
+            return ldap_connect($hostName,$port);
+        } else {
+            return ldap_connect($hostName.":".$port);
+        }
     }
 
     /**


### PR DESCRIPTION
ldap_connect() ignores the port argument, if $hostname is in the Form of an ldap-URI (like ldaps://....), therefore the $port must be added to the first argument, if an URI is present, otherwise it allways tries to use Port 636.

This is a quick fix, which probably needs some further adjustment.