### PR TITLE
Use Str::slug to create slugs from string #2026

### DIFF
--- a/app/Entities/SlugGenerator.php
+++ b/app/Entities/SlugGenerator.php
@@ -1,5 +1,7 @@
 <?php namespace BookStack\Entities;
 
+use Illuminate\Support\Str;
+
 class SlugGenerator
 {
 
@@ -32,9 +34,7 @@ class SlugGenerator
      */
     protected function formatNameAsSlug(string $name): string
     {
-        $slug = preg_replace('/[\+\/\\\?\@\}\{\.\,\=\[\]\#\&\!\*\'\;\:\$\%]/', '', mb_strtolower($name));
-        $slug = preg_replace('/\s{2,}/', ' ', $slug);
-        $slug = str_replace(' ', '-', $slug);
+        $slug = Str::slug($name);
         if ($slug === "") {
             $slug = substr(md5(rand(1, 500)), 0, 5);
         }

--- a/tests/Entity/EntityTest.php
+++ b/tests/Entity/EntityTest.php
@@ -273,15 +273,20 @@ class EntityTest extends BrowserKitTest
             ->seeInElement('#recently-updated-pages', $page->name);
     }
 
-    public function test_slug_multi_byte_lower_casing()
+    public function test_slug_multi_byte_url_safe()
     {
         $book = $this->newBook([
-            'name' => 'КНИГА'
+            'name' => 'информация'
         ]);
 
-        $this->assertEquals('книга', $book->slug);
-    }
+        $this->assertEquals('informatsiya', $book->slug);
 
+        $book = $this->newBook([
+            'name' => '¿Qué?'
+        ]);
+
+        $this->assertEquals('que', $book->slug);
+    }
 
     public function test_slug_format()
     {


### PR DESCRIPTION
Added Illuminate\Support\Str::slug to generate slug from text to improve the creation of slugs with non-English characters.

Fix issue #2026 

**before:**
```
name = "¿ De qué color son los paños calientes ?"
slug  = "¿-de-qué-color-son-los-paños-calientes-"
encoded_slug = "%C2%BF-de-qu%C3%A9-color-son-los-pa%C3%B1os-calientes-"
```

```
name = "основная-информация"
slug="основная-информация"
encoded_url = "%D0%BE%D1%81%D0%BD%D0%BE%D0%B2%D0%BD%D0%B0%D1%8F-%D0%B8%D0%BD%D1%84%D0%BE%D1%80%D0%BC%D0%B0%D1%86%D0%B8%D1%8F"
```

**After ( with Str::slug() )**

```
name = "¿ De qué color son los paños calientes ?"
slug  = "de-que-color-son-los-panos-calientes"
encoded_slug = "de-que-color-son-los-panos-calientes"
```

```
name = "основная-информация"
slug="osnovnaya-informatsiya"
encoded_slug = "osnovnaya-informatsiya"
```
