### PR TITLE
Decode HTML entities in excerpts

### DIFF
--- a/app/Entities/Managers/PageContent.php
+++ b/app/Entities/Managers/PageContent.php
@@ -25,7 +25,7 @@ class PageContent
     public function setNewHTML(string $html)
     {
         $this->page->html = $this->formatHtml($html);
-        $this->page->text = $this->toPlainText();
+        $this->page->text = html_entity_decode($this->toPlainText());
     }
 
     /**


### PR DESCRIPTION
Decode HTML entities in the text content before returning an excerpt.  Fixes #2114.