### PR TITLE
Render included content when exporting books

### DIFF
--- a/app/Entities/Managers/BookContents.php
+++ b/app/Entities/Managers/BookContents.php
@@ -41,7 +41,6 @@ class BookContents
 
     /**
      * Get the contents as a sorted collection tree.
-     * TODO - Support $renderPages option
      */
     public function getTree(bool $showDrafts = false, bool $renderPages = false): Collection
     {
@@ -60,8 +59,12 @@ class BookContents
             }
         });
 
-        $all->each(function (Entity $entity) {
+        $all->each(function (Entity $entity) use ($renderPages) {
             $entity->setRelation('book', $this->book);
+
+            if ($renderPages && get_class($entity) == 'BookStack\Entities\Page') {
+                $entity->html = (new PageContent($entity))->render();
+            }
         });
 
         return collect($chapters)->concat($lonePages)->sortBy($this->bookChildSortFunc());


### PR DESCRIPTION
Currently, if I create a page with included content (`{{@123}}`) then I see the rendered content when I export the page or its containing chapter.  But the book export prints the literal string `{{@123}}` in the output instead of the included content.

This change results in the included content being rendered no matter which object (book, chapter, page) is exported.

Fixes #2228