### PR TITLE
Concat hostName and port for ldap_connect

### DIFF
--- a/app/Auth/Access/Ldap.php
+++ b/app/Auth/Access/Ldap.php
@@ -17,7 +17,10 @@ class Ldap
      */
     public function connect($hostName, $port)
     {
-        return ldap_connect($hostName, $port);
+        if (substr( $hostName, 0, 4 ) === "ldap") {
+            return ldap_connect($hostName . ':' . (string)$port);
+        } else {
+            return ldap_connect($hostName, $port);
     }
 
     /**


### PR DESCRIPTION
Instead of using two parameters for ldap_connect (hostName and port), this PR combines them to a single parameter. The docs of [ldap_connect](https://www.php.net/manual/en/function.ldap-connect.php) describe the host parameter as either a hostName or a LDAP URI. In case the latter is used, the second parameter (port) is ignored. When using a protocol, the parameters are combined, otherwise it stays the same.

It works for me with `ldaps` now, did not test it without the protocol.

resolves #1220 