### PR TITLE
Fix An Exception 

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -28,7 +28,7 @@ class TrustProxies extends Middleware
      * @param Closure $next
      * @return mixed
      */
-    public function handle($request, Closure $next)
+    public function handle(Request $request, Closure $next)
     {
         $setProxies = config('app.proxies');
         if ($setProxies !== '**' && $setProxies !== '*' && $setProxies !== '') {


### PR DESCRIPTION
Fix an exception error 
```
ErrorException
Declaration of BookStack\Http\Middleware\TrustProxies::handle($request, Closure $next) should be compatible with Fideloper\Proxy\TrustProxies::handle(Illuminate\Http\Request $request, Closure $next) 
```