### PR TITLE
Code block display in details tag

### DIFF
--- a/resources/js/services/code.js
+++ b/resources/js/services/code.js
@@ -27,6 +27,7 @@ import 'codemirror/mode/yaml/yaml';
 
 // Addons
 import 'codemirror/addon/scroll/scrollpastend';
+import 'codemirror/addon/display/autorefresh'
 
 const modeMap = {
     css: 'css',
@@ -104,7 +105,10 @@ function highlightElem(elem) {
         lineNumbers: true,
         lineWrapping: false,
         theme: getTheme(),
-        readOnly: true
+        readOnly: true,
+        autoRefresh: {
+          delay: 50
+        }
     });
 
     addCopyIcon(cm);


### PR DESCRIPTION
Fixes #781.  Use codemirror display/autoReload addon to watch for state changes and resize the codemirror blocks if they were hidden when the DOM was loaded.

> This is done by polling every 250 milliseconds (you can pass a value like {delay: 500} as the option value to configure this).
>
> [codemirror docs](https://codemirror.net/doc/manual.html#addon_autorefresh)

I've set this to poll every 50ms, which was a bit smoother transition.  A 1ms poll, just for fun, produced the best result but is likely to cause performance issues.