### PR TITLE
Feature - add the "Create Shelf" resp. "Create Book" to the home view

### DIFF
--- a/resources/views/common/home-book.blade.php
+++ b/resources/views/common/home-book.blade.php
@@ -12,6 +12,12 @@
     <div class="actions mb-xl">
         <h5>{{ trans('common.actions') }}</h5>
         <div class="icon-list text-primary">
+            @if($currentUser->can('book-create-all'))
+                <a href="{{ url("/create-book") }}" class="icon-list-item">
+                    <span>@icon('add')</span>
+                    <span>{{ trans('entities.books_create') }}</span>
+                </a>
+            @endif
             @include('partials.view-toggle', ['view' => $view, 'type' => 'book'])
             @include('components.expand-toggle', ['target' => '.entity-list.compact .entity-item-snippet', 'key' => 'home-details'])
         </div>

--- a/resources/views/common/home-shelves.blade.php
+++ b/resources/views/common/home-shelves.blade.php
@@ -12,6 +12,12 @@
     <div class="actions mb-xl">
         <h5>{{ trans('common.actions') }}</h5>
         <div class="icon-list text-primary">
+            @if($currentUser->can('bookshelf-create-all'))
+                <a href="{{ url("/create-shelf") }}" class="icon-list-item">
+                    <span>@icon('add')</span>
+                    <span>{{ trans('entities.shelves_new_action') }}</span>
+                </a>
+            @endif
             @include('partials.view-toggle', ['view' => $view, 'type' => 'shelf'])
             @include('components.expand-toggle', ['target' => '.entity-list.compact .entity-item-snippet', 'key' => 'home-details'])
         </div>


### PR DESCRIPTION
This PR adds the "Create Shelf" button to the Shelves-Homepage and "Create Book" button to the Books-Homepage definied in the settings menu.

Assume you've set the homepage to "shelves". With this PR, there is no need to click on "Shelves" in the top menu first (which is for the user basically the same view) in order to create a shelf.

In our case, some users were confused why they were not allowed to create a shelf even if they had the permission. This was only caused by the missing button in the home view.