### PR TITLE
Markdown Export

### DIFF
--- a/app/Entities/ExportService.php
+++ b/app/Entities/ExportService.php
@@ -6,6 +6,7 @@ use BookStack\Uploads\ImageService;
 use DomPDF;
 use Exception;
 use SnappyPDF;
+use League\HTMLToMarkdown\HtmlConverter;
 use Throwable;
 
 class ExportService
@@ -232,11 +233,11 @@ class ExportService
      */
     public function pageToMarkdown(Page $page)
     {
-        if (property_exists($page, 'markdown') || $page->markdown != '') {
-            return "#" . $page->name . "\n\n" . $page->markdown;
+        if (property_exists($page, 'markdown') && $page->markdown != '') {
+            return "# " . $page->name . "\n\n" . $page->markdown;
         } else {
-            // TODO: Implement this feature.
-            return "# Unimplemented Feature\nidk how to turn html into markdown";
+            $converter = new HtmlConverter();
+            return "# " . $page->name . "\n\n" . $converter->convert($page->html);
         }
     }
 
@@ -246,7 +247,7 @@ class ExportService
      */
     public function chapterToMarkdown(Chapter $chapter)
     {
-        $text = "#" . $chapter->name . "\n\n";
+        $text = "# " . $chapter->name . "\n\n";
         $text .= $chapter->description . "\n\n";
         foreach ($chapter->pages as $page) {
             $text .= $this->pageToMarkdown($page);
@@ -260,7 +261,7 @@ class ExportService
     public function bookToMarkdown(Book $book): string
     {
         $bookTree = (new BookContents($book))->getTree(false, true);
-        $text = "#" . $book->name . "\n\n";
+        $text = "# " . $book->name . "\n\n";
         foreach ($bookTree as $bookChild) {
             if ($bookChild->isA('chapter')) {
                 $text .= $this->chapterToMarkdown($bookChild);

--- a/app/Entities/ExportService.php
+++ b/app/Entities/ExportService.php
@@ -225,4 +225,49 @@ class ExportService
         }
         return $text;
     }
+
+    /**
+     * Convert a page to a Markdown file.
+     * @throws Throwable
+     */
+    public function pageToMarkdown(Page $page)
+    {
+        if (property_exists($page, 'markdown') || $page->markdown != '') {
+            return "#" . $page->name . "\n\n" . $page->markdown;
+        } else {
+            // TODO: Implement this feature.
+            return "# Unimplemented Feature\nidk how to turn html into markdown";
+        }
+    }
+
+    /**
+     * Convert a chapter to a Markdown file.
+     * @throws Throwable
+     */
+    public function chapterToMarkdown(Chapter $chapter)
+    {
+        $text = "#" . $chapter->name . "\n\n";
+        $text .= $chapter->description . "\n\n";
+        foreach ($chapter->pages as $page) {
+            $text .= $this->pageToMarkdown($page);
+        }
+        return $text;
+    }
+
+    /**
+     * Convert a book into a plain text string.
+     */
+    public function bookToMarkdown(Book $book): string
+    {
+        $bookTree = (new BookContents($book))->getTree(false, true);
+        $text = "#" . $book->name . "\n\n";
+        foreach ($bookTree as $bookChild) {
+            if ($bookChild->isA('chapter')) {
+                $text .= $this->chapterToMarkdown($bookChild);
+            } else {
+                $text .= $this->pageToMarkdown($bookChild);
+            }
+        }
+        return $text;
+    }
 }

--- a/app/Http/Controllers/BookExportController.php
+++ b/app/Http/Controllers/BookExportController.php
@@ -6,7 +6,6 @@ use BookStack\Entities\Managers\BookContents;
 use BookStack\Entities\ExportService;
 use BookStack\Entities\Repos\BookRepo;
 use Throwable;
-use ZipArchive;
 
 class BookExportController extends Controller
 {
@@ -72,20 +71,7 @@ class BookExportController extends Controller
     public function zip(string $bookSlug)
     {
         $book = $this->bookRepo->getBySlug($bookSlug);
-        $z = new ZipArchive();
-        $z->open("book.zip", \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
-        $bookTree = (new BookContents($book))->getTree(false, true);
-        foreach ($bookTree as $bookChild) {
-            if ($bookChild->isA('chapter')) {
-                $z->addEmptyDir($bookChild->name);
-                foreach ($bookChild->pages as $page) {
-                    $z->addFromString($bookChild->name . "/" . $page->name . ".md", $this->exportService->pageToMarkdown($page));
-                }
-            } else {
-                $z->addFromString($bookChild->name . ".md", $this->exportService->pageToMarkdown($bookChild));
-            }
-        }
-        return response()->download('book.zip');
-        // TODO: Is not unlinking it a security issue?
+        $filename = $this->exportService->bookToZip($book);
+        return response()->download($filename);
     }
 }

--- a/app/Http/Controllers/BookExportController.php
+++ b/app/Http/Controllers/BookExportController.php
@@ -53,4 +53,15 @@ class BookExportController extends Controller
         $textContent = $this->exportService->bookToPlainText($book);
         return $this->downloadResponse($textContent, $bookSlug . '.txt');
     }
+
+    /**
+     * Export a book as a markdown file.
+     */
+    public function markdown(string $bookSlug)
+    {
+        // TODO: This should probably export to a zip file.
+        $book = $this->bookRepo->getBySlug($bookSlug);
+        $textContent = $this->exportService->bookToMarkdown($book);
+        return $this->downloadResponse($textContent, $bookSlug . '.md');
+    }
 }

--- a/app/Http/Controllers/ChapterExportController.php
+++ b/app/Http/Controllers/ChapterExportController.php
@@ -55,4 +55,16 @@ class ChapterExportController extends Controller
         $chapterText = $this->exportService->chapterToPlainText($chapter);
         return $this->downloadResponse($chapterText, $chapterSlug . '.txt');
     }
+
+    /**
+     * Export a chapter to a simple markdown file.
+     * @throws NotFoundException
+     */
+    public function markdown(string $bookSlug, string $chapterSlug)
+    {
+        // TODO: This should probably export to a zip file.
+        $chapter = $this->chapterRepo->getBySlug($bookSlug, $chapterSlug);
+        $chapterText = $this->exportService->chapterToMarkdown($chapter);
+        return $this->downloadResponse($chapterText, $chapterSlug . '.md');
+    }
 }

--- a/app/Http/Controllers/PageExportController.php
+++ b/app/Http/Controllers/PageExportController.php
@@ -63,4 +63,15 @@ class PageExportController extends Controller
         $pageText = $this->exportService->pageToPlainText($page);
         return $this->downloadResponse($pageText, $pageSlug . '.txt');
     }
+
+    /**
+     * Export a page to a simple markdown .md file.
+     * @throws NotFoundException
+     */
+    public function markdown(string $bookSlug, string $pageSlug)
+    {
+        $page = $this->pageRepo->getBySlug($bookSlug, $pageSlug);
+        $pageText = $this->exportService->pageToMarkdown($page);
+        return $this->downloadResponse($pageText, $pageSlug . '.md');
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "laravel/socialite": "^4.3.2",
         "league/commonmark": "^1.4",
         "league/flysystem-aws-s3-v3": "^1.0",
+        "league/html-to-markdown": "^4.9",
         "nunomaduro/collision": "^3.0",
         "onelogin/php-saml": "^3.3",
         "predis/predis": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bbe47cff4f167fd6ce7047dff4602a78",
+    "content-hash": "280a7e2fe2a6f65812594d73df2ccc0f",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -2003,6 +2003,70 @@
             ],
             "description": "Flysystem adapter for the AWS S3 SDK v3.x",
             "time": "2020-02-23T13:31:58+00:00"
+        },
+        {
+            "name": "league/html-to-markdown",
+            "version": "4.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/html-to-markdown.git",
+                "reference": "1dcd0f85de786f46a7f224a27cc3d709ddd2a68c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/html-to-markdown/zipball/1dcd0f85de786f46a7f224a27cc3d709ddd2a68c",
+                "reference": "1dcd0f85de786f46a7f224a27cc3d709ddd2a68c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xml": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "mikehaertl/php-shellcommand": "~1.1.0",
+                "phpunit/phpunit": "^4.8|^5.7",
+                "scrutinizer/ocular": "~1.1"
+            },
+            "bin": [
+                "bin/html-to-markdown"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\HTMLToMarkdown\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Nick Cernis",
+                    "email": "nick@cern.is",
+                    "homepage": "http://modernnerd.net",
+                    "role": "Original Author"
+                }
+            ],
+            "description": "An HTML-to-markdown conversion helper for PHP",
+            "homepage": "https://github.com/thephpleague/html-to-markdown",
+            "keywords": [
+                "html",
+                "markdown"
+            ],
+            "time": "2019-12-28T01:32:28+00:00"
         },
         {
             "name": "league/oauth1-client",

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -4,9 +4,9 @@ ENV APACHE_DOCUMENT_ROOT /app/public
 WORKDIR /app
 
 RUN apt-get update -y \
-    && apt-get install -y git zip unzip libtidy-dev libpng-dev libldap2-dev libxml++2.6-dev wait-for-it \
+    && apt-get install -y git zip unzip libtidy-dev libpng-dev libldap2-dev libxml++2.6-dev wait-for-it libzip-dev \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
-    && docker-php-ext-install pdo pdo_mysql tidy dom xml mbstring gd ldap \
+    && docker-php-ext-install pdo pdo_mysql tidy dom xml mbstring gd ldap zip \
     && a2enmod rewrite \
     && sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
     && sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf \

--- a/resources/lang/en/entities.php
+++ b/resources/lang/en/entities.php
@@ -33,6 +33,7 @@ return [
     'export_html' => 'Contained Web File',
     'export_pdf' => 'PDF File',
     'export_text' => 'Plain Text File',
+    'export_md' => 'Markdown File',
 
     // Permissions and restrictions
     'permissions' => 'Permissions',

--- a/resources/views/partials/entity-export-menu.blade.php
+++ b/resources/views/partials/entity-export-menu.blade.php
@@ -8,5 +8,6 @@
         <li><a href="{{ $entity->getUrl('/export/html') }}" target="_blank">{{ trans('entities.export_html') }} <span class="text-muted float right">.html</span></a></li>
         <li><a href="{{ $entity->getUrl('/export/pdf') }}" target="_blank">{{ trans('entities.export_pdf') }} <span class="text-muted float right">.pdf</span></a></li>
         <li><a href="{{ $entity->getUrl('/export/plaintext') }}" target="_blank">{{ trans('entities.export_text') }} <span class="text-muted float right">.txt</span></a></li>
+        <li><a href="{{ $entity->getUrl('/export/markdown') }}" target="_blank">{{ trans('entities.export_md') }} <span class="text-muted float right">.md</span></a></li>
     </ul>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,7 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('/{bookSlug}/export/html', 'BookExportController@html');
         Route::get('/{bookSlug}/export/pdf', 'BookExportController@pdf');
         Route::get('/{bookSlug}/export/markdown', 'BookExportController@markdown');
+        Route::get('/{bookSlug}/export/zip', 'BookExportController@zip');
         Route::get('/{bookSlug}/export/plaintext', 'BookExportController@plainText');
 
         // Pages

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,6 +47,7 @@ Route::group(['middleware' => 'auth'], function () {
         Route::put('/{bookSlug}/sort', 'BookSortController@update');
         Route::get('/{bookSlug}/export/html', 'BookExportController@html');
         Route::get('/{bookSlug}/export/pdf', 'BookExportController@pdf');
+        Route::get('/{bookSlug}/export/markdown', 'BookExportController@markdown');
         Route::get('/{bookSlug}/export/plaintext', 'BookExportController@plainText');
 
         // Pages
@@ -57,6 +58,7 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('/{bookSlug}/page/{pageSlug}', 'PageController@show');
         Route::get('/{bookSlug}/page/{pageSlug}/export/pdf', 'PageExportController@pdf');
         Route::get('/{bookSlug}/page/{pageSlug}/export/html', 'PageExportController@html');
+        Route::get('/{bookSlug}/page/{pageSlug}/export/markdown', 'PageExportController@markdown');
         Route::get('/{bookSlug}/page/{pageSlug}/export/plaintext', 'PageExportController@plainText');
         Route::get('/{bookSlug}/page/{pageSlug}/edit', 'PageController@edit');
         Route::get('/{bookSlug}/page/{pageSlug}/move', 'PageController@showMove');
@@ -91,6 +93,7 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('/{bookSlug}/chapter/{chapterSlug}/permissions', 'ChapterController@showPermissions');
         Route::get('/{bookSlug}/chapter/{chapterSlug}/export/pdf', 'ChapterExportController@pdf');
         Route::get('/{bookSlug}/chapter/{chapterSlug}/export/html', 'ChapterExportController@html');
+        Route::get('/{bookSlug}/chapter/{chapterSlug}/export/markdown', 'ChapterExportController@markdown');
         Route::get('/{bookSlug}/chapter/{chapterSlug}/export/plaintext', 'ChapterExportController@plainText');
         Route::put('/{bookSlug}/chapter/{chapterSlug}/permissions', 'ChapterController@permissions');
         Route::get('/{bookSlug}/chapter/{chapterSlug}/delete', 'ChapterController@showDelete');


### PR DESCRIPTION
I want to be able to export a full, organized, plaintext copy of a book like @XVilka [suggests](https://github.com/BookStackApp/BookStack/issues/1717#issuecomment-543028773) in #1717.

## Status

- [x] Export single .md files
- [x] Convert WYSIWYG HTML into Markdown on export
- [x] Make the export button show in the UI
- [x] Export zip files with proper directory trees

I know this is a cold PR, but hopefully there's something usable in here. General guidance for how/where to implement these features is appreciated.

## Help Needed
- [ ] Export media in the zip file
- [ ] Since this is a heavy operation, gate .zip export behind a permission

These are things that might be good to also add... not sure where to start on them though.

## Benefits

- Adopting BookStack is easier knowing that all the data stored there is in a standard format. 
- A lot of people like git sync (hi @dkess), so this makes that possible with external software.