### PR TITLE
Fixed canonical redirects on non-root url app instances

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -11,9 +11,10 @@
 
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule ^(.*)/$ /$1 [L,R=301]
+    RewriteCond %{REQUEST_URI} (.+)/$
+    RewriteRule ^ %1 [L,R=301]
 
-    # Handle Front Controller...
+    # Send Requests To Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]


### PR DESCRIPTION
If BookStack instance is deployed to any non-root path, e.g. `http://example.com/wiki/`,
requests for `http://example.com/wiki/shelves/`
was redirected to `http://example.com/shelves`
instead of `http://example.com/wiki/shelves`.

`%{REQUEST_URI}` contains whole URL path, script path included.