### PR TITLE
Added i18n support for default data

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -23,7 +23,7 @@ class CreateUsersTable extends Migration
 
         // Create the initial admin user
         DB::table('users')->insert([
-            'name' => 'Admin',
+            'name' => __('migrations.users.admin'),
             'email' => 'admin@admin.com',
             'password' => bcrypt('password'),
             'created_at' => \Carbon\Carbon::now()->toDateTimeString(),

--- a/database/migrations/2015_08_29_105422_add_roles_and_permissions.php
+++ b/database/migrations/2015_08_29_105422_add_roles_and_permissions.php
@@ -70,35 +70,35 @@ class AddRolesAndPermissions extends Migration
         // Create default roles
         $adminId = DB::table('roles')->insertGetId([
             'name' => 'admin',
-            'display_name' => 'Admin',
-            'description' => 'Administrator of the whole application',
+            'display_name' => __('migrations.roles.admin.display_name'),
+            'description' => __('migrations.roles.admin.description'),
             'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
             'updated_at' => \Carbon\Carbon::now()->toDateTimeString()
         ]);
         $editorId = DB::table('roles')->insertGetId([
             'name' => 'editor',
-            'display_name' => 'Editor',
-            'description' => 'User can edit Books, Chapters & Pages',
+            'display_name' => __('migrations.roles.editor.display_name'),
+            'description' => __('migrations.roles.editor.description'),
             'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
             'updated_at' => \Carbon\Carbon::now()->toDateTimeString()
         ]);
         $viewerId = DB::table('roles')->insertGetId([
             'name' => 'viewer',
-            'display_name' => 'Viewer',
-            'description' => 'User can view books & their content behind authentication',
+            'display_name' => __('migrations.roles.viewer.display_name'),
+            'description' => __('migrations.roles.viewer.description'),
             'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
             'updated_at' => \Carbon\Carbon::now()->toDateTimeString()
         ]);
 
 
         // Create default CRUD permissions and allocate to admins and editors
-        $entities = ['Book', 'Page', 'Chapter', 'Image'];
-        $ops = ['Create', 'Update', 'Delete'];
+        $entities = ['book', 'page', 'chapter', 'image'];
+        $ops = ['create', 'update', 'delete'];
         foreach ($entities as $entity) {
             foreach ($ops as $op) {
                 $newPermId = DB::table('permissions')->insertGetId([
-                    'name' => strtolower($entity) . '-' . strtolower($op),
-                    'display_name' => $op . ' ' . $entity . 's',
+                    'name' => $entity . '-' . $op,
+                    'display_name' => __('migrations.permissions.ops.' . $op) . ' ' . __('migrations.permissions.entities.' . $entity),
                     'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
                     'updated_at' => \Carbon\Carbon::now()->toDateTimeString()
                 ]);
@@ -110,13 +110,13 @@ class AddRolesAndPermissions extends Migration
         }
 
         // Create admin permissions
-        $entities = ['Settings', 'User'];
-        $ops = ['Create', 'Update', 'Delete'];
+        $entities = ['settings', 'user'];
+        $ops = ['create', 'update', 'delete'];
         foreach ($entities as $entity) {
             foreach ($ops as $op) {
                 $newPermId = DB::table('permissions')->insertGetId([
-                    'name' => strtolower($entity) . '-' . strtolower($op),
-                    'display_name' => $op . ' ' . $entity,
+                    'name' => $entity . '-' . $op,
+                    'display_name' => __('migrations.permissions.ops.' . $op) . ' ' . __('migrations.permissions.entities.' . $entity),
                     'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
                     'updated_at' => \Carbon\Carbon::now()->toDateTimeString()
                 ]);

--- a/database/migrations/2016_02_27_120329_update_permissions_and_roles.php
+++ b/database/migrations/2016_02_27_120329_update_permissions_and_roles.php
@@ -21,11 +21,11 @@ class UpdatePermissionsAndRoles extends Migration
 
         // Create & attach new admin permissions
         $permissionsToCreate = [
-            'settings-manage' => 'Manage Settings',
-            'users-manage' => 'Manage Users',
-            'user-roles-manage' => 'Manage Roles & Permissions',
-            'restrictions-manage-all' => 'Manage All Entity Permissions',
-            'restrictions-manage-own' => 'Manage Entity Permissions On Own Content'
+            'settings-manage' => __('migrations.permissions.settings-manage'),
+            'users-manage' => __('migrations.permissions.users-manage'),
+            'user-roles-manage' => __('migrations.permissions.user-roles-manage'),
+            'restrictions-manage-all' => __('migrations.permissions.restrictions-manage-all'),
+            'restrictions-manage-own' => __('migrations.permissions.restrictions-manage-own'),
         ];
         foreach ($permissionsToCreate as $name => $displayName) {
             $permissionId = DB::table('permissions')->insertGetId([
@@ -41,13 +41,13 @@ class UpdatePermissionsAndRoles extends Migration
         }
 
         // Create & attach new entity permissions
-        $entities = ['Book', 'Page', 'Chapter', 'Image'];
-        $ops = ['Create All', 'Create Own', 'Update All', 'Update Own', 'Delete All', 'Delete Own'];
+        $entities = ['book', 'page', 'chapter', 'image'];
+        $ops = ['create-all', 'create-own', 'update-all', 'update-own', 'delete-all', 'delete-own'];
         foreach ($entities as $entity) {
             foreach ($ops as $op) {
                 $permissionId = DB::table('permissions')->insertGetId([
-                    'name' => strtolower($entity) . '-' . strtolower(str_replace(' ', '-', $op)),
-                    'display_name' => $op . ' ' . $entity . 's',
+                    'name' => $entity . '-' . $op,
+                    'display_name' => __('migrations.permissions.ops.' . $op) . ' ' . __('migrations.permissions.entities.' . $entity),
                     'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
                     'updated_at' => \Carbon\Carbon::now()->toDateTimeString()
                 ]);
@@ -80,13 +80,13 @@ class UpdatePermissionsAndRoles extends Migration
         $permissions = DB::table('permissions')->delete();
 
         // Create default CRUD permissions and allocate to admins and editors
-        $entities = ['Book', 'Page', 'Chapter', 'Image'];
-        $ops = ['Create', 'Update', 'Delete'];
+        $entities = ['book', 'page', 'chapter', 'image'];
+        $ops = ['create', 'update', 'delete'];
         foreach ($entities as $entity) {
             foreach ($ops as $op) {
                 $permissionId = DB::table('permissions')->insertGetId([
-                    'name' => strtolower($entity) . '-' . strtolower($op),
-                    'display_name' => $op . ' ' . $entity . 's',
+                    'name' => $entity . '-' . $op,
+                    'display_name' => __('migrations.permissions.ops.' . $op) . ' ' . __('migrations.permissions.entities.' . $entity),
                     'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
                     'updated_at' => \Carbon\Carbon::now()->toDateTimeString()
                 ]);
@@ -98,13 +98,13 @@ class UpdatePermissionsAndRoles extends Migration
         }
 
         // Create admin permissions
-        $entities = ['Settings', 'User'];
-        $ops = ['Create', 'Update', 'Delete'];
+        $entities = ['settings', 'user'];
+        $ops = ['create', 'update', 'delete'];
         foreach ($entities as $entity) {
             foreach ($ops as $op) {
                 $permissionId = DB::table('permissions')->insertGetId([
-                    'name' => strtolower($entity) . '-' . strtolower($op),
-                    'display_name' => $op . ' ' . $entity,
+                    'name' => $entity . '-' . $op,
+                    'display_name' => __('migrations.permissions.ops.' . $op) . ' ' . __('migrations.permissions.entities.' . $entity),
                     'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
                     'updated_at' => \Carbon\Carbon::now()->toDateTimeString()
                 ]);

--- a/database/migrations/2016_04_09_100730_add_view_permissions_to_roles.php
+++ b/database/migrations/2016_04_09_100730_add_view_permissions_to_roles.php
@@ -15,13 +15,13 @@ class AddViewPermissionsToRoles extends Migration
         $currentRoles = DB::table('roles')->get();
 
         // Create new view permission
-        $entities = ['Book', 'Page', 'Chapter'];
-        $ops = ['View All', 'View Own'];
+        $entities = ['book', 'page', 'chapter'];
+        $ops = ['view-all', 'view-own'];
         foreach ($entities as $entity) {
             foreach ($ops as $op) {
                 $permId = DB::table('permissions')->insertGetId([
-                    'name' => strtolower($entity) . '-' . strtolower(str_replace(' ', '-', $op)),
-                    'display_name' => $op . ' ' . $entity . 's',
+                    'name' => $entity . '-' . $op,
+                    'display_name' => __('migrations.permissions.ops.' . $op) . ' ' . __('migrations.permissions.entities.' . $entity),
                     'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
                     'updated_at' => \Carbon\Carbon::now()->toDateTimeString()
                 ]);

--- a/database/migrations/2016_04_20_192649_create_joint_permissions_table.php
+++ b/database/migrations/2016_04_20_192649_create_joint_permissions_table.php
@@ -43,8 +43,8 @@ class CreateJointPermissionsTable extends Migration
         // Create the new public role
         $publicRoleData = [
             'name' => 'public',
-            'display_name' => 'Public',
-            'description' => 'The role given to public visitors if allowed',
+            'display_name' => __('migrations.roles.public.display_name'),
+            'description' => __('migrations.roles.public.description'),
             'system_name' => 'public',
             'hidden' => true,
             'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
@@ -58,11 +58,11 @@ class CreateJointPermissionsTable extends Migration
         $publicRoleId = DB::table('roles')->insertGetId($publicRoleData);
 
         // Add new view permissions to public role
-        $entities = ['Book', 'Page', 'Chapter'];
-        $ops = ['View All', 'View Own'];
+        $entities = ['book', 'page', 'chapter'];
+        $ops = ['view-all', 'view-own'];
         foreach ($entities as $entity) {
             foreach ($ops as $op) {
-                $name = strtolower($entity) . '-' . strtolower(str_replace(' ', '-', $op));
+                $name = $entity . '-' . $op;
                 $permission = DB::table('role_permissions')->where('name', '=', $name)->first();
                 // Assign view permission to public
                 DB::table('permission_role')->insert([

--- a/database/migrations/2016_09_29_101449_remove_hidden_roles.php
+++ b/database/migrations/2016_09_29_101449_remove_hidden_roles.php
@@ -26,13 +26,13 @@ class RemoveHiddenRoles extends Migration
         // Insert our new public system user.
         $publicUserId = DB::table('users')->insertGetId([
             'email' => 'guest@example.com',
-            'name' => 'Guest',
+            'name' => __('migrations.users.guest'),
             'system_name' => 'public',
             'email_confirmed' => true,
             'created_at' => \Carbon\Carbon::now(),
             'updated_at' => \Carbon\Carbon::now(),
         ]);
-        
+
         // Get the public role
         $publicRole = DB::table('roles')->where('system_name', '=', 'public')->first();
 

--- a/database/migrations/2016_10_09_142037_create_attachments_table.php
+++ b/database/migrations/2016_10_09_142037_create_attachments_table.php
@@ -34,12 +34,12 @@ class CreateAttachmentsTable extends Migration
         $adminRoleId = DB::table('roles')->where('system_name', '=', 'admin')->first()->id;
 
         // Create & attach new entity permissions
-        $ops = ['Create All', 'Create Own', 'Update All', 'Update Own', 'Delete All', 'Delete Own'];
-        $entity = 'Attachment';
+        $entity = 'attachment';
+        $ops = ['create-all', 'create-own', 'update-all', 'update-own', 'delete-all', 'delete-own'];
         foreach ($ops as $op) {
             $permissionId = DB::table('role_permissions')->insertGetId([
-                'name' => strtolower($entity) . '-' . strtolower(str_replace(' ', '-', $op)),
-                'display_name' => $op . ' ' . $entity . 's',
+                'name' => $entity . '-' . $op,
+                'display_name' => __('migrations.permissions.ops.' . $op) . ' ' . __('migrations.permissions.entities.' . $entity),
                 'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
                 'updated_at' => \Carbon\Carbon::now()->toDateTimeString()
             ]);

--- a/database/migrations/2017_08_01_130541_create_comments_table.php
+++ b/database/migrations/2017_08_01_130541_create_comments_table.php
@@ -31,12 +31,12 @@ class CreateCommentsTable extends Migration
             // Assign new comment permissions to admin role
             $adminRoleId = DB::table('roles')->where('system_name', '=', 'admin')->first()->id;
             // Create & attach new entity permissions
-            $ops = ['Create All', 'Create Own', 'Update All', 'Update Own', 'Delete All', 'Delete Own'];
-            $entity = 'Comment';
+            $ops = ['create-all', 'create-own', 'update-all', 'update-own', 'delete-all', 'delete-own'];
+            $entity = 'comment';
             foreach ($ops as $op) {
                 $permissionId = DB::table('role_permissions')->insertGetId([
-                    'name' => strtolower($entity) . '-' . strtolower(str_replace(' ', '-', $op)),
-                    'display_name' => $op . ' ' . $entity . 's',
+                    'name' => $entity . '-' . $op,
+                    'display_name' => __('migrations.permissions.ops.' . $op) . ' ' . __('migrations.permissions.entities.' . $entity),
                     'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
                     'updated_at' => \Carbon\Carbon::now()->toDateTimeString()
                 ]);
@@ -58,10 +58,10 @@ class CreateCommentsTable extends Migration
     {
         Schema::dropIfExists('comments');
         // Delete comment role permissions
-        $ops = ['Create All', 'Create Own', 'Update All', 'Update Own', 'Delete All', 'Delete Own'];
-        $entity = 'Comment';
+        $ops = ['create-all', 'create-own', 'update-all', 'update-own', 'delete-all', 'delete-own'];
+        $entity = 'comment';
         foreach ($ops as $op) {
-            $permName = strtolower($entity) . '-' . strtolower(str_replace(' ', '-', $op));
+            $permName = $entity . '-' . $op;
             DB::table('role_permissions')->where('name', '=', $permName)->delete();
         }
     }

--- a/database/migrations/2018_08_04_115700_create_bookshelves_table.php
+++ b/database/migrations/2018_08_04_115700_create_bookshelves_table.php
@@ -70,7 +70,8 @@ class CreateBookshelvesTable extends Migration
         DB::table('role_permissions')->where('name', 'like', 'bookshelf-%')->delete();
 
         // Copy existing role permissions from Books
-        $ops = ['View All', 'View Own', 'Create All', 'Create Own', 'Update All', 'Update Own', 'Delete All', 'Delete Own'];
+        $entity = 'bookshelf';
+        $ops = ['view-all', 'view-own', 'create-all', 'create-own', 'update-all', 'update-own', 'delete-all', 'delete-own'];
         foreach ($ops as $op) {
             $dbOpName = strtolower(str_replace(' ', '-', $op));
             $roleIdsWithBookPermission = DB::table('role_permissions')
@@ -79,8 +80,8 @@ class CreateBookshelvesTable extends Migration
                 ->where('role_permissions.name', '=', 'book-' . $dbOpName)->get(['roles.id'])->pluck('id');
 
             $permId = DB::table('role_permissions')->insertGetId([
-                'name' => 'bookshelf-' . $dbOpName,
-                'display_name' => $op . ' ' . 'BookShelves',
+                'name' => $entity . '-' . $op,
+                'display_name' => __('migrations.permissions.ops.' . $op) . ' ' . __('migrations.permissions.entities.' . $entity),
                 'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
                 'updated_at' => \Carbon\Carbon::now()->toDateTimeString()
             ]);

--- a/resources/lang/en/migrations.php
+++ b/resources/lang/en/migrations.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Initial database seed data
+ */
+return [
+
+	'users' => [
+		'admin' => 'Admin',
+		'guest' => 'Guest',
+	],
+
+	'roles' => [
+
+		'admin' => [
+			'display_name' => 'Admin',
+			'description' => 'Administrator of the whole application',
+		],
+		'editor' => [
+			'display_name' => 'Editor',
+			'description' => 'User can edit Books, Chapters & Pages',
+		],
+		'viewer' => [
+			'display_name' => 'Viewer',
+			'description' => 'User can view books & their content behind authentication',
+		],
+		'public' => [
+			'display_name' => 'Public',
+			'description' => 'The role given to public visitors if allowed',
+		],
+	],
+
+	'permissions' => [
+		'settings-manage' => 'Manage Settings',
+		'users-manage' => 'Manage Users',
+		'user-roles-manage' => 'Manage Roles & Permissions',
+		'restrictions-manage-all' => 'Manage All Entity Permissions',
+		'restrictions-manage-own' => 'Manage Entity Permissions On Own Content',
+		'entities' => [
+			'settings' => 'Settings', // legacy
+			'user' => 'User', // legacy
+			'book' => 'Books',
+			'page' => 'Pages',
+			'chapter' => 'Chapters',
+			'image' => 'Images',
+			'bookshelf' => 'BookShelves',
+		],
+		'ops' => [
+			'create' => 'Create', // legacy
+			'create-all' => 'Create All',
+			'create-own' => 'Create Own',
+			'update' => 'Update', // legacy
+			'update-all' => 'Update All',
+			'update-own' => 'Update Own',
+			'delete' => 'Delete', // legacy
+			'delete-all' => 'Delete All',
+			'delete-own' => 'Delete Own',
+			'view-all' => 'View All',
+			'view-own' => 'View Own',
+		]
+	],
+
+];


### PR DESCRIPTION
Default data loaded as part of the initial setup and/or upgrades can now be translated.

This is meant to be a draft commit, most new strings are not very i18n friendly yet.

I'd appreciate some feedback on how this was done. One of the main issues that came up, is that the translation file introduced contains strings that are no longer valid, which might be an unnecessary burden for translators.