### PR TITLE
Add sign up link to login screen and fix registration form validation

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -70,7 +70,7 @@ class RegisterController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
-            'name' => 'required|max:255',
+            'name' => 'required|min:2|max:255',
             'email' => 'required|email|max:255|unique:users',
             'password' => 'required|min:6',
         ]);

--- a/resources/views/auth/forms/login/standard.blade.php
+++ b/resources/views/auth/forms/login/standard.blade.php
@@ -6,5 +6,10 @@
 <div class="form-group">
     <label for="password">{{ trans('auth.password') }}</label>
     @include('form.password', ['name' => 'password', 'tabindex' => 1])
-    <span class="block small mt-s"><a href="{{ baseUrl('/password/email') }}">{{ trans('auth.forgot_password') }}</a></span>
+    <span class="block small mt-s">
+        <a href="{{ baseUrl('/password/email') }}">{{ trans('auth.forgot_password') }}</a>
+        @if(setting('registration-enabled', false))
+            • <a href="{{ baseUrl('/register') }}">{{ trans('auth.sign_up') }}</a>
+        @endif
+    </span>
 </div>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -9,7 +9,7 @@
         <div class="card content-wrap">
             <h1 class="list-heading">{{ title_case(trans('auth.log_in')) }}</h1>
 
-            <form action="{{ baseUrl("/login") }}" method="POST" id="login-form" class="mt-l">
+            <form action="{{ baseUrl('/login') }}" method="POST" id="login-form" class="mt-l">
                 {!! csrf_field() !!}
 
                 <div class="stretch-inputs">

--- a/resources/views/common/header.blade.php
+++ b/resources/views/common/header.blade.php
@@ -41,7 +41,7 @@
 
                     @if(!signedInUser())
                         @if(setting('registration-enabled', false))
-                            <a href="{{ baseUrl("/register") }}">@icon('new-user') {{ trans('auth.sign_up') }}</a>
+                            <a href="{{ baseUrl('/register') }}">@icon('new-user') {{ trans('auth.sign_up') }}</a>
                         @endif
                         <a href="{{ baseUrl('/login') }}">@icon('login') {{ trans('auth.log_in') }}</a>
                     @endif

--- a/tests/Auth/AuthTest.php
+++ b/tests/Auth/AuthTest.php
@@ -69,6 +69,31 @@ class AuthTest extends BrowserKitTest
             ->seePageIs('/register');
     }
 
+    public function test_registration_validation()
+    {
+        $this->setSettings(['registration-enabled' => 'true']);
+
+        $this->visit('/register')
+            ->type('1', '#name')
+            ->type('1', '#email')
+            ->type('1', '#password')
+            ->press('Create Account')
+            ->see('The name must be at least 2 characters.')
+            ->see('The email must be a valid email address.')
+            ->see('The password must be at least 6 characters.')
+            ->seePageIs('/register');
+    }
+
+    public function test_sign_up_link_on_login()
+    {
+        $this->visit('/login')
+            ->dontSee('Sign up');
+
+        $this->setSettings(['registration-enabled' => 'true']);
+
+        $this->visit('/login')
+            ->see('Sign up');
+    }
 
     public function test_confirmed_registration()
     {


### PR DESCRIPTION
I think people expect to find a sign up link close to the login form, so added one next to forgot password if registration is enabled. Also fixed #1239 while I was there.

<img width="506" alt="image" src="https://user-images.githubusercontent.com/1470412/56205636-426c1b80-6042-11e9-90c8-5afff3ad9918.png">

<img width="483" alt="image" src="https://user-images.githubusercontent.com/1470412/56205664-531c9180-6042-11e9-9eb1-85f290d33b2a.png">

Hope this helps.