### PR TITLE
Resolve issue #1911 (Additional margin/padding present in nested lists)

### DIFF
--- a/resources/sass/_text.scss
+++ b/resources/sass/_text.scss
@@ -295,6 +295,13 @@ li.checkbox-item, li.task-list-item {
   }
 }
 
+li > ol, li > ul {
+  margin-block-end: 0px;
+  margin-block-start: 0px;
+  padding-block-end: 0px;
+  padding-block-start: 0px;
+}
+
 /*
  * Generic text styling classes
  */


### PR DESCRIPTION
Optionally we could consider removing the rule at line 274. This doesn't handle multiple layers of nested lists and would be better covered by the generic rule which checks for an `ol` or `ul` nested inside a `li` which is how MarkDown renders nested lists as HTML.

**Issue Link:** #1911 