### PR TITLE
feature: support nested inclusions

### DIFF
--- a/app/Entities/Repos/EntityRepo.php
+++ b/app/Entities/Repos/EntityRepo.php
@@ -53,6 +53,13 @@ class EntityRepo
     protected $searchService;
 
     /**
+     * PAGE_INCLUDE_MATCHER
+     *
+     * Regex to match page inclusion tags e.g. {{@1}}
+     */
+    const PAGE_INCLUDE_MATCHER = "/{{@\s?([0-9].*?)}}/";
+
+    /**
      * EntityRepo constructor.
      * @param EntityProvider $entityProvider
      * @param ViewService $viewService
@@ -674,7 +681,9 @@ class EntityRepo
         if ($blankIncludes) {
             $content = $this->blankPageIncludes($content);
         } else {
-            $content = $this->parsePageIncludes($content);
+            while (preg_match(self::PAGE_INCLUDE_MATCHER, $content)) {
+                $content = $this->parsePageIncludes($content);
+            }
         }
 
         return $content;
@@ -687,7 +696,7 @@ class EntityRepo
      */
     protected function blankPageIncludes(string $html) : string
     {
-        return preg_replace("/{{@\s?([0-9].*?)}}/", '', $html);
+        return preg_replace(self::PAGE_INCLUDE_MATCHER, '', $html);
     }
 
     /**
@@ -698,7 +707,7 @@ class EntityRepo
     protected function parsePageIncludes(string $html) : string
     {
         $matches = [];
-        preg_match_all("/{{@\s?([0-9].*?)}}/", $html, $matches);
+        preg_match_all(self::PAGE_INCLUDE_MATCHER, $html, $matches);
 
         $topLevelTags = ['table', 'ul', 'ol'];
         foreach ($matches[1] as $index => $includeId) {


### PR DESCRIPTION
Previously we could only support one level of page inclusion. So, if we
have a three pages with this content:

    Page one: 'Test'

    Page two: 'Include page one: {{@1}}'

    Page three: 'Include page two: {{@2}}'

Rendering 'Page three' would not expand the nested includes, and would
result in:

    Include page two: Include page one: {{@1}}

To fix this we just keep expanding the includes until there are none
left.

Extract out the regex that matches the includes into a constant - since
this is now used in three places.