### PR TITLE
Updated callout link formatting

### DIFF
--- a/resources/sass/_blocks.scss
+++ b/resources/sass/_blocks.scss
@@ -27,6 +27,7 @@
     border-left-color: $positive;
     @include lightDark(background-color, lighten($positive, 68%), darken($positive, 22%));
     @include lightDark(color, darken($positive, 16%), lighten($positive, 5%));
+    a {@include lightDark(color, darken($positive, 16%), lighten($positive, 5%)); font-weight: bold;}
   }
   &.success:before {
     background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIGZpbGw9IiMzNzZjMzkiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+ICAgIDxwYXRoIGQ9Ik0wIDBoMjR2MjRIMHoiIGZpbGw9Im5vbmUiLz4gICAgPHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6bS0yIDE1bC01LTUgMS40MS0xLjQxTDEwIDE0LjE3bDcuNTktNy41OUwxOSA4bC05IDl6Ii8+PC9zdmc+");
@@ -35,6 +36,7 @@
     border-left-color: $negative;
     @include lightDark(background-color, lighten($negative, 56%), darken($negative, 30%));
     @include lightDark(color, darken($negative, 20%), lighten($negative, 5%));
+    a {@include lightDark(color, darken($positive, 16%), lighten($positive, 5%)); font-weight: bold;}
   }
   &.danger:before {
     background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIGZpbGw9IiNiOTE4MTgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+ICAgIDxwYXRoIGQ9Ik0xNS43MyAzSDguMjdMMyA4LjI3djcuNDZMOC4yNyAyMWg3LjQ2TDIxIDE1LjczVjguMjdMMTUuNzMgM3pNMTIgMTcuM2MtLjcyIDAtMS4zLS41OC0xLjMtMS4zIDAtLjcyLjU4LTEuMyAxLjMtMS4zLjcyIDAgMS4zLjU4IDEuMyAxLjMgMCAuNzItLjU4IDEuMy0xLjMgMS4zem0xLTQuM2gtMlY3aDJ2NnoiLz4gICAgPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIvPjwvc3ZnPg==");
@@ -43,11 +45,13 @@
     border-left-color: $info;
     @include lightDark(color, darken($info, 20%), lighten($info, 10%));
     @include lightDark(background-color, lighten($info, 50%), darken($info, 35%));
+    a {@include lightDark(color, darken($positive, 16%), lighten($positive, 5%)); font-weight: bold;}
   }
   &.warning {
     border-left-color: $warning;
     @include lightDark(background-color, lighten($warning, 50%), darken($warning, 36%));
     @include lightDark(color, darken($warning, 20%), $warning);
+    a {@include lightDark(color, darken($positive, 16%), lighten($positive, 5%)); font-weight: bold;}
   }
   &.warning:before {
     background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIGZpbGw9IiNiNjUzMWMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+ICAgIDxwYXRoIGQ9Ik0wIDBoMjR2MjRIMHoiIGZpbGw9Im5vbmUiLz4gICAgPHBhdGggZD0iTTEgMjFoMjJMMTIgMiAxIDIxem0xMi0zaC0ydi0yaDJ2MnptMC00aC0ydi00aDJ2NHoiLz48L3N2Zz4=");


### PR DESCRIPTION
Updated callout links to use font colouring based on type, with bold text to denote link, instead of using the theme link colour. Closes #303.

SCSS has been updated, will need CSS (npm run dev) before merge.