### PR TITLE
Added console command to sync with ldap server

### DIFF
--- a/app/Auth/Access/Guards/LdapSessionGuard.php
+++ b/app/Auth/Access/Guards/LdapSessionGuard.php
@@ -79,7 +79,7 @@ class LdapSessionGuard extends ExternalBaseSessionGuard
             return false;
         }
 
-        if (is_null($user)) {
+        if ((is_null($user) && config("auth.auth_register"))) {
             try {
                 $user = $this->createNewFromLdapAndCreds($userDetails, $credentials);
             } catch (UserRegistrationException $exception) {

--- a/app/Auth/Access/Guards/LdapSessionGuard.php
+++ b/app/Auth/Access/Guards/LdapSessionGuard.php
@@ -79,9 +79,13 @@ class LdapSessionGuard extends ExternalBaseSessionGuard
             return false;
         }
 
-        if ((is_null($user) && config("auth.auth_register"))) {
+        if (is_null($user)) {
             try {
-                $user = $this->createNewFromLdapAndCreds($userDetails, $credentials);
+                if (!config("auth.auth_register")) {
+                    $user = $this->createNewFromLdapAndCreds($userDetails, $credentials);
+                } else {
+                    throw new LoginAttemptException("LDAP on and Auth_Register disabled");
+                }
             } catch (UserRegistrationException $exception) {
                 throw new LoginAttemptException($exception->message);
             }

--- a/app/Auth/Access/LdapService.php
+++ b/app/Auth/Access/LdapService.php
@@ -342,4 +342,29 @@ class LdapService extends ExternalAuthService
         $userLdapGroups = $this->getUserGroups($username);
         $this->syncWithGroups($user, $userLdapGroups);
     }
+
+    /**
+     * Fetch all users for SyncLdap command
+     * defaults to using $this->config['sync_user_filter']
+     * allows for a filter to be passed in so if nested groups/recursion enabled
+     *  it can pass in the filter from that call
+     */
+    public function getAllUsers(string $filter = '')
+    {
+        $ldapConnection = $this->getConnection();
+        $followReferrals = $this->config['follow_referrals'] ? 1 : 0;
+        $this->ldap->setOption($ldapConnection, LDAP_OPT_REFERRALS, $followReferrals);
+
+        $baseDn = $this->config['base_dn'];
+
+        if ($filter) {
+            $userFilter = $filter;
+        } else {
+            $userFilter = $this->config['sync_user_filter'];
+        }
+
+        $usersLdap = $this->ldap->searchAndGetEntries($ldapConnection, $baseDn, $userFilter, array(config("services.ldap.id_attribute")));
+
+        return $usersLdap;
+    }
 }

--- a/app/Config/auth.php
+++ b/app/Config/auth.php
@@ -14,6 +14,11 @@ return [
     // Options: standard, ldap, saml2
     'method' => env('AUTH_METHOD', 'standard'),
 
+    // if ldap, allow admin to enable/disable auto registration
+    //  checked in Access call in /Auth/Acces/Guards/LdapSessionGuard.php
+    //  [defaults to true/existing behaviour]
+    'auto-register' => env('AUTH_AUTO_REGISTER', true),
+
     // Authentication Defaults
     // This option controls the default authentication "guard" and password
     // reset options for your application.

--- a/app/Config/services.php
+++ b/app/Config/services.php
@@ -132,6 +132,8 @@ return [
         'group_attribute' => env('LDAP_GROUP_ATTRIBUTE', 'memberOf'),
         'remove_from_groups' => env('LDAP_REMOVE_FROM_GROUPS', false),
         'tls_insecure' => env('LDAP_TLS_INSECURE', false),
+        'sync_user_filter' => env('LDAP_SYNC_USER_FILTER', false),
+        'sync_user_recursive_groups' => env('LDAP_SYNC_USER_RECURSIVE_GROUPS', true),
     ],
 
 ];

--- a/app/Config/services.php
+++ b/app/Config/services.php
@@ -134,6 +134,7 @@ return [
         'tls_insecure' => env('LDAP_TLS_INSECURE', false),
         'sync_user_filter' => env('LDAP_SYNC_USER_FILTER', false),
         'sync_user_recursive_groups' => env('LDAP_SYNC_USER_RECURSIVE_GROUPS', true),
+        'sync_user_exclude_email' => env('LDAP_SYNC_EXCLUDE_EMAIL', false),
     ],
 
 ];

--- a/app/Console/Commands/SyncLdap.php
+++ b/app/Console/Commands/SyncLdap.php
@@ -39,7 +39,7 @@ class SyncLdap extends Command
      *
      * @var string
      */
-    protected $signature = 'bookstack:syncldap';
+    protected $signature = 'bookstack:syncldap {filter? : Optional LDAP filter for initial group pull}';
 
     /**
      * The console command description.
@@ -72,6 +72,9 @@ class SyncLdap extends Command
      */
     public function handle()
     {
+        if ($this->argument('filter')) {
+            $this->sync_user_filter = $this->argument('filter');
+        }
 
         Log::info("[syncldap] starting...");
         if (config('auth.method') !== 'ldap') {

--- a/app/Console/Commands/SyncLdap.php
+++ b/app/Console/Commands/SyncLdap.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace BookStack\Console\Commands;
+
+use Auth;
+use Hash;
+use Str;
+use BookStack\Auth\Access\Ldap;
+use Illuminate\Console\Command;
+use BookStack\Auth\Access\LdapService;
+use BookStack\Auth\Role;
+use BookStack\Auth\User;
+use BookStack\Auth\Access\Guards\LdapSessionGuard;
+
+
+class SyncLdap extends Command
+{
+    /**
+     * Used to sync users with LDAP server on a per request basis
+     *
+     * Use case:
+     * SSO logins need user account to exist/roles synced prior to login
+     */
+
+    public $users = array();
+    public $users_checked = array();
+    public $cn_checked = array(); // list of groups that have already been fetched
+    public $groups = array();
+    public $sync_user_filter;
+    public $sync_user_recursive_groups;
+    public $id_attribute;
+    public $LDAP;
+    public $ldap;
+
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'bookstack:syncldap';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Batch syncs LDAP users and groups';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $config = config('services.ldap');
+        $this->id_attribute = $config['id_attribute'];
+        $this->sync_user_filter = $config['sync_user_filter'];
+        $this->sync_user_recursive_groups = $config['sync_user_recursive_groups'];
+        $this->LDAP = new Ldap();
+        $this->ldap = new LdapService($this->LDAP);
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+
+        if (config('auth.method') !== 'ldap') {
+            dd("Must be using ldap for auth method");
+        }
+
+        // get all users with the LDAP_SYNC_USER_FILTER
+        //   [Use that to limit specific group/dn users to be auto-added]
+        $data = $this->ldap->getAllUsers();
+
+        // if there's a nested group/cn found in the users returned, recurse those as well
+        //   [recursion enabled/disabled with LDAP_SYNC_USER_RECURSIVE_GROUPS]
+        $this->checkDnForUserRecursive($data);
+
+        // run thru the returned list of all user records
+        foreach ($this->users as $userdata) {
+            // did we find an id_attribute?
+            if (isset($userdata[$this->id_attribute][0])) {
+
+                $user_id = $userdata[$this->id_attribute][0];
+
+                // fetch the user details and check if they exist
+                $ldapUserDetails = $this->ldap->getUserDetails($user_id);
+                $user = User::where('email', '=', $ldapUserDetails["email"])->first();
+
+                if ($user === null) {
+                    // user doesn't exist
+                    $user = new User();
+                    $user->password = Hash::make(Str::random(32));
+                    $user->email = $ldapUserDetails['email'];
+                    $user->name = $ldapUserDetails['name'];
+                    $user->external_auth_id = $user_id;
+
+                    $user->save();
+                } else {
+                    // user exists but this is the first time they're being paired to LDAP
+                    //   so set the external_auth_id
+                    if (is_null($user->external_auth_id)) {
+                        $user->email = $user_id;
+                        $user->save();
+                    }
+                }
+
+                // sync the user groups to bookstack groups
+                $this->ldap->syncGroups($user, $user_id);
+            }
+        }
+    }
+
+    private function checkDnForUserRecursive($data)
+    {
+        // passes in the results of LdapService->getAllUsers (uses LDAP_SYNC_USER_FILTER)
+        // needs to recurse and check for all nested groups
+        //  nested recursion can be enabled/disabled with LDAP_SYNC_USER_RECURSIVE_GROUPS
+
+        for ($i = 0; $i < $data["count"]; $i++) {
+            if (isset($data[$i][$this->id_attribute][0])) {
+                if (!in_array($data[$i][$this->id_attribute][0], $this->users_checked)) {
+                    $this->users_checked[] = $data[$i][$this->id_attribute][0];
+                    $this->users[] = $data[$i];
+                }
+            } elseif ((isset($data[$i]["dn"]) && $this->sync_user_recursive_groups)) {
+                // found a nested group record [dn => cn=GROUP ] for recursion
+                foreach ($this->LDAP->explodeDn($data[$i]["dn"], 0) as $attribute) {
+                    // pop out the cn record for the group name
+                    $pieces = explode("=", $attribute);
+                    if (strtolower($pieces[0]) == 'cn') {
+                        // was the group already checked?
+                        if (!in_array($pieces[1], $this->cn_checked)) {
+                            $filter = "(memberOf=" . $data[$i]["dn"] . ")";
+                            $this->cn_checked[] = $pieces[1];
+                            $data = $this->ldap->getAllUsers($filter);
+                            $this->checkDnForUserRecursive($data);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/Console/Commands/SyncLdap.php
+++ b/app/Console/Commands/SyncLdap.php
@@ -138,8 +138,8 @@ class SyncLdap extends Command
                         if (!in_array($pieces[1], $this->cn_checked)) {
                             $filter = "(memberOf=" . $new_dn . ")";
                             $this->cn_checked[] = $pieces[1];
-                            $data = $this->ldap->getAllUsers($filter);
-                            $this->checkDnForUserRecursive($data);
+                            $newdata = $this->ldap->getAllUsers($filter);
+                            $this->checkDnForUserRecursive($newdata);
                         }
                     }
                 }


### PR DESCRIPTION
Current behaviour:

When LDAP enabled, if a user tries to log in and isn't found, credentials are checked and user is imported.

Issue:

We require users to be populated from the LDAP server before they visit the site the first time. Also want option to prevent users from being auto registered if we'd prefer to use the LdapSync.

As example, if you're using any sort of SSO or Server/Header authentication, the user won't exist for an auto login check, and will have to click Login before being logged into their account.  Very confusing for users who expect to just be auto logged into their own account.

Fix:

Use this console command to trigger a sync with an LDAP filter (LDAP_SYNC_USER_FILTER) that will pull in users and sync groups prior to the login request.  

Changes:

Added and stuck most of the logic in  /app/Console/Commands/SyncLdap.php command

Added two config variables in config/services.php -> LDAP which default to current behaviours of the app
        'sync_user_filter' => env('LDAP_SYNC_USER_FILTER', false),
        'sync_user_recursive_groups' => env('LDAP_SYNC_USER_RECURSIVE_GROUPS', true),

Added public function to app/Auth/Access/LdapService.php to getAllUsers() by filter [defaults to sync_user_filter]

Added an option to disable auto registering members when using LDAP (config/auth/auto-register = TRUE) which stops the createNewFromLdapAndCreds call in /app/Auth/Access/Guards/LdapSessionGuard.php




