### PR TITLE
Show list of bookshelves that a book belongs to on a book view

### DIFF
--- a/app/Entities/Repos/EntityRepo.php
+++ b/app/Entities/Repos/EntityRepo.php
@@ -413,6 +413,17 @@ class EntityRepo
         return collect($tree);
     }
 
+
+    /**
+     * Get the bookshelves that a book is contained in.
+     * @param Book $book
+     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     */
+    public function getBookParentShelves(Book $book)
+    {
+        return $this->permissionService->enforceEntityRestrictions('shelf', $book->shelves())->get();
+    }
+
     /**
      * Get the child items for a chapter sorted by priority but
      * with draft items floated to the top.

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -150,6 +150,7 @@ class BookController extends Controller
         $this->checkOwnablePermission('book-view', $book);
 
         $bookChildren = $this->bookRepo->getBookChildren($book);
+        $bookParentShelves = $this->bookRepo->getBookParentShelves($book);
 
         Views::add($book);
         if ($request->has('shelf')) {
@@ -161,6 +162,7 @@ class BookController extends Controller
             'book' => $book,
             'current' => $book,
             'bookChildren' => $bookChildren,
+            'bookParentShelves' => $bookParentShelves,
             'activity' => Activity::entityActivity($book, 20, 1)
         ]);
     }

--- a/resources/lang/en/entities.php
+++ b/resources/lang/en/entities.php
@@ -135,6 +135,7 @@ return [
     'books_sort_chapters_last' => 'Chapters Last',
     'books_sort_show_other' => 'Show Other Books',
     'books_sort_save' => 'Save New Order',
+    'book_parent_shelves_empty' => 'Shelves that this book is on will appear here.',
 
     // Chapters
     'chapter' => 'Chapter',

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -57,9 +57,7 @@
 
 @stop
 
-
 @section('right')
-
     <div class="mb-xl">
         <h5>{{ trans('common.details') }}</h5>
         <div class="text-small text-muted blended-links">
@@ -75,7 +73,6 @@
             @endif
         </div>
     </div>
-
 
     <div class="actions mb-xl">
         <h5>{{ trans('common.actions') }}</h5>
@@ -123,6 +120,16 @@
 
             @include('partials.entity-export-menu', ['entity' => $book])
         </div>
+    </div>
+
+    <div class="actions mb-xl">
+        <h5>{{ trans('entities.shelves_long') }}</h5>
+
+        @if(count($bookParentShelves) > 0)
+            @include('partials.entity-list', ['entities' => $bookParentShelves, 'style' => 'compact'])
+        @else
+            <div class="body text-muted">{{ trans('entities.book_parent_shelves_empty') }}</div>
+        @endif
     </div>
 
 @stop

--- a/tests/Entity/BookShelfTest.php
+++ b/tests/Entity/BookShelfTest.php
@@ -240,4 +240,32 @@ class BookShelfTest extends TestCase
         $pageVisit->assertElementNotContains('.breadcrumbs', $shelf->getShortName());
     }
 
+    public function test_bookshelves_show_on_book()
+    {
+        // Create shelf
+        $shelfInfo = [
+            'name' => 'My test shelf' . Str::random(4),
+            'description' => 'Test shelf description ' . Str::random(10)
+        ];
+
+        $this->asEditor()->post('/shelves', $shelfInfo);
+        $shelf = Bookshelf::where('name', '=', $shelfInfo['name'])->first();
+
+        // Create book and add to shelf
+        $this->asEditor()->post($shelf->getUrl('/create-book'), [
+            'name' => 'Test book name',
+            'description' => 'Book in shelf description'
+        ]);
+
+        $newBook = Book::query()->orderBy('id', 'desc')->first();
+
+        $resp = $this->asEditor()->get($newBook->getUrl());
+        $resp->assertSee($shelfInfo['name']);
+
+        // Remove shelf
+        $this->delete($shelf->getUrl());
+
+        $resp = $this->asEditor()->get($newBook->getUrl());
+        $resp->assertDontSee($shelfInfo['name']);
+    }
 }


### PR DESCRIPTION
Closes #1598
I put these underneath actions because there could potentially be many that push the actions off-screen. But you will likely want to change the placement of this if this is a feature you wish to merge 👍 

Another part of this PR to look out for is the heading above the list. I went with Bookshelves because I think it should be clear enough from the context (a book) that it is referring to the bookshelves that the book can be found on.

Thanks

![image](https://user-images.githubusercontent.com/1470412/65732708-047c2480-e0c3-11e9-8cb7-00df00c00b54.png)
![image](https://user-images.githubusercontent.com/1470412/65732749-31c8d280-e0c3-11e9-9079-02a3c31d93ec.png)
