### PR TITLE
Install composer dependencies in Docker entrypoint

### DIFF
--- a/dev/docker/entrypoint.app.sh
+++ b/dev/docker/entrypoint.app.sh
@@ -7,6 +7,7 @@ env
 if [[ -n "$1" ]]; then
     exec "$@"
 else
+    composer install
     wait-for-it db:3306 -t 45
     php artisan migrate --database=mysql
     chown -R www-data:www-data storage

--- a/readme.md
+++ b/readme.md
@@ -93,12 +93,11 @@ To get started, make sure you meet the following requirements:
 
 If all the conditions are met, you can proceed with the following steps:
 
-1. Install PHP/Composer dependencies with **`docker-compose run app composer install`** (first time can take a while because the image has to be built).
-2. **Copy `.env.example` to `.env`** and change `APP_KEY` to a random 32 char string.
-3. Make sure **port 8080 is unused** *or else* change `DEV_PORT` to a free port on your host.
-4. **Run `chgrp -R docker storage`**. The development container will chown the `storage` directory to the `www-data` user inside the container so BookStack can write to it. You need to change the group to your host's `docker` group here to not lose access to the `storage` directory.
-5. **Run `docker-compose up`** and wait until all database migrations have been done.
-6. You can now login with `admin@admin.com` and `password` as password on `localhost:8080` (or another port if specified).
+1. **Copy `.env.example` to `.env`**, change `APP_KEY` to a random 32 char string and set `APP_ENV` to `local`.
+2. Make sure **port 8080 is unused** *or else* change `DEV_PORT` to a free port on your host.
+3. **Run `chgrp -R docker storage`**. The development container will chown the `storage` directory to the `www-data` user inside the container so BookStack can write to it. You need to change the group to your host's `docker` group here to not lose access to the `storage` directory.
+4. **Run `docker-compose up`** and wait until the image is built and all database migrations have been done.
+5. You can now login with `admin@admin.com` and `password` as password on `localhost:8080` (or another port if specified).
 
 If needed, You'll be able to run any artisan commands via docker-compose like so:
 


### PR DESCRIPTION
I think it is an unnecessary step to install composer dependencies manually when using the Docker development environment. NPM dependencies also get installed automatically so this is just one less thing to think of :)

I also noted that you need to set `APP_ENV` to `local` because database migrations won't run otherwise. (Command is skipped in production)