### PR TITLE
Feature - allow toggling between grid and list view in shelf view (shelves.show)

### DIFF
--- a/app/Http/Controllers/BookshelfController.php
+++ b/app/Http/Controllers/BookshelfController.php
@@ -103,6 +103,7 @@ class BookshelfController extends Controller
     public function show(string $slug)
     {
         $shelf = $this->bookshelfRepo->getBySlug($slug);
+        $view = setting()->getForCurrentUser('books_view_type', config('app.views.books'));
         $this->checkOwnablePermission('book-view', $shelf);
 
         Views::add($shelf);
@@ -111,6 +112,7 @@ class BookshelfController extends Controller
         $this->setPageTitle($shelf->getShortName());
         return view('shelves.show', [
             'shelf' => $shelf,
+            'view' => $view,
             'activity' => Activity::entityActivity($shelf, 20, 1)
         ]);
     }

--- a/resources/views/shelves/show.blade.php
+++ b/resources/views/shelves/show.blade.php
@@ -13,11 +13,19 @@
         <div class="book-content">
             <p class="text-muted">{!! nl2br(e($shelf->description)) !!}</p>
             @if(count($shelf->visibleBooks) > 0)
-                <div class="entity-list">
-                    @foreach($shelf->visibleBooks as $book)
-                        @include('books.list-item', ['book' => $book])
-                    @endforeach
-                </div>
+                @if($view === 'list')
+                    <div class="entity-list">
+                        @foreach($shelf->visibleBooks as $book)
+                            @include('books.list-item', ['book' => $book])
+                        @endforeach
+                    </div>
+                @else
+                    <div class="grid third">
+                        @foreach($shelf->visibleBooks as $key => $book)
+                            @include('books.grid-item', ['book' => $book])
+                        @endforeach
+                    </div>
+                @endif
             @else
                 <div class="mt-xl">
                     <hr>
@@ -86,6 +94,8 @@
                     <span>{{ trans('entities.books_new_action') }}</span>
                 </a>
             @endif
+
+            @include('partials.view-toggle', ['view' => $view, 'type' => 'book'])
 
             <hr class="primary-background">
 


### PR DESCRIPTION
This PR adds the list/grid view toggle button to the shelves.show view. This button is already available in the shelves.index as well as in books.index.

This allows users to use the desired view even when looking directly into a shelf.