### PR TITLE
Feature: Move a page directly into a chapter of another book

### DIFF
--- a/app/Entities/Repos/PageRepo.php
+++ b/app/Entities/Repos/PageRepo.php
@@ -307,15 +307,13 @@ class PageRepo
         }
 
         if ($parent instanceof Chapter) {
-            $parentChapter = $parent;
-            $parent = $parent->book;
-            $page->chapter_id = $parentChapter->id;
-            $page->save();
+            $page->chapter_id = $parent->id;
         }
 
         $page->changeBook($parent instanceof Book ? $parent->id : $parent->book->id);
         $page->rebuildPermissions();
-        return $parent;
+
+        return ($parent instanceof Book ? $parent : $parent->book);
     }
 
     /**

--- a/app/Entities/Repos/PageRepo.php
+++ b/app/Entities/Repos/PageRepo.php
@@ -306,6 +306,13 @@ class PageRepo
             throw new PermissionsException('User does not have permission to create a page within the new parent');
         }
 
+        if ($parent instanceof Chapter) {
+            $parentChapter = $parent;
+            $parent = $parent->book;
+            $page->chapter_id = $parentChapter->id;
+            $page->save();
+        }
+
         $page->changeBook($parent instanceof Book ? $parent->id : $parent->book->id);
         $page->rebuildPermissions();
         return $parent;


### PR DESCRIPTION
Currently, when you move a page, you get a list of Books and chapters. Unfortunately, if you choose a chapter as new destination for a page, you get an error, since currently only books as target are supported.

This PR allows you to move a page directly into a chapter by checking, if the parent is a Chapter. If so, the page will be assigned to the target chapter and moved to the corresponding book.