### PR TITLE
Add support for GCS storage

### DIFF
--- a/.env.example.complete
+++ b/.env.example.complete
@@ -120,6 +120,16 @@ STORAGE_S3_ENDPOINT=https://my-custom-s3-compatible.service.com:8001
 # An s3-format URL will be generated if not set.
 STORAGE_URL=false
 
+# Google Cloud Storage (GCS) configuration
+STORAGE_GCS_PROJECT_ID=your-project-id
+STORAGE_GCS_BUCKET=your-bucket
+
+# GCS service account path
+STORAGE_GCS_KEY_FILE_PATH=/etc/google/service-account.json
+
+# GCS custom URL
+STORAGE_GCS_URL=http://no-https-possible.example.net
+
 # Authentication method to use
 # Can be 'standard' or 'ldap'
 AUTH_METHOD=standard

--- a/config/app.php
+++ b/config/app.php
@@ -119,6 +119,9 @@ return [
         BookStack\Providers\EventServiceProvider::class,
         BookStack\Providers\RouteServiceProvider::class,
         BookStack\Providers\CustomFacadeProvider::class,
+
+        // Register GCS storage
+        mix5003\GCSProvider\GoogleCloudStorageServiceProvider::class,
     ],
 
     /*

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -59,6 +59,14 @@ return [
             'use_path_style_endpoint' => env('STORAGE_S3_ENDPOINT', null) !== null,
         ],
 
+        'gcs' => [
+            'driver' => 'gcs',
+            'projectId' => env('STORAGE_GCS_PROJECT_ID', 'your-project-id'),
+            'bucket' => env('STORAGE_GCS_BUCKET', 'your-bucket'),
+        ] + // Only add those parameters if not empty
+        (env('STORAGE_GCS_URL', '') == '' ? [] : ['url' => env('STORAGE_GCS_URL', '')]) +
+        (env('STORAGE_GCS_KEY_FILE_PATH', '') == '' ? [] : ['keyFilePath' => env('STORAGE_GCS_KEY_FILE_PATH', '')]),
+
         'rackspace' => [
             'driver'    => 'rackspace',
             'username'  => 'your-username',


### PR DESCRIPTION
This seems to work well for us. Not too sure not touched PHP code in years, but more than happy to invest some more time into it.

I think we should use the URL abstraction of laravel-filesystem rather than building it in our code base (getPublicUrl). This would make it easier to support signed temporary URLs as a next step