### PR TITLE
Fixed 'interaction_required' response for azure

### DIFF
--- a/app/Auth/Access/SocialAuthService.php
+++ b/app/Auth/Access/SocialAuthService.php
@@ -233,6 +233,9 @@ class SocialAuthService
         if ($driverName === 'google' && config('services.google.select_account')) {
             $driver->with(['prompt' => 'select_account']);
         }
+        if ($driverName === 'azure') {
+            $driver->with(['resource' => 'https://graph.windows.net']);
+        }
 
         return $driver;
     }


### PR DESCRIPTION
Azure Conditional Access policy 2FA returns 'interaction_required' 400 response and therefor breaks authentication when forced to use 2FA. 
https://github.com/SocialiteProviders/Providers/issues/208