### PR TITLE
Fixed "Ubunto Mono" $mono type misspelling

### DIFF
--- a/resources/sass/_variables.scss
+++ b/resources/sass/_variables.scss
@@ -35,7 +35,7 @@ $text: -apple-system, BlinkMacSystemFont,
 "Segoe UI", "Oxygen", "Ubuntu", "Roboto", "Cantarell",
 "Fira Sans", "Droid Sans", "Helvetica Neue",
 sans-serif;
-$mono: "Lucida Console", "DejaVu Sans Mono", "Ubunto Mono", Monaco, monospace;
+$mono: "Lucida Console", "DejaVu Sans Mono", "Ubuntu Mono", Monaco, monospace;
 $heading: $text;
 $fs-m: 14px;
 $fs-s: 12px;


### PR DESCRIPTION
`$mono` CSS variable had misspelling of `Ubuntu Mono`.