### PR TITLE
Inherit book permission from shelf when assigning book

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ APP_KEY=SomeRandomString
 # a proxy, if using a third-party authentication option.
 # This must be the root URL that you want to host BookStack on.
 # All URL's in BookStack will be generated using this value.
-#APP_URL=https://example.com
+APP_URL=https://example.com
 
 # Database details
 DB_HOST=localhost
@@ -26,6 +26,8 @@ MAIL_PORT=1025
 MAIL_USERNAME=null
 MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null
+
+FORCE_SSL=false
 
 
 # A full list of options can be found in the '.env.example.complete' file.

--- a/app/Entities/Bookshelf.php
+++ b/app/Entities/Bookshelf.php
@@ -105,7 +105,7 @@ class Bookshelf extends Entity implements HasCoverImage
     }
 
     /**
-     * Add a book to the end of this shelf. If shelve inheritance is enabled, copy permissions to book.
+     * Add a book to the end of this shelf. If shelf inheritance is enabled, copy permissions to book.
      * @param Book $book
      */
     public function appendBook(Book $book)

--- a/app/Entities/Bookshelf.php
+++ b/app/Entities/Bookshelf.php
@@ -105,7 +105,7 @@ class Bookshelf extends Entity implements HasCoverImage
     }
 
     /**
-     * Add a book to the end of this shelf.
+     * Add a book to the end of this shelf. If shelve inheritance is enabled, copy permissions to book.
      * @param Book $book
      */
     public function appendBook(Book $book)
@@ -116,5 +116,14 @@ class Bookshelf extends Entity implements HasCoverImage
 
         $maxOrder = $this->books()->max('order');
         $this->books()->attach($book->id, ['order' => $maxOrder + 1]);
+
+        if (setting()->get('app-inherit-from-shelve')){
+            $shelfPermissions = $this->permissions()->get(['role_id', 'action'])->toArray();
+            $book->permissions()->delete();
+            $book->restricted = $this->restricted;
+            $book->permissions()->createMany($shelfPermissions);
+            $book->save();
+            $book->rebuildPermissions();
+        }
     }
 }

--- a/app/Entities/Bookshelf.php
+++ b/app/Entities/Bookshelf.php
@@ -117,7 +117,7 @@ class Bookshelf extends Entity implements HasCoverImage
         $maxOrder = $this->books()->max('order');
         $this->books()->attach($book->id, ['order' => $maxOrder + 1]);
 
-        if (setting()->get('app-inherit-from-shelve')){
+        if (setting()->get('app-inherit-from-shelf')){
             $shelfPermissions = $this->permissions()->get(['role_id', 'action'])->toArray();
             $book->permissions()->delete();
             $book->restricted = $this->restricted;

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -40,9 +40,9 @@ return [
     'app_disable_comments' => 'Disable Comments',
     'app_disable_comments_toggle' => 'Disable comments',
     'app_disable_comments_desc' => 'Disables comments across all pages in the application. <br> Existing comments are not shown.',
-    'app_inherit_from_shelve' => 'Inherit book permission from shelve',
-    'app_inherit_from_shelve_desc' => 'The permission of the shelve will be copied to the book, when assigning it to a shelve. All other permissions of the book will be overwritten.',
-    'app_inherit_from_shelve_toggle' => 'Enable inheritance',
+    'app_inherit_from_shelf' => 'Inherit book permission from shelf',
+    'app_inherit_from_shelf_desc' => 'The permission of the shelf will be copied to the book, when assigning it to a shelf. All other permissions of the book will be overwritten.',
+    'app_inherit_from_shelf_toggle' => 'Enable inheritance',
 
     // Registration Settings
     'reg_settings' => 'Registration',

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -40,6 +40,9 @@ return [
     'app_disable_comments' => 'Disable Comments',
     'app_disable_comments_toggle' => 'Disable comments',
     'app_disable_comments_desc' => 'Disables comments across all pages in the application. <br> Existing comments are not shown.',
+    'app_inherit_from_shelve' => 'Inherit book permission from shelve',
+    'app_inherit_from_shelve_desc' => 'The permission of the shelve will be copied to the book, when assigning it to a shelve. All other permissions of the book will be overwritten.',
+    'app_inherit_from_shelve_toggle' => 'Enable inheritance',
 
     // Registration Settings
     'reg_settings' => 'Registration',

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -71,14 +71,14 @@
 
                     <div class="grid half gap-xl">
                         <div>
-                            <label class="setting-list-label">{{ trans('settings.app_inherit_from_shelve') }}</label>
-                            <p class="small">{!! trans('settings.app_inherit_from_shelve_desc') !!}</p>
+                            <label class="setting-list-label">{{ trans('settings.app_inherit_from_shelf') }}</label>
+                            <p class="small">{!! trans('settings.app_inherit_from_shelf_desc') !!}</p>
                         </div>
                         <div>
                             @include('components.toggle-switch', [
-                                'name' => 'setting-app-inherit-from-shelve',
-                                'value' => setting('app-inherit-from-shelve'),
-                                'label' => trans('settings.app_inherit_from_shelve_toggle'),
+                                'name' => 'setting-app-inherit-from-shelf',
+                                'value' => setting('app-inherit-from-shelf'),
+                                'label' => trans('settings.app_inherit_from_shelf_toggle'),
                             ])
                         </div>
                     </div>

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -69,6 +69,20 @@
                         </div>
                     </div>
 
+                    <div class="grid half gap-xl">
+                        <div>
+                            <label class="setting-list-label">{{ trans('settings.app_inherit_from_shelve') }}</label>
+                            <p class="small">{!! trans('settings.app_inherit_from_shelve_desc') !!}</p>
+                        </div>
+                        <div>
+                            @include('components.toggle-switch', [
+                                'name' => 'setting-app-inherit-from-shelve',
+                                'value' => setting('app-inherit-from-shelve'),
+                                'label' => trans('settings.app_inherit_from_shelve_toggle'),
+                            ])
+                        </div>
+                    </div>
+
 
                 </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,4 +1,7 @@
 <?php
+if (env('FORCE_SSL')=="true"){
+    URL::forceScheme('https');
+}
 
 Route::get('/robots.txt', 'HomeController@getRobots');
 


### PR DESCRIPTION
When ever you assign a book to a shelve and have the "Inherit book permission from shelve" setting enabled, the permissions of the shelve will be copied to the book.