### PR TITLE
Feature - Convert Code Language to Select instead of Links + Input

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,6 @@
 # Run `php artisan key:generate` to generate a valid key.
 APP_KEY=SomeRandomString
 
-# Necessary to set if running docker-compose in a dev setting.
-APP_ENV=local
-
 # Application URL
 # Remove the hash below and set a URL if using BookStack behind
 # a proxy, if using a third-party authentication option.

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@
 # Run `php artisan key:generate` to generate a valid key.
 APP_KEY=SomeRandomString
 
+# Necessary to set if running docker-compose in a dev setting.
+APP_ENV=local
+
 # Application URL
 # Remove the hash below and set a URL if using BookStack behind
 # a proxy, if using a third-party authentication option.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-* text=auto
+* text=auto eol=lf
 *.css linguist-vendored
 *.less linguist-vendored

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       MAIL_DRIVER: smtp
       MAIL_HOST: mailhog
       MAIL_PORT: 1025
+      APP_ENV: local
     ports:
       - ${DEV_PORT:-8080}:80
     volumes:

--- a/resources/js/components/code-editor.js
+++ b/resources/js/components/code-editor.js
@@ -11,9 +11,8 @@ class CodeEditor {
         this.container = this.$refs.container;
         this.popup = this.$el;
         this.editorInput = this.$refs.editor;
-        this.languageLinks = this.$manyRefs.languageLink;
         this.saveButton = this.$refs.saveButton;
-        this.languageInput = this.$refs.languageInput;
+        this.languageSelect = this.$refs.languageSelect;
         this.historyDropDown = this.$refs.historyDropDown;
         this.historyList = this.$refs.historyList;
 
@@ -31,13 +30,10 @@ class CodeEditor {
             }
         });
 
-        onSelect(this.languageLinks, event => {
-            const language = event.target.dataset.lang;
-            this.languageInput.value = language;
-            this.updateEditorMode(language);
+        onSelect(this.languageSelect, event => {
+            this.updateEditorMode(this.getLanguageValue());
         });
 
-        onEnterPress(this.languageInput, e => this.save());
         onSelect(this.saveButton, e => this.save());
 
         onChildEvent(this.historyList, 'button', 'click', (event, elem) => {
@@ -51,13 +47,13 @@ class CodeEditor {
 
     save() {
         if (this.callback) {
-            this.callback(this.editor.getValue(), this.languageInput.value);
+            this.callback(this.editor.getValue(), this.getLanguageValue());
         }
         this.hide();
     }
 
     open(code, language, callback) {
-        this.languageInput.value = language;
+        this.languageSelect.value = language;
         this.callback = callback;
 
         this.show();
@@ -68,7 +64,7 @@ class CodeEditor {
 
     show() {
         if (!this.editor) {
-            this.editor = Code.popupEditor(this.editorInput, this.languageInput.value);
+            this.editor = Code.popupEditor(this.editorInput, this.getLanguageValue());
         }
         this.loadHistory();
         this.popup.components.popup.show(() => {
@@ -110,6 +106,11 @@ class CodeEditor {
         this.history[String(Date.now())] = code;
         const historyString = JSON.stringify(this.history);
         window.sessionStorage.setItem(this.historyKey, historyString);
+    }
+
+    getLanguageValue() {
+        const selectedIndex = this.languageSelect.selectedIndex;
+        return this.languageSelect.options[selectedIndex].value;
     }
 
 }

--- a/resources/js/services/code.js
+++ b/resources/js/services/code.js
@@ -27,6 +27,7 @@ import 'codemirror/mode/shell/shell';
 import 'codemirror/mode/sql/sql';
 import 'codemirror/mode/toml/toml';
 import 'codemirror/mode/xml/xml';
+import 'codemirror/mode/jsx/jsx';
 import 'codemirror/mode/yaml/yaml';
 
 // Addons
@@ -52,13 +53,17 @@ const modeMap = {
     hs: 'haskell',
     html: 'htmlmixed',
     ini: 'properties',
-    javascript: 'javascript',
-    json: {name: 'javascript', json: true},
     js: 'javascript',
+    javascript: 'javascript',
+    ts: { name: 'javascript', typescript: true },
+    typescript: { name: 'javascript', typescript: true },
+    jsx: { name: "jsx", base: { name: "javascript"}},
+    tsx: { name: "jsx", base: { name: "javascript", typescript: true }},
+    json: { name: 'javascript', json: true }, 
     jl: 'julia',
     julia: 'julia',
     lua: 'lua',
-    md: 'markdown',
+    md: 'markdown', 
     mdown: 'markdown',
     markdown: 'markdown',
     ml: 'mllike',

--- a/resources/views/components/code-editor.blade.php
+++ b/resources/views/components/code-editor.blade.php
@@ -22,6 +22,9 @@
                             <a refs="code-editor@languageLink" data-lang="INI">INI</a>
                             <a refs="code-editor@languageLink" data-lang="Java">Java</a>
                             <a refs="code-editor@languageLink" data-lang="JavaScript">JavaScript</a>
+                            <a refs="code-editor@languageLink" data-lang="TypeScript">TypeScript</a>
+                            <a refs="code-editor@languageLink" data-lang="JSX">JSX</a>
+                            <a refs="code-editor@languageLink" data-lang="TSX">TSX</a>
                             <a refs="code-editor@languageLink" data-lang="JSON">JSON</a>
                             <a refs="code-editor@languageLink" data-lang="Lua">Lua</a>
                             <a refs="code-editor@languageLink" data-lang="MarkDown">MarkDown</a>

--- a/resources/views/components/code-editor.blade.php
+++ b/resources/views/components/code-editor.blade.php
@@ -11,37 +11,38 @@
                 <div class="form-group">
                     <label for="code-editor-language">{{ trans('components.code_language') }}</label>
                     <div class="lang-options">
-                        <small>
-                            <a refs="code-editor@languageLink" data-lang="CSS">CSS</a>
-                            <a refs="code-editor@languageLink" data-lang="C">C</a>
-                            <a refs="code-editor@languageLink" data-lang="C++">C++</a>
-                            <a refs="code-editor@languageLink" data-lang="C#">C#</a>
-                            <a refs="code-editor@languageLink" data-lang="Fortran">Fortran</a>
-                            <a refs="code-editor@languageLink" data-lang="Go">Go</a>
-                            <a refs="code-editor@languageLink" data-lang="HTML">HTML</a>
-                            <a refs="code-editor@languageLink" data-lang="INI">INI</a>
-                            <a refs="code-editor@languageLink" data-lang="Java">Java</a>
-                            <a refs="code-editor@languageLink" data-lang="JavaScript">JavaScript</a>
-                            <a refs="code-editor@languageLink" data-lang="TypeScript">TypeScript</a>
-                            <a refs="code-editor@languageLink" data-lang="JSX">JSX</a>
-                            <a refs="code-editor@languageLink" data-lang="TSX">TSX</a>
-                            <a refs="code-editor@languageLink" data-lang="JSON">JSON</a>
-                            <a refs="code-editor@languageLink" data-lang="Lua">Lua</a>
-                            <a refs="code-editor@languageLink" data-lang="MarkDown">MarkDown</a>
-                            <a refs="code-editor@languageLink" data-lang="Nginx">Nginx</a>
-                            <a refs="code-editor@languageLink" data-lang="PASCAL">Pascal</a>
-                            <a refs="code-editor@languageLink" data-lang="Perl">Perl</a>
-                            <a refs="code-editor@languageLink" data-lang="PHP">PHP</a>
-                            <a refs="code-editor@languageLink" data-lang="Powershell">Powershell</a>
-                            <a refs="code-editor@languageLink" data-lang="Python">Python</a>
-                            <a refs="code-editor@languageLink" data-lang="Ruby">Ruby</a>
-                            <a refs="code-editor@languageLink" data-lang="shell">Shell/Bash</a>
-                            <a refs="code-editor@languageLink" data-lang="SQL">SQL</a>
-                            <a refs="code-editor@languageLink" data-lang="XML">XML</a>
-                            <a refs="code-editor@languageLink" data-lang="YAML">YAML</a>
-                        </small>
+                        <select  id="code-editor-language" refs="code-editor@languageSelect">
+                            <?php $options = array(
+                                "C++",
+                                "C#",
+                                "Fortran",
+                                "Go",
+                                "HTML",
+                                "INI",
+                                "Java",
+                                "JavaScript",
+                                "TypeScript",
+                                "JSX",
+                                "TSX",
+                                "JSON",
+                                "Lua",
+                                "MarkDown",
+                                "Nginx",
+                                "PASCAL",
+                                "Perl",
+                                "PHP",
+                                "Powershell",
+                                "Python",
+                                "Ruby",
+                                "shell",
+                                "SQL",
+                                "XML",
+                                "YAML");?>
+                            <?php foreach ($options as &$option): ?>
+                                <option value="<?php echo $option; ?>"><?php echo $option; ?></option>"
+                            <?php endforeach; ?>
+                        </select>
                     </div>
-                    <input refs="code-editor@languageInput" id="code-editor-language" type="text">
                 </div>
 
                 <div class="form-group">


### PR DESCRIPTION
Description

Converted the language select in the code editor to be a dropdown instead of a link select and free-text input field.  This is a common pattern for this UI element and makes a lot of sense for a code language.

Added language support for TypeScript and JSX/TSX to allow for React and Typescript documentation.

Added a change that would ensure that the line-endings are LF (for windows developers) to not have an issue with the developer docker setup.

Added an environment variable `APP_ENV` to docker-compose as it was necessary for my development environment to run.