### PR TITLE
Fix Book form (create) returning to the full books list on cancel

### DIFF
--- a/resources/views/books/form.blade.php
+++ b/resources/views/books/form.blade.php
@@ -36,6 +36,15 @@
 </div>
 
 <div class="form-group text-right">
-    <a href="{{ isset($book) ? $book->getUrl() : url('/books') }}" class="button outline">{{ trans('common.cancel') }}</a>
+    <?php
+        if (isset($bookshelf)) {
+            $cancelUrl = $bookshelf->getUrl();
+        } else if (isset($book)) {
+            $cancelUrl = $book->getUrl();
+        } else {
+            $cancelUrl = '/books';
+        }
+    ?>
+    <a href="{{ $cancelUrl }}" class="button outline">{{ trans('common.cancel') }}</a>
     <button type="submit" class="button">{{ trans('entities.books_save') }}</button>
 </div>

--- a/tests/Entity/EntityTest.php
+++ b/tests/Entity/EntityTest.php
@@ -1,5 +1,6 @@
 <?php namespace Tests;
 
+use BookStack\Entities\Bookshelf;
 use BookStack\Entities\Book;
 use BookStack\Entities\Chapter;
 use BookStack\Entities\Page;
@@ -290,6 +291,31 @@ class EntityTest extends BrowserKitTest
         ]);
 
         $this->assertEquals('parta-partb-partc', $book->slug);
+    }
+
+    public function test_shelf_cancel_creation_returns_to_correct_place()
+    {
+        $shelf = Bookshelf::first();
+
+        // Cancel button from shelf goes back to shelf
+        $this->asEditor()->visit($shelf->getUrl('/create-book'))
+            ->see('Cancel')
+            ->click('Cancel')
+            ->seePageIs($shelf->getUrl());
+
+        // Cancel button from books goes back to books
+        $this->asEditor()->visit('/create-book')
+            ->see('Cancel')
+            ->click('Cancel')
+            ->seePageIs('/books');
+
+        // Cancel button from book edit goes back to book
+        $book = Book::first();
+
+        $this->asEditor()->visit($book->getUrl('/edit'))
+            ->see('Cancel')
+            ->click('Cancel')
+            ->seePageIs($book->getUrl());
     }
 
 }


### PR DESCRIPTION
Fixes #1662
Added a small block of logic to determine the correct URL to attribute to the cancel button on a given page create form.
If adding a book from a bookshelf, return to the bookshelf. If editing a book, return to the book. In all other cases, return to the full books list.