### PR TITLE
Fix overflow issue of page content

### DIFF
--- a/resources/sass/_blocks.scss
+++ b/resources/sass/_blocks.scss
@@ -180,7 +180,7 @@
   margin-left: auto;
   margin-right: auto;
   margin-bottom: $-xl;
-  overflow: initial;
+  overflow: hidden;
   min-height: 60vh;
   &.auto-height {
     min-height: 0;


### PR DESCRIPTION
Currently a long table in a page will overflow the white card background, since `overflow: initial` means `overflow: visible`.