### PR TITLE
Add ability to override translations with custom text

### DIFF
--- a/app/Config/app.php
+++ b/app/Config/app.php
@@ -96,7 +96,6 @@ return [
         Illuminate\Redis\RedisServiceProvider::class,
         Illuminate\Auth\Passwords\PasswordResetServiceProvider::class,
         Illuminate\Session\SessionServiceProvider::class,
-        Illuminate\Translation\TranslationServiceProvider::class,
         Illuminate\Validation\ValidationServiceProvider::class,
         Illuminate\View\ViewServiceProvider::class,
         Illuminate\Notifications\NotificationServiceProvider::class,
@@ -107,9 +106,9 @@ return [
         Barryvdh\DomPDF\ServiceProvider::class,
         Barryvdh\Snappy\ServiceProvider::class,
 
-
         // BookStack replacement service providers (Extends Laravel)
         BookStack\Providers\PaginationServiceProvider::class,
+        BookStack\Providers\TranslationServiceProvider::class,
 
         // BookStack custom service providers
         BookStack\Providers\AuthServiceProvider::class,

--- a/app/Providers/TranslationServiceProvider.php
+++ b/app/Providers/TranslationServiceProvider.php
@@ -1,0 +1,21 @@
+<?php namespace BookStack\Providers;
+
+use BookStack\Translation\FileLoader;
+use Illuminate\Translation\TranslationServiceProvider as BaseProvider;
+
+class TranslationServiceProvider extends BaseProvider
+{
+
+    /**
+     * Register the translation line loader.
+     * Overrides the default register action from Laravel so a custom loader can be used.
+     * @return void
+     */
+    protected function registerLoader()
+    {
+        $this->app->singleton('translation.loader', function ($app) {
+            return new FileLoader($app['files'], $app['path.lang']);
+        });
+    }
+
+}

--- a/app/Translation/FileLoader.php
+++ b/app/Translation/FileLoader.php
@@ -1,0 +1,30 @@
+<?php namespace BookStack\Translation;
+
+use Illuminate\Translation\FileLoader as BaseLoader;
+
+class FileLoader extends BaseLoader
+{
+    /**
+     * Load the messages for the given locale.
+     * Extends Laravel's translation FileLoader to look in multiple directories
+     * so that we can load in translation overrides from the theme file if wanted.
+     * @param  string  $locale
+     * @param  string  $group
+     * @param  string|null  $namespace
+     * @return array
+     */
+    public function load($locale, $group, $namespace = null)
+    {
+        if ($group === '*' && $namespace === '*') {
+            return $this->loadJsonPaths($locale);
+        }
+
+        if (is_null($namespace) || $namespace === '*') {
+            $themeTranslations = $this->loadPath(theme_path('lang'), $locale, $group);
+            $originalTranslations =  $this->loadPath($this->path, $locale, $group);
+            return array_merge($originalTranslations, $themeTranslations);
+        }
+
+        return $this->loadNamespaced($locale, $group, $namespace);
+    }
+}

--- a/tests/ThemeTest.php
+++ b/tests/ThemeTest.php
@@ -1,0 +1,43 @@
+<?php namespace Tests;
+
+use File;
+
+class ThemeTest extends TestCase
+{
+    protected $themeFolderName;
+    protected $themeFolderPath;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a folder and configure a theme
+        $this->themeFolderName = 'testing_theme_' . rtrim(base64_encode(time()), "=");
+        config()->set('view.theme', $this->themeFolderName);
+        $this->themeFolderPath = theme_path('');
+        File::makeDirectory($this->themeFolderPath);
+    }
+
+    public function tearDown(): void
+    {
+        // Cleanup the custom theme folder we created
+        File::deleteDirectory($this->themeFolderPath);
+
+        parent::tearDown();
+    }
+
+    public function test_translation_text_can_be_overriden_via_theme()
+    {
+        $translationPath = theme_path('/lang/en');
+        File::makeDirectory($translationPath, 0777, true);
+
+        $customTranslations = '<?php
+            return [\'books\' => \'Sandwiches\'];
+        ';
+        file_put_contents($translationPath . '/entities.php', $customTranslations);
+
+        $homeRequest = $this->actingAs($this->getViewer())->get('/');
+        $homeRequest->assertElementContains('header nav', 'Sandwiches');
+    }
+
+}


### PR DESCRIPTION
Related to #406, Although does not close it outright.

This pull request adds the ability to override existing text translation content with custom values via the theme system (#652).

### How to configure

1. Create a custom theme folder within the existing `themes/` directory.
   - For example `themes/awesome_theme`
2. Within your `.env` folder set a `APP_THEME` variable with the value matching your custom theme folder name.
   - For example `APP_THEME=awesome_theme`
3. Add some language content within your theme folder within a `lang` folder.
   - This folder mirrors the default structure of the BookStack `resources/lang/` folder.
   - For example, I can create `themes/awesome_theme/lang/en/entities.php`, Adding in the content below:
   ```php
    <?php
    return [
        'books' => 'Sandwiches',
    ];
   ```
4. The new translations will now be used first instead of default BookStack translations.

### Things to note

* Translations will fall back to default BookStack translations, so you only need to define translations you want to customize, you don't need to copy all of them out.
* Changes may be made within the BookStack project to translations so you may need to double check things upon updating as custom overrides may become outdated. 