### PR TITLE
Bugfix - takes APP_URL on redirect after login into account. Fixes issue #1377

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -110,7 +110,7 @@ class LoginController extends Controller
             $app_url = parse_url(env('APP_URL'));
             return redirect(preg_replace("/".addcslashes($app_url['path'], '/')."/", '', redirect()->intended('/')->getTargetUrl(), 1));
         } else {
-            redirect()->intended('/');
+            return redirect()->intended('/');
         }
     }
 

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -106,9 +106,8 @@ class LoginController extends Controller
             $this->ldapService->syncGroups($user, $request->get($this->username()));
         }
 
-        if (env('APP_URL')) {
-            $app_url = parse_url(env('APP_URL'));
-            return redirect(preg_replace("/".addcslashes($app_url['path'], '/')."/", '', redirect()->intended('/')->getTargetUrl(), 1));
+        if (parse_url(env('APP_URL'), PHP_URL_PATH)) {
+            return redirect(preg_replace("/".addcslashes(parse_url(env('APP_URL'), PHP_URL_PATH), '/')."/", '', redirect()->intended('/')->getTargetUrl(), 1));
         } else {
             return redirect()->intended('/');
         }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -106,8 +106,12 @@ class LoginController extends Controller
             $this->ldapService->syncGroups($user, $request->get($this->username()));
         }
 
-        $app_url = parse_url(env('APP_URL'));
-        return redirect(preg_replace("/".addcslashes($app_url['path'], '/')."/", '', redirect()->intended('/')->getTargetUrl(), 1));
+        if (env('APP_URL')) {
+            $app_url = parse_url(env('APP_URL'));
+            return redirect(preg_replace("/".addcslashes($app_url['path'], '/')."/", '', redirect()->intended('/')->getTargetUrl(), 1));
+        } else {
+            redirect()->intended('/');
+        }
     }
 
     /**

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -106,7 +106,8 @@ class LoginController extends Controller
             $this->ldapService->syncGroups($user, $request->get($this->username()));
         }
 
-        return redirect()->intended('/');
+        $app_url = parse_url(env('APP_URL'));
+        return redirect(preg_replace("/".addcslashes($app_url['path'], '/')."/", '', redirect()->intended('/')->getTargetUrl(), 1));
     }
 
     /**


### PR DESCRIPTION
This PR strips the path of the APP_URL from the wrong url.intended string. This causes a correct redirect after login no matter if the APP_URL variable is set or not.