### PR TITLE
Feature - Show pages and chapters in shelf view

### DIFF
--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -40,6 +40,9 @@ return [
     'app_disable_comments' => 'Disable Comments',
     'app_disable_comments_toggle' => 'Disable comments',
     'app_disable_comments_desc' => 'Disables comments across all pages in the application. <br> Existing comments are not shown.',
+    'app_show_pages_in_shelf_view' => 'Detailed shelf view',
+    'app_show_pages_in_shelf_view_desc' => 'Shows all pages and chapters of a book inside the shelf view.',
+    'app_show_pages_in_shelf_view_toggle' => 'Enable detailed view',
 
     // Registration Settings
     'reg_settings' => 'Registration',

--- a/resources/views/books/list-item.blade.php
+++ b/resources/views/books/list-item.blade.php
@@ -9,3 +9,24 @@
         </div>
     </div>
 </a>
+
+@if (setting()->get('app-show-pages-in-shelf-view'))
+    <div class="entity-shelf-books grid third gap-y-xs entity-list-item-children">
+        @foreach((new BookStack\Entities\Managers\BookContents($book))->getTree(true) as $bookChild)
+            <div>
+                @if ($bookChild->isA('chapter'))
+                    <a href="{{$bookChild->getUrl()}}" class="entity-chip text-book" style="color: var(--color-chapter)">
+                        @icon('chapter')
+                        @elseif ($bookChild->draft)
+                            <a href="{{$bookChild->getUrl()}}" class="entity-chip text-book" style="color: var(--color-page-draft)">
+                                @icon('edit')
+                                @else
+                                    <a href="{{$bookChild->getUrl()}}" class="entity-chip text-book" style="color: var(--color-page)">
+                                        @icon('page')
+                                        @endif
+                                        {{ $bookChild->name }}
+                                    </a>
+            </div>
+        @endforeach
+    </div>
+@endif

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -69,6 +69,20 @@
                         </div>
                     </div>
 
+                    <div class="grid half gap-xl">
+                        <div>
+                            <label class="setting-list-label">{{ trans('settings.app_show_pages_in_shelf_view') }}</label>
+                            <p class="small">{!! trans('settings.app_show_pages_in_shelf_view_desc') !!}</p>
+                        </div>
+                        <div>
+                            @include('components.toggle-switch', [
+                                'name' => 'setting-app-show-pages-in-shelf-view',
+                                'value' => setting('app-show-pages-in-shelf-view'),
+                                'label' => trans('settings.app_show_pages_in_shelf_view_toggle'),
+                            ])
+                        </div>
+                    </div>
+
 
                 </div>
 


### PR DESCRIPTION
This PR adds a setting to the settings page, which allows user to toggle between a detailed and the regular shelf view. In the detailed view, all pages and chapters of a book will be shown (similar to the overview of all shelves, where the books are shown). 

I think this is very useful, if you use BookStack as a wiki, because it reduces the amount of clicks until a user finds the right page or chapter.

![image](https://user-images.githubusercontent.com/5772650/67773141-87462580-fa5b-11e9-8c53-50f339ae4359.png)
