### PR TITLE
Fixing composer install inside docker `app` container

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -4,7 +4,7 @@ ENV APACHE_DOCUMENT_ROOT /app/public
 WORKDIR /app
 
 RUN apt-get update -y \
-    && apt-get install -y libtidy-dev libpng-dev libldap2-dev libxml++2.6-dev wait-for-it \
+    && apt-get install -y git libtidy-dev libpng-dev libldap2-dev libxml++2.6-dev wait-for-it \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
     && docker-php-ext-install pdo pdo_mysql tidy dom xml mbstring gd ldap \
     && a2enmod rewrite \


### PR DESCRIPTION
**Describe the bug**
Can not run `composer install` inside `app` docker container. The error appears because `Composer` can not find `git`. 

**Steps To Reproduce**
Steps to reproduce the behavior:
The same steps explained in the `README` file.
1. Clone master branch.
2. Run the command: `docker-compose run app composer install`.
3. The error appears as the image in screenshots.


**Expected behavior**
Installing Packages inside Docker container.

**Screenshots**
Tested on my local machine and on a Digitalocean droplet.
![image](https://user-images.githubusercontent.com/16087389/66148068-c9c14180-e618-11e9-8597-b1307edf817b.png)


**My Configuration:**
 - Exact BookStack Version: The version of `master` branch.
 - PHP Version: 7.3
 - Hosting Method (Nginx/Apache/Docker): Docker.


This pull request adding git to the docker image. So Composer can install packages without the `git` error.