### PR TITLE
Recall intended route when manually clicking login

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -128,6 +128,10 @@ class LoginController extends Controller
             ]);
         }
 
+        if ($request->has('intended')) {
+            redirect()->setIntendedUrl($request->get('intended'));
+        }
+
         return view('auth.login', [
           'socialDrivers' => $socialDrivers,
           'authMethod' => $authMethod,

--- a/resources/views/common/header.blade.php
+++ b/resources/views/common/header.blade.php
@@ -45,7 +45,7 @@
                         @if(setting('registration-enabled', false))
                             <a href="{{ url('/register') }}">@icon('new-user') {{ trans('auth.sign_up') }}</a>
                         @endif
-                        <a href="{{ url('/login') }}">@icon('login') {{ trans('auth.log_in') }}</a>
+                        <a href="{{ action('Auth\LoginController@getLogin', ['intended' => url()->current()]) }}">@icon('login') {{ trans('auth.log_in') }}</a>
                     @endif
                 </div>
                 @if(signedInUser())


### PR DESCRIPTION
Currently, for a non-public BookStack instance, the [Authenticate Middleware](https://github.com/BookStackApp/BookStack/blob/02af69ddf29e0a2d03cc3a8660bfca9a65175afc/app/Http/Middleware/Authenticate.php#L44) sets the `url.intended` session key when accessing any link while not logged in, which tells the [login procedure](https://github.com/BookStackApp/BookStack/blob/02af69ddf29e0a2d03cc3a8660bfca9a65175afc/app/Http/Controllers/Auth/LoginController.php#L110) to redirect there after login.

A public BookStack instance will not exhibit this behavior for pages which require additional permissions, as a common 404 is returned (which is the correct thing to do). With these changes, the view at `/login` recognizes an optional query parameter `intended` and sets the intended redirect URL when present.

Our use-case is sharing links to a partially public BookStack instance with our team via E-Mail which they currently need to click twice if they are not already logged in.

In the future it may also be useful to redirect a not-logged-in user to the login page with `intended` set instead of the root when accessing URLs like `/settings`.