### PR TITLE
Replace dots with something else on user create and edit screens

### DIFF
--- a/resources/views/form/role-checkboxes.blade.php
+++ b/resources/views/form/role-checkboxes.blade.php
@@ -3,10 +3,10 @@
     @foreach($roles as $role)
         <div>
             @include('components.custom-checkbox', [
-                'name' => $name . '[' . $role->name . ']',
+                'name' => $name . '[' . str_replace('.', 'DOT', $role->name) . ']',
                 'label' => $role->display_name,
                 'value' => $role->id,
-                'checked' => old($name . '.' . $role->name) || (!old('name') && isset($model) && $model->hasRole($role->name))
+                'checked' => old($name . '.' . str_replace('.', 'DOT', $role->name)) || (!old('name') && isset($model) && $model->hasRole($role->name))
             ])
         </div>
     @endforeach


### PR DESCRIPTION
Fix for #1325 
Dot notation handling in laravel means it was looking for the existence of a value in the wrong place.
Eg, if the role name was `a.role.name` it would look in `roles['a']['role']['name']` instead of `roles['a.role.name']`

I couldn't find anywhere where the name of the role is used in setting roles (they are set with IDs), so changing the dots in the form elements name attribute to something else seems to have fixed this without any unintended side effects.

Could be an issue if someone had a role called `a.role` and a second role called `aDOTrole`, but I can't see this being the case for too many users.

Edit: I should note that the display name of the role isn't changed, so it will still appear in the form with dots. 