### PR TITLE
fix translate for "actions"

### DIFF
--- a/resources/views/pages/show.blade.php
+++ b/resources/views/pages/show.blade.php
@@ -121,7 +121,7 @@
     </div>
 
     <div class="actions mb-xl">
-        <h5>Actions</h5>
+        <h5>{{ trans('common.actions') }}</h5>
 
         <div class="icon-list text-primary">
 


### PR DESCRIPTION
"Actions" is plain word in page show file, translation is not used. This is a fix based on release, but its also unfixed in master yet.