### PR TITLE
Fix LDAP attribute case sensitivity issue

### DIFF
--- a/app/Auth/Access/LdapService.php
+++ b/app/Auth/Access/LdapService.php
@@ -80,7 +80,7 @@ class LdapService
     public function getUserDetails($userName)
     {
         $emailAttr = $this->config['email_attribute'];
-        $displayNameAttr = $this->config['display_name_attribute'];
+        $displayNameAttr = strtolower($this->config['display_name_attribute']);
 
         $user = $this->getUserWithAttributes($userName, ['cn', 'uid', 'dn', $emailAttr, $displayNameAttr]);
 

--- a/tests/Auth/LdapTest.php
+++ b/tests/Auth/LdapTest.php
@@ -365,7 +365,7 @@ class LdapTest extends BrowserKitTest
                 'uid' => [$this->mockUser->name],
                 'cn' => [$this->mockUser->name],
                 'dn' => ['dc=test' . config('services.ldap.base_dn')],
-                'displayName' => 'displayNameAttribute'
+                'displayname' => 'displayNameAttribute'
             ]]);
         $this->mockLdap->shouldReceive('bind')->times(6)->andReturn(true);
         $this->mockEscapes(4);


### PR DESCRIPTION
Fixes an issue described in #1317 where attributes with upper-cased characters were not mapped correctly.