### PR TITLE
Add support Windows Authentication via SAML

### DIFF
--- a/.env.example.complete
+++ b/.env.example.complete
@@ -222,6 +222,12 @@ SAML2_ONELOGIN_OVERRIDES=null
 SAML2_DUMP_USER_DETAILS=false
 SAML2_AUTOLOAD_METADATA=false
 
+# SAML Authentication context.
+# Set to false and no AuthContext will be sent in the AuthNRequest,
+# Set true and you will get an AuthContext 'exact' 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
+# Set an array with the possible auth context values: array ('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509'),
+SAML2_IDP_AUTHNCONTEXT=false
+
 # SAML group sync configuration
 # Refer to https://www.bookstackapp.com/docs/admin/saml2-auth/
 SAML2_USER_TO_GROUPS=false

--- a/app/Config/saml2.php
+++ b/app/Config/saml2.php
@@ -139,6 +139,12 @@ return [
             //      )
             // ),
         ],
+        'security' => [
+            // Specifies Authentication context
+            // false means that IDP choose authentication method
+            // null force Form based authentication or is possible set via array supported methods. See to onelogin/php-sampl/advance_settings
+            'requestedAuthnContext' => env('SAML2_IDP_AUTHNCONTEXT',false), 
+        ],
     ],
 
 ];


### PR DESCRIPTION
With default SAML configuration wasn't possible use Windows Authentication via AD FS and everytime is offered only login via AD FS form. That is due missing 'requestedAuthnContext' set to false  when 
 IDP choose available method. Instead of that is send request with "'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport" which on AD FS force to use form.
I just use setting from onelogin/php-saml/advanced_settings and provide configuration to .ENV file