### PR TITLE
Fix build:js:watch not building at first launch in Docker

### DIFF
--- a/dev/docker/entrypoint.node.sh
+++ b/dev/docker/entrypoint.node.sh
@@ -5,4 +5,4 @@ set -e
 npm install
 npm rebuild node-sass
 
-exec npm run watch
+SHELL=/bin/sh exec npm run watch

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build:css:watch": "sass ./resources/sass:./public/dist --watch",
     "build:css:production": "sass ./resources/sass:./public/dist -s compressed",
     "build:js:dev": "esbuild --bundle ./resources/js/index.js --outfile=public/dist/app.js --sourcemap --target=es2019 --main-fields=module,main",
-    "build:js:watch": "chokidar \"./resources/**/*.js\" -c \"npm run build:js:dev\"",
+    "build:js:watch": "chokidar --initial \"./resources/**/*.js\" -c \"npm run build:js:dev\"",
     "build:js:production": "NODE_ENV=production esbuild --bundle ./resources/js/index.js --outfile=public/dist/app.js --sourcemap --target=es2019 --main-fields=module,main --minify",
     "build": "npm-run-all --parallel build:*:dev",
     "production": "npm-run-all --parallel build:*:production",


### PR DESCRIPTION
This PR adds the `--initial` flag to `chokidar`. This ensures that the JS resources get built immediately after starting the `build:js:watch` script. I also passed the `SHELL` environment variable down to node in the node entrypoint because `chokidar` does not run without it.

tl;dr: this makes it possible again to clone the repository, follow the Docker steps in the README and having a working dev installation after that :)