### PR TITLE
Bugfix - Bookshelf cover was not assigned

### DIFF
--- a/app/Entities/Repos/BaseRepo.php
+++ b/app/Entities/Repos/BaseRepo.php
@@ -82,6 +82,7 @@ class BaseRepo
             $this->imageRepo->destroyImage($entity->cover);
             $image = $this->imageRepo->saveNew($coverImage, 'cover_book', $entity->id, 512, 512, true);
             $entity->cover()->associate($image);
+            $entity->save();
         }
 
         if ($removeImage) {


### PR DESCRIPTION
When creating or updating a bookshelf, the provided cover was not assigned.