### PR TITLE
Replace entity.link with a root relative link in actionShowLinkSelector

### DIFF
--- a/resources/assets/js/components/markdown-editor.js
+++ b/resources/assets/js/components/markdown-editor.js
@@ -323,8 +323,9 @@ class MarkdownEditor {
     actionShowLinkSelector() {
         let cursorPos = this.cm.getCursor('from');
         window.EntitySelectorPopup.show(entity => {
+            let rootRelativePath = (new URL(entity.link)).pathname;
             let selectedText = this.cm.getSelection() || entity.name;
-            let newText = `[${selectedText}](${entity.link})`;
+            let newText = `[${selectedText}](${rootRelativePath})`;
             this.cm.focus();
             this.cm.replaceSelection(newText);
             this.cm.setCursor(cursorPos.line, cursorPos.ch + newText.length);


### PR DESCRIPTION
Making the links from insert Entity link in the markdown editor root relative will make it that the links won't break when changing domains.