### PR TITLE
Update maintenance.php to link to Github release page & minor style tweak

### DIFF
--- a/resources/views/settings/maintenance.blade.php
+++ b/resources/views/settings/maintenance.blade.php
@@ -7,9 +7,10 @@
         <div class="py-m">
             @include('settings.navbar', ['selected' => 'maintenance'])
         </div>
-        <div class="text-right mb-l px-m">
-            <br>
+        <div class="text-right py-m">
+            <a href="https://github.com/BookStackApp/BookStack/releases">
             BookStack @if(strpos($version, 'v') !== 0) version @endif {{ $version }}
+            </a>
         </div>
     </div>
 


### PR DESCRIPTION
* Added a link to the Github releases page when someone clicks the current release version (to look for changelog information, or to see if there are new updates)
* Removed unnecessary BR tag by fixing the CSS class for the version display so it is properly aligned with the rest of the menu