### PR TITLE
Add Perl syntax highlighting to code editor

### DIFF
--- a/resources/js/services/code.js
+++ b/resources/js/services/code.js
@@ -14,6 +14,7 @@ import 'codemirror/mode/haskell/haskell';
 import 'codemirror/mode/markdown/markdown';
 import 'codemirror/mode/mllike/mllike';
 import 'codemirror/mode/nginx/nginx';
+import 'codemirror/mode/perl/perl';
 import 'codemirror/mode/php/php';
 import 'codemirror/mode/powershell/powershell';
 import 'codemirror/mode/properties/properties';
@@ -59,6 +60,8 @@ const modeMap = {
     markdown: 'markdown',
     ml: 'mllike',
     nginx: 'nginx',
+    perl: 'perl',
+    pl: 'perl',
     powershell: 'powershell',
     properties: 'properties',
     ocaml: 'mllike',

--- a/resources/views/components/code-editor.blade.php
+++ b/resources/views/components/code-editor.blade.php
@@ -26,6 +26,7 @@
                             <a @click="updateLanguage('MarkDown')">MarkDown</a>
                             <a @click="updateLanguage('Nginx')">Nginx</a>
                             <a @click="updateLanguage('PASCAL')">Pascal</a>
+                            <a @click="updateLanguage('Perl')">Perl</a>
                             <a @click="updateLanguage('PHP')">PHP</a>
                             <a @click="updateLanguage('Powershell')">Powershell</a>
                             <a @click="updateLanguage('Python')">Python</a>


### PR DESCRIPTION
As it says. There's a lot of legacy Perl scripts going around. Just the kind of stuff you'd like to document in a wiki.