### PR TITLE
Make RequestedAuthnContext configurable in SAML2

### DIFF
--- a/.env.example.complete
+++ b/.env.example.complete
@@ -221,6 +221,7 @@ SAML2_IDP_x509=null
 SAML2_ONELOGIN_OVERRIDES=null
 SAML2_DUMP_USER_DETAILS=false
 SAML2_AUTOLOAD_METADATA=false
+SAML2_REQUESTED_AUTHN_CONTEXT=true
 
 # SAML group sync configuration
 # Refer to https://www.bookstackapp.com/docs/admin/saml2-auth/

--- a/app/Config/saml2.php
+++ b/app/Config/saml2.php
@@ -139,6 +139,9 @@ return [
             //      )
             // ),
         ],
+        'security' => [
+            'requestedAuthnContext' => env('SAML2_REQUESTED_AUTHN_CONTEXT', true),
+        ],
     ],
 
 ];


### PR DESCRIPTION
When using SAML IDP providers that have different authentication methods available, authentication will occasionally fail since by default the OneLogin SAML library sets `requestedAuthnContext` to `true`.

This has the effect of requiring the `exact` `urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport` authentication context from the IDP (Refer to README: https://github.com/onelogin/php-saml)

I've been getting SAML to work with Microsoft ADFS that is configured with a range of different authentication mechanisms, and in this configuration ADFS is unable to authenticate a request that asks for `PasswordProtectedTransport`

In this PR I have made this option configurable by setting `SAML2_REQUESTED_AUTHN_CONTEXT` in the env config file. I have made it default to `true` as to not change the current working configuration for already deployed Bookstack instances.

Setting `SAML2_REQUESTED_AUTHN_CONTEXT` to `false` will send an authentication request to the IDP without specifying any authentication context, allowing the IDP to select the most appropriate method to authenticate the end user.

Setting `SAML2_REQUESTED_AUTHN_CONTEXT` to `true` or not configuring it will keep the same behavior of requesting `PasswordProtectedTransport`.

(Note: The online GitHub editor has automatically added a newline to the .env.example.complete file)