### PR TITLE
Enable pasting base64 images to the editor

### DIFF
--- a/resources/js/components/wysiwyg-editor.js
+++ b/resources/js/components/wysiwyg-editor.js
@@ -451,7 +451,7 @@ class WysiwygEditor {
             end_container_on_empty_block: true,
             statusbar: false,
             menubar: false,
-            paste_data_images: false,
+            paste_data_images: true,
             extended_valid_elements: 'pre[*],svg[*],div[drawio-diagram]',
             automatic_uploads: false,
             valid_children: "-div[p|h1|h2|h3|h4|h5|h6|blockquote],+div[pre],+div[img]",


### PR DESCRIPTION
This PR resolve #1697 
For more information about the edited option:
https://www.tiny.cloud/docs/plugins/paste/#paste_data_images

A screenshot for the editor after the PR:
![image](https://user-images.githubusercontent.com/16087389/66155329-0b0d1d80-e628-11e9-9acb-f774452d550d.png)
