### PR TITLE
Add id tag to the registration form

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -8,7 +8,7 @@
         <div class="card content-wrap auto-height">
             <h1 class="list-heading">{{ Str::title(trans('auth.sign_up')) }}</h1>
 
-            <form action="{{ url("/register") }}" method="POST" class="mt-l stretch-inputs">
+            <form id="register-form" action="{{ url("/register") }}" method="POST" class="mt-l stretch-inputs">
                 {!! csrf_field() !!}
 
                 <div class="form-group">


### PR DESCRIPTION
Add an id tag to the registration form. An id tag already exists on the login form and this will allow both the login form and registration form elements be alterable from the "Custom HTML Head Content" option in Settings. We hide both of these forms because all of our users use federated authentication to log in. We do not want users creating accounts in the app via the registration form.