### PR TITLE
Shared drafts

### DIFF
--- a/app/Auth/Permissions/PermissionService.php
+++ b/app/Auth/Permissions/PermissionService.php
@@ -665,34 +665,28 @@ class PermissionService
     public function enforceDraftVisiblityOnQuery(Builder $query): Builder
     {
         return $query->where(function (Builder $query) {
-            $query->where('draft', '=', false)
-                ->orWhere(function (Builder $query) {
-                    if (setting('app-shared-drafts')) {
-                        $this->clean();
-                        $query->where(function (Builder $parentQuery) {
-                            $parentQuery->whereHas('jointPermissions', function (Builder $permissionQuery) {
-                                $permissionQuery->whereIn('role_id', $this->getRoles())
-                                ->where(function (Builder $query) {
-                                    $query->where(function (Builder $query) {
-                                        $query->where('action', '=', 'editdraft')
-                                        ->where('has_permission', '=', true);
-                                    })->orWhere(function (Builder $query) {
-                                        $query->where('action', '=', 'update')
-                                        ->where(function (Builder $query) {
-                                            $query->where('has_permission', '=', true)
-                                            ->orWhere(function (Builder $query) {
-                                                $query->where('has_permission_own', '=', true)
-                                                ->where('created_by', '=', $this->currentUser()->id);
-                                            });
+            $query->where('draft', '=', false)->orWhere(function (Builder $query) {
+                if (setting('app-shared-drafts')) {
+                    $this->clean();
+                    $query->where(function (Builder $parentQuery) {
+                        $parentQuery->whereHas('jointPermissions', function (Builder $permissionQuery) {
+                            $permissionQuery->whereIn('role_id', $this->getRoles())->where(function (Builder $query) {
+                                $query->where(function (Builder $query) {
+                                    $query->where('action', '=', 'editdraft')->where('has_permission', '=', true);
+                                })->orWhere(function (Builder $query) {
+                                    $query->where('action', '=', 'update')->where(function (Builder $query) {
+                                        $query->where('has_permission', '=', true)->orWhere(function (Builder $query) {
+                                            $query->where('has_permission_own', '=', true)->where('created_by', '=', $this->currentUser()->id);
                                         });
                                     });
                                 });
                             });
                         });
-                    } else {
-                        $query->where('created_by', '=', $this->currentUser()->id);
-                    }
-                });
+                    });
+                } else {
+                    $query->where('created_by', '=', $this->currentUser()->id);
+                }
+            });
         });
     }
 

--- a/app/Entities/Chapter.php
+++ b/app/Entities/Chapter.php
@@ -52,12 +52,12 @@ class Chapter extends BookChild
     }
 
     /**
-     * Check if this chapter has any child pages.
+     * Check if this chapter has visible child pages.
      * @return bool
      */
-    public function hasChildren()
+    public function hasVisibleChildren()
     {
-        return count($this->pages) > 0;
+        return $this->pages()->visible()->count() > 0;
     }
 
     /**

--- a/app/Entities/Managers/PageEditActivity.php
+++ b/app/Entities/Managers/PageEditActivity.php
@@ -57,10 +57,7 @@ class PageEditActivity
                 return trans('entities.pages_editing_shared_draft_notification.message', ['timeDiff' => $time, 'userName' => trans('entities.pages_editing_shared_draft_notification.you')]);
             }
             $createdUser = User::find($draft->created_by);
-            $userName = '_user'.$draft->created_by.'_';
-            if ($createdUser) {
-                $userName = $createdUser->name;
-            }
+            $userName = $createdUser ? $createdUser->name : '_user'.$draft->created_by.'_';
             return trans('entities.pages_editing_shared_draft_notification.message', ['timeDiff' => $time, 'userName' => $userName]) . "\n" .
                 trans('entities.pages_editing_shared_draft_notification.warn');
         }

--- a/app/Entities/Repos/PageRepo.php
+++ b/app/Entities/Repos/PageRepo.php
@@ -204,11 +204,7 @@ class PageRepo
         $page->save();
 
         // Remove all update drafts for this user & page.
-        if (setting('app-shared-drafts')) {
-            $this->getDraftQuery($page)->delete();
-        } else {
-            $this->getUserDraftQuery($page)->delete();
-        }
+        setting('app-shared-drafts') ? $this->getDraftQuery($page)->delete() : $this->getUserDraftQuery($page)->delete();
 
         // Save a revision after updating
         $summary = $input['summary'] ?? null;

--- a/app/Http/Controllers/ChapterController.php
+++ b/app/Http/Controllers/ChapterController.php
@@ -64,7 +64,7 @@ class ChapterController extends Controller
         $chapter = $this->chapterRepo->getBySlug($bookSlug, $chapterSlug);
         $this->checkOwnablePermission('chapter-view', $chapter);
 
-        $sidebarTree = (new BookContents($chapter->book))->getTree();
+        $sidebarTree = (new BookContents($chapter->book))->getTree(true);
         $pages = $chapter->getVisiblePages();
         Views::add($chapter);
 

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -93,6 +93,22 @@ abstract class Controller extends BaseController
     }
 
     /**
+     * Check the current user's permissions in or against an ownable item.
+     * @param Collection $permissions
+     * @param Ownable $ownable
+     * @return bool
+     */
+    protected function checkOwnableOrPermissions($permissions, Ownable $ownable)
+    {
+        foreach ($permissions as $permission) {
+            if (userCan($permission, $ownable)) {
+                return true;
+            }
+        }
+        return $this->showPermissionError();
+    }
+
+    /**
      * Check if a user has a permission or bypass if the callback is true.
      * @param $permissionName
      * @param $callback

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -78,7 +78,9 @@ class PageController extends Controller
     public function editDraft(string $bookSlug, int $pageId)
     {
         $draft = $this->pageRepo->getById($pageId);
-        $this->checkOwnablePermission('page-update', $draft->parent());
+        if (!(userCan('page-update', $draft) || userCan('page-editdraft', $draft))) {
+            $this->showPermissionError();
+        }
         $this->setPageTitle(trans('entities.pages_edit_draft'));
 
         $draftsEnabled = $this->isSignedIn();
@@ -173,7 +175,9 @@ class PageController extends Controller
     public function edit(string $bookSlug, string $pageSlug)
     {
         $page = $this->pageRepo->getBySlug($bookSlug, $pageSlug);
-        $this->checkOwnablePermission('page-update', $page);
+        if (!(userCan('page-update', $page) || userCan('page-editdraft', $page))) {
+            $this->showPermissionError();
+        }
 
         $sharedDrafts = setting('app-shared-drafts');
         $page->isDraft = false;
@@ -239,7 +243,9 @@ class PageController extends Controller
     public function saveDraft(Request $request, int $pageId)
     {
         $page = $this->pageRepo->getById($pageId);
-        $this->checkOwnablePermission('page-update', $page);
+        if (!(userCan('page-update', $page) || userCan('page-editdraft', $page))) {
+            $this->showPermissionError();
+        }
 
         if (!$this->isSignedIn()) {
             return $this->jsonError(trans('errors.guests_cannot_save_drafts'), 500);

--- a/database/migrations/2020_01_29_171400_add_edit_draft_permission.php
+++ b/database/migrations/2020_01_29_171400_add_edit_draft_permission.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddEditDraftPermission extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Create new editdraft permission
+        $entity = 'Page';
+        $p = 'EditDraft';
+        $o = 'All';
+        $pu = 'Update';
+
+        // Create permission
+        $permId = DB::table('role_permissions')->insertGetId([
+            'name' => strtolower($entity) . '-' . strtolower($p) . '-' . strtolower($o),
+            'display_name' => $p . ' ' . $o . ' ' . $entity . 's',
+            'created_at' => \Carbon\Carbon::now()->toDateTimeString(),
+            'updated_at' => \Carbon\Carbon::now()->toDateTimeString()
+        ]);
+
+        // Find all current roles that already have update permission
+        $roleIdsWithUdatePermission = DB::table('role_permissions')
+            ->leftJoin('permission_role', 'role_permissions.id', '=', 'permission_role.permission_id')
+            ->leftJoin('roles', 'roles.id', '=', 'permission_role.role_id')
+            ->where('role_permissions.name', '=', strtolower($entity) . '-' . strtolower($pu) . '-' . strtolower($o))->get(['roles.id'])->pluck('id');
+
+        // Generate permission_role entry
+        $rowsToInsert = $roleIdsWithUdatePermission->filter(function($roleId) {
+            return !is_null($roleId);
+        })->map(function($roleId) use ($permId) {
+            return [
+                'role_id' => $roleId,
+                'permission_id' => $permId
+            ];
+        })->toArray();
+
+        // Assign editdraft permission to roles
+        DB::table('permission_role')->insert($rowsToInsert);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Delete the new editdraft permission
+        $entity = 'Page';
+        $op = 'EditDraft All';
+
+        $permissionName = strtolower($entity) . '-' . strtolower(str_replace(' ', '-', $op));
+        $permission = DB::table('role_permissions')->where('name', '=', $permissionName)->first();
+        DB::table('permission_role')->where('permission_id', '=', $permission->id)->delete();
+        DB::table('role_permissions')->where('name', '=', $permissionName)->delete();
+    }
+}

--- a/resources/lang/en/common.php
+++ b/resources/lang/en/common.php
@@ -28,6 +28,8 @@ return [
     'create' => 'Create',
     'update' => 'Update',
     'edit' => 'Edit',
+    'drafts' => 'Drafts',
+    'edit_draft' => 'Edit Draft',
     'sort' => 'Sort',
     'move' => 'Move',
     'copy' => 'Copy',

--- a/resources/lang/en/entities.php
+++ b/resources/lang/en/entities.php
@@ -224,6 +224,11 @@ return [
     'pages_initial_revision' => 'Initial publish',
     'pages_initial_name' => 'New Page',
     'pages_editing_draft_notification' => 'You are currently editing a draft that was last saved :timeDiff.',
+    'pages_editing_shared_draft_notification' => [
+        'message' => 'You are currently editing a draft that was last saved :timeDiff by :userName.',
+        'you' => 'you',
+        'warn' => 'Take care not to overwrite each other\'s updates!',
+    ],
     'pages_draft_edited_notification' => 'This page has been updated by since that time. It is recommended that you discard this draft.',
     'pages_draft_edit_active' => [
         'start_a' => ':count users have started editing this page',

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -40,6 +40,9 @@ return [
     'app_disable_comments' => 'Disable Comments',
     'app_disable_comments_toggle' => 'Disable comments',
     'app_disable_comments_desc' => 'Disables comments across all pages in the application. <br> Existing comments are not shown.',
+    'app_shared_drafts' => 'Shared Drafts',
+    'app_shared_drafts_toggle' => 'Enable shared drafts',
+    'app_shared_drafts_desc' => 'Enable shared drafts across all users with edit permission on the page. <br> Existing drafts on the same page are overwritten, the last edited take precedence over the others.',
 
     // Color settings
     'content_colors' => 'Content Colors',

--- a/resources/views/chapters/child-menu.blade.php
+++ b/resources/views/chapters/child-menu.blade.php
@@ -1,10 +1,10 @@
 <div class="chapter-child-menu">
     <button chapter-toggle type="button" aria-expanded="{{ $isOpen ? 'true' : 'false' }}"
             class="text-muted @if($isOpen) open @endif">
-        @icon('caret-right') @icon('page') <span>{{ trans_choice('entities.x_pages', $bookChild->pages->count()) }}</span>
+        @icon('caret-right') @icon('page') <span>{{ trans_choice('entities.x_pages', $bookChild->getVisiblePages()->count()) }}</span>
     </button>
     <ul class="sub-menu inset-list @if($isOpen) open @endif" @if($isOpen) style="display: block;" @endif role="menu">
-        @foreach($bookChild->pages as $childPage)
+        @foreach($bookChild->getVisiblePages() as $childPage)
             <li class="list-item-page {{ $childPage->isA('page') && $childPage->draft ? 'draft' : '' }}" role="presentation">
                 @include('partials.entity-list-item-basic', ['entity' => $childPage, 'classes' => $current->matches($childPage)? 'selected' : '' ])
             </li>

--- a/resources/views/chapters/list-item.blade.php
+++ b/resources/views/chapters/list-item.blade.php
@@ -1,4 +1,4 @@
-<a href="{{ $chapter->getUrl() }}" class="chapter entity-list-item @if($chapter->hasChildren()) has-children @endif" data-entity-type="chapter" data-entity-id="{{$chapter->id}}">
+<a href="{{ $chapter->getUrl() }}" class="chapter entity-list-item @if($chapter->hasVisibleChildren()) has-children @endif" data-entity-type="chapter" data-entity-id="{{$chapter->id}}">
     <span class="icon text-chapter">@icon('chapter')</span>
     <div class="content">
         <h4 class="entity-list-item-name break-text">{{ $chapter->name }}</h4>
@@ -7,7 +7,7 @@
         </div>
     </div>
 </a>
-@if ($chapter->hasChildren())
+@if ($chapter->hasVisibleChildren())
     <div class="chapter chapter-expansion">
         <span class="icon text-chapter">@icon('page')</span>
         <div class="content">

--- a/resources/views/form/entity-permissions.blade.php
+++ b/resources/views/form/entity-permissions.blade.php
@@ -14,7 +14,7 @@
     <table permissions-table class="table permissions-table toggle-switch-list" style="{{ !$model->restricted ? 'display: none' : '' }}">
         <tr>
             <th>{{ trans('common.role') }}</th>
-            <th @if($model->isA('page')) colspan="3" @else colspan="4" @endif>
+            <th @if($model->isA('page')) colspan="4" @else colspan="5" @endif>
                 {{ trans('common.actions') }}
                 <a href="#" permissions-table-toggle-all class="text-small ml-m text-primary">{{ trans('common.toggle_all') }}</a>
             </th>
@@ -29,6 +29,7 @@
                 @if(!$model->isA('page'))
                     <td>@include('form.restriction-checkbox', ['name'=>'restrictions', 'label' => trans('common.create'), 'action' => 'create'])</td>
                 @endif
+                <td>@include('form.restriction-checkbox', ['name'=>'restrictions', 'label' => trans('common.edit_draft'), 'action' => 'editdraft'])</td>
                 <td>@include('form.restriction-checkbox', ['name'=>'restrictions', 'label' => trans('common.update'), 'action' => 'update'])</td>
                 <td>@include('form.restriction-checkbox', ['name'=>'restrictions', 'label' => trans('common.delete'), 'action' => 'delete'])</td>
             </tr>

--- a/resources/views/pages/form.blade.php
+++ b/resources/views/pages/form.blade.php
@@ -45,18 +45,20 @@
             </div>
 
             <div class="action-buttons px-m py-xs" v-cloak>
-                <div dropdown dropdown-move-menu class="dropdown-container">
-                    <button type="button" dropdown-toggle aria-haspopup="true" aria-expanded="false" class="text-primary text-button">@icon('edit') <span v-text="changeSummaryShort"></span></button>
-                    <ul class="wide dropdown-menu">
-                        <li class="px-l py-m">
-                            <p class="text-muted pb-s">{{ trans('entities.pages_edit_enter_changelog_desc') }}</p>
-                            <input name="summary" id="summary-input" type="text" placeholder="{{ trans('entities.pages_edit_enter_changelog') }}" v-model="changeSummary" />
-                        </li>
-                    </ul>
-                    <span>{{-- Prevents button jumping on menu show --}}</span>
-                </div>
+                @if(userCan('page-update', $model))
+                    <div dropdown dropdown-move-menu class="dropdown-container">
+                        <button type="button" dropdown-toggle aria-haspopup="true" aria-expanded="false" class="text-primary text-button">@icon('edit') <span v-text="changeSummaryShort"></span></button>
+                        <ul class="wide dropdown-menu">
+                            <li class="px-l py-m">
+                                <p class="text-muted pb-s">{{ trans('entities.pages_edit_enter_changelog_desc') }}</p>
+                                <input name="summary" id="summary-input" type="text" placeholder="{{ trans('entities.pages_edit_enter_changelog') }}" v-model="changeSummary" />
+                            </li>
+                        </ul>
+                        <span>{{-- Prevents button jumping on menu show --}}</span>
+                    </div>
 
-                <button type="submit" id="save-button" class="float-left text-primary text-button text-pos-hover hide-under-m">@icon('save')<span>{{ trans('entities.pages_save') }}</span></button>
+                    <button type="submit" id="save-button" class="float-left text-primary text-button text-pos-hover hide-under-m">@icon('save')<span>{{ trans('entities.pages_save') }}</span></button>
+                @endif
             </div>
         </div>
     </div>

--- a/resources/views/pages/form.blade.php
+++ b/resources/views/pages/form.blade.php
@@ -32,9 +32,11 @@
                         <li>
                             <button type="button" @click="saveDraft()" class="text-pos">@icon('save'){{ trans('entities.pages_edit_save_draft') }}</button>
                         </li>
-                        <li v-if="isNewDraft">
-                            <a href="{{ $model->getUrl('/delete') }}" class="text-neg">@icon('delete'){{ trans('entities.pages_edit_delete_draft') }}</a>
-                        </li>
+                        @if(userCan('page-delete', $model))
+                            <li v-if="isNewDraft">
+                                <a href="{{ $model->getUrl('/delete') }}" class="text-neg">@icon('delete'){{ trans('entities.pages_edit_delete_draft') }}</a>
+                            </li>
+                        @endif
                         <li v-if="isUpdateDraft">
                             <button type="button" @click="discardDraft" class="text-neg">@icon('cancel'){{ trans('entities.pages_edit_discard_draft') }}</button>
                         </li>

--- a/resources/views/pages/show.blade.php
+++ b/resources/views/pages/show.blade.php
@@ -118,7 +118,7 @@
         <div class="icon-list text-primary">
 
             {{--User Actions--}}
-            @if(userCan('page-update', $page))
+            @if(userCan('page-update', $page) || userCan('page-editdraft', $page))
                 <a href="{{ $page->getUrl('/edit') }}" class="icon-list-item">
                     <span>@icon('edit')</span>
                     <span>{{ trans('common.edit') }}</span>

--- a/resources/views/partials/book-tree.blade.php
+++ b/resources/views/partials/book-tree.blade.php
@@ -12,7 +12,7 @@
             <li class="list-item-{{ $bookChild->getClassName() }} {{ $bookChild->getClassName() }} {{ $bookChild->isA('page') && $bookChild->draft ? 'draft' : '' }}">
                 @include('partials.entity-list-item-basic', ['entity' => $bookChild, 'classes' => $current->matches($bookChild)? 'selected' : ''])
 
-                @if($bookChild->isA('chapter') && count($bookChild->pages) > 0)
+                @if($bookChild->isA('chapter') && $bookChild->hasVisibleChildren())
                     <div class="entity-list-item no-hover">
                         <span role="presentation" class="icon text-chapter"></span>
                         <div class="content">

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -70,6 +70,20 @@
                         </div>
                     </div>
 
+                    <div class="grid half gap-xl">
+                        <div>
+                            <label class="setting-list-label">{{ trans('settings.app_shared_drafts') }}</label>
+                            <p class="small">{!! trans('settings.app_shared_drafts_desc') !!}</p>
+                        </div>
+                        <div>
+                            @include('components.toggle-switch', [
+                                'name' => 'setting-app-shared-drafts',
+                                'value' => setting('app-shared-drafts'),
+                                'label' => trans('settings.app_shared_drafts_toggle'),
+                            ])
+                        </div>
+                    </div>
+
 
                 </div>
 

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -8,9 +8,7 @@
                 @include('settings.navbar', ['selected' => 'settings'])
             </div>
             <div class="text-right p-m">
-                <a target="_blank" rel="noopener noreferrer" href="https://github.com/BookStackApp/BookStack/releases">
-                    BookStack @if(strpos($version, 'v') !== 0) version @endif {{ $version }}
-                </a>
+                <a target="_blank" rel="noopener noreferrer" href="https://github.com/BookStackApp/BookStack/releases">BookStack @if(strpos($version, 'v') !== 0) version @endif {{ $version }}</a>
             </div>
         </div>
 
@@ -21,7 +19,6 @@
                 <input type="hidden" name="section" value="features">
 
                 <div class="setting-list">
-
 
                     <div class="grid half gap-xl">
                         <div>
@@ -37,8 +34,7 @@
                             @include('components.toggle-switch', [
                                 'name' => 'setting-app-public',
                                 'value' => setting('app-public'),
-                                'label' => trans('settings.app_public_access_toggle'),
-                            ])
+                                'label' => trans('settings.app_public_access_toggle')])
                         </div>
                     </div>
 
@@ -51,8 +47,7 @@
                             @include('components.toggle-switch', [
                                 'name' => 'setting-app-secure-images',
                                 'value' => setting('app-secure-images'),
-                                'label' => trans('settings.app_secure_images_toggle'),
-                            ])
+                                'label' => trans('settings.app_secure_images_toggle')])
                         </div>
                     </div>
 
@@ -65,8 +60,7 @@
                             @include('components.toggle-switch', [
                                 'name' => 'setting-app-disable-comments',
                                 'value' => setting('app-disable-comments'),
-                                'label' => trans('settings.app_disable_comments_toggle'),
-                            ])
+                                'label' => trans('settings.app_disable_comments_toggle')])
                         </div>
                     </div>
 
@@ -79,11 +73,9 @@
                             @include('components.toggle-switch', [
                                 'name' => 'setting-app-shared-drafts',
                                 'value' => setting('app-shared-drafts'),
-                                'label' => trans('settings.app_shared_drafts_toggle'),
-                            ])
+                                'label' => trans('settings.app_shared_drafts_toggle')])
                         </div>
                     </div>
-
 
                 </div>
 
@@ -111,8 +103,7 @@
                             @include('components.toggle-switch', [
                                 'name' => 'setting-app-name-header',
                                 'value' => setting('app-name-header'),
-                                'label' => trans('settings.app_name_header'),
-                            ])
+                                'label' => trans('settings.app_name_header')])
                         </div>
                     </div>
 
@@ -136,13 +127,12 @@
                         </div>
                         <div>
                             @include('components.image-picker', [
-                                     'removeName' => 'setting-app-logo',
-                                     'removeValue' => 'none',
-                                     'defaultImage' => url('/logo.png'),
-                                     'currentImage' => setting('app-logo'),
-                                     'name' => 'app_logo',
-                                     'imageClass' => 'logo-image',
-                                 ])
+                                'removeName' => 'setting-app-logo',
+                                'removeValue' => 'none',
+                                'defaultImage' => url('/logo.png'),
+                                'currentImage' => setting('app-logo'),
+                                'name' => 'app_logo',
+                                'imageClass' => 'logo-image'])
                         </div>
                     </div>
 
@@ -195,11 +185,13 @@
                             </select>
 
                             <div page-picker-container style="display: none;" class="mt-m">
-                                @include('components.page-picker', ['name' => 'setting-app-homepage', 'placeholder' => trans('settings.app_homepage_select'), 'value' => setting('app-homepage')])
+                                @include('components.page-picker', [
+                                    'name' => 'setting-app-homepage',
+                                    'placeholder' => trans('settings.app_homepage_select'),
+                                    'value' => setting('app-homepage')])
                             </div>
                         </div>
                     </div>
-
 
                     <div>
                         <label for="setting-app-custom-head" class="setting-list-label">{{ trans('settings.app_custom_html') }}</label>
@@ -207,7 +199,6 @@
                         <textarea name="setting-app-custom-head" id="setting-app-custom-head" class="simple-code-input mt-m">{{ setting('app-custom-head', '') }}</textarea>
                         <p class="small text-right">{{ trans('settings.app_custom_html_disabled_notice') }}</p>
                     </div>
-
 
                 </div>
 
@@ -233,8 +224,7 @@
                             @include('components.toggle-switch', [
                                 'name' => 'setting-registration-enabled',
                                 'value' => setting('registration-enabled'),
-                                'label' => trans('settings.reg_enable_toggle')
-                            ])
+                                'label' => trans('settings.reg_enable_toggle')])
 
                             @if(in_array(config('auth.method'), ['ldap', 'saml2']))
                                 <div class="text-warn text-small mb-l">{{ trans('settings.reg_enable_external_warning') }}</div>
@@ -243,9 +233,7 @@
                             <label for="setting-registration-role">{{ trans('settings.reg_default_role') }}</label>
                             <select id="setting-registration-role" name="setting-registration-role" @if($errors->has('setting-registration-role')) class="neg" @endif>
                                 @foreach(\BookStack\Auth\Role::all() as $role)
-                                    <option value="{{$role->id}}" data-role-name="{{ $role->name }}"
-                                            @if(setting('registration-role', \BookStack\Auth\Role::first()->id) == $role->id) selected @endif
-                                    >
+                                    <option value="{{$role->id}}" data-role-name="{{ $role->name }}" @if(setting('registration-role', \BookStack\Auth\Role::first()->id) == $role->id) selected @endif>
                                         {{ $role->display_name }}
                                     </option>
                                 @endforeach
@@ -272,8 +260,7 @@
                             @include('components.toggle-switch', [
                                 'name' => 'setting-registration-confirmation',
                                 'value' => setting('registration-confirmation'),
-                                'label' => trans('settings.reg_email_confirmation_toggle')
-                            ])
+                                'label' => trans('settings.reg_email_confirmation_toggle')])
                         </div>
                     </div>
 

--- a/resources/views/settings/roles/form.blade.php
+++ b/resources/views/settings/roles/form.blade.php
@@ -155,6 +155,8 @@
                         @include('settings.roles.checkbox', ['permission' => 'page-update-own', 'label' => trans('settings.role_own')])
                         <br>
                         @include('settings.roles.checkbox', ['permission' => 'page-update-all', 'label' => trans('settings.role_all')])
+                        <br>
+                        @include('settings.roles.checkbox', ['permission' => 'page-editdraft-all', 'label' => trans('common.drafts')])
                     </td>
                     <td>
                         @include('settings.roles.checkbox', ['permission' => 'page-delete-own', 'label' => trans('settings.role_own')])


### PR DESCRIPTION
Added settings flag to enable shared drafts across all users with edit permission on the page.
Also added _editdraft_ permission, that allow users to edit pages and only save draft of them (if they not have also _update_ permission).