### PR TITLE
Add close icon to notifications

### DIFF
--- a/resources/sass/_components.scss
+++ b/resources/sass/_components.scss
@@ -15,7 +15,7 @@
   transition: transform ease-in-out 280ms;
   transform: translateX(580px);
   display: grid;
-  grid-template-columns: 42px 1fr;
+  grid-template-columns: 42px 1fr 12px;
   color: #444;
   font-weight: 700;
   span, svg {
@@ -28,6 +28,13 @@
     height: 2.8rem;
     padding-right: $-s;
     fill: currentColor;
+  }
+  .dismiss {
+    margin-top: -8px;
+    svg {
+      height: 1.0rem;
+      color: #444;
+    }
   }
   span {
     vertical-align: middle;

--- a/resources/views/partials/notifications.blade.php
+++ b/resources/views/partials/notifications.blade.php
@@ -1,11 +1,11 @@
 <div notification="success" style="display: none;" data-autohide class="pos" role="alert" @if(session()->has('success')) data-show @endif>
-    @icon('check-circle') <span>{!! nl2br(htmlentities(session()->get('success'))) !!}</span>
+    @icon('check-circle') <span>{!! nl2br(htmlentities(session()->get('success'))) !!}</span><div class="dismiss">@icon('close')</div>
 </div>
 
 <div notification="warning" style="display: none;" class="warning" role="alert" @if(session()->has('warning')) data-show @endif>
-    @icon('info') <span>{!! nl2br(htmlentities(session()->get('warning'))) !!}</span>
+    @icon('info') <span>{!! nl2br(htmlentities(session()->get('warning'))) !!}</span><div class="dismiss">@icon('close')</div>
 </div>
 
 <div notification="error" style="display: none;" class="neg" role="alert" @if(session()->has('error')) data-show @endif>
-    @icon('danger') <span>{!! nl2br(htmlentities(session()->get('error'))) !!}</span>
+    @icon('danger') <span>{!! nl2br(htmlentities(session()->get('error'))) !!}</span><div class="dismiss">@icon('close')</div>
 </div>


### PR DESCRIPTION
In relation to #1525

This adds a simple close icon to all notification panes. Here is an example of how it looks:

![image](https://user-images.githubusercontent.com/33401067/72377597-5fb73e80-36d5-11ea-8655-e1881383d8c0.png)

Per the comments on the bottom of the issue thread, it doesn't actually do anything, besides provide the user a visual cue reminding users to click to dismiss the notification.