### PR TITLE
Fix the `AddActivityIndexes` migration's `down()` method

### DIFF
--- a/database/migrations/2020_09_19_094251_add_activity_indexes.php
+++ b/database/migrations/2020_09_19_094251_add_activity_indexes.php
@@ -27,8 +27,8 @@ class AddActivityIndexes extends Migration
     public function down()
     {
         Schema::table('activities', function(Blueprint $table) {
-            $table->dropIndex('key');
-            $table->dropIndex('created_at');
+            $table->dropIndex('activities_key_index');
+            $table->dropIndex('activities_created_at_index');
         });
     }
 }


### PR DESCRIPTION
This PR fixes `artisan migration:rollback`, which was broken due to incorrect index names in the `2020_09_19_094251_add_activity_indexes` migration:

```
SQLSTATE[42000]: Syntax error or access violation: 1091 Can't DROP INDEX `key`; check that it exists (SQL: alter table `activities` drop index `key`)
```