### PR TITLE
Allow users to create roles when creating users

### DIFF
--- a/resources/js/components/create-user-role.js
+++ b/resources/js/components/create-user-role.js
@@ -1,0 +1,24 @@
+class CreateUserRole {
+
+    constructor(elem) {
+        const toggle = elem.querySelector('input[name=create_user_role]')
+
+        if (toggle) {
+            toggle.addEventListener('change', () => {
+                const checked = toggle.value === 'true'
+                document.getElementById('create-user-role-input').style.display = checked
+                    ? 'block'
+                    : 'none'
+
+                if (checked) {
+                    const nameTextField = document.getElementById('name')
+                    if (nameTextField) {
+                        elem.querySelector('[name=user_role_name]').value = nameTextField.value
+                    }
+                }
+            })
+        }
+    }
+}
+
+export default CreateUserRole

--- a/resources/js/components/index.js
+++ b/resources/js/components/index.js
@@ -10,6 +10,7 @@ import chapterToggle from "./chapter-toggle.js"
 import codeEditor from "./code-editor.js"
 import codeHighlighter from "./code-highlighter.js"
 import collapsible from "./collapsible.js"
+import createUserRole from "./create-user-role"
 import customCheckbox from "./custom-checkbox.js"
 import detailsHighlighter from "./details-highlighter.js"
 import dropdown from "./dropdown.js"
@@ -63,6 +64,7 @@ const componentMapping = {
     "code-editor": codeEditor,
     "code-highlighter": codeHighlighter,
     "collapsible": collapsible,
+    "create-user-role": createUserRole,
     "custom-checkbox": customCheckbox,
     "details-highlighter": detailsHighlighter,
     "dropdown": dropdown,

--- a/resources/lang/de/settings.php
+++ b/resources/lang/de/settings.php
@@ -144,6 +144,7 @@ Hinweis: Benutzer können ihre E-Mail Adresse nach erfolgreicher Registrierung �
     'users_details_desc_no_email' => 'Legen Sie für diesen Benutzer einen Anzeigenamen fest, damit andere ihn erkennen können.',
     'users_role' => 'Benutzerrollen',
     'users_role_desc' => 'Wählen Sie aus, welchen Rollen dieser Benutzer zugeordnet werden soll. Wenn ein Benutzer mehreren Rollen zugeordnet ist, werden die Berechtigungen dieser Rollen gestapelt und er erhält alle Fähigkeiten der zugewiesenen Rollen.',
+    'users_role_create_user_role' => 'Neue Rolle für diesen Benutzer anlegen',
     'users_password' => 'Benutzerpasswort',
     'users_password_desc' => 'Legen Sie ein Passwort fest, mit dem Sie sich anmelden möchten. Diese muss mindestens 5 Zeichen lang sein.',
     'users_send_invite_text' => 'Sie können diesem Benutzer eine Einladungs-E-Mail senden, die es ihm erlaubt, sein eigenes Passwort zu setzen, andernfalls können Sie sein Passwort selbst setzen.',

--- a/resources/lang/de_informal/settings.php
+++ b/resources/lang/de_informal/settings.php
@@ -144,6 +144,7 @@ Hinweis: Benutzer können ihre E-Mail Adresse nach erfolgreicher Registrierung �
     'users_details_desc_no_email' => 'Legen Sie für diesen Benutzer einen Anzeigenamen fest, damit andere ihn erkennen können.',
     'users_role' => 'Benutzerrollen',
     'users_role_desc' => 'Wählen Sie aus, welchen Rollen dieser Benutzer zugeordnet werden soll. Wenn ein Benutzer mehreren Rollen zugeordnet ist, werden die Berechtigungen dieser Rollen gestapelt und er erhält alle Fähigkeiten der zugewiesenen Rollen.',
+    'users_role_create_user_role' => 'Neue Rolle für diesen Benutzer anlegen',
     'users_password' => 'Benutzerpasswort',
     'users_password_desc' => 'Legen Sie ein Passwort fest, mit dem Sie sich anmelden möchten. Diese muss mindestens 5 Zeichen lang sein.',
     'users_send_invite_text' => 'Du kannst diesem Benutzer eine Einladungs-E-Mail senden, die es ihm erlaubt, sein eigenes Passwort zu setzen, andernfalls kannst du sein Passwort selbst setzen.',

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -141,6 +141,7 @@ return [
     'users_details_desc_no_email' => 'Set a display name for this user so others can recognise them.',
     'users_role' => 'User Roles',
     'users_role_desc' => 'Select which roles this user will be assigned to. If a user is assigned to multiple roles the permissions from those roles will stack and they will receive all abilities of the assigned roles.',
+    'users_role_create_user_role' => 'Create new role for this user',
     'users_password' => 'User Password',
     'users_password_desc' => 'Set a password used to log-in to the application. This must be at least 6 characters long.',
     'users_send_invite_text' => 'You can choose to send this user an invitation email which allows them to set their own password otherwise you can set their password yourself.',

--- a/resources/views/users/form.blade.php
+++ b/resources/views/users/form.blade.php
@@ -44,6 +44,19 @@
         <div class="mt-m">
             @include('form.role-checkboxes', ['name' => 'roles', 'roles' => $roles])
         </div>
+        @if(!isset($model))
+            <div class="mt-m" create-user-role>
+                @include('components.toggle-switch', [
+                    'name' => 'create_user_role',
+                    'value' => false,
+                    'label' => trans('settings.users_role_create_user_role')
+                ])
+                <div id="create-user-role-input" style="display: none">
+                    <label for="user_role_name">{{ trans('settings.role_name') }}</label>
+                    @include('form.text', ['name' => 'user_role_name'])
+                </div>
+            </div>
+        @endif
     </div>
 @endif
 


### PR DESCRIPTION
I often create a new role for each user to have granular control over user permissions. This PR makes this easier by adding an option to create a new role on the fly while creating a new user:

![image](https://user-images.githubusercontent.com/8849554/94804277-d5da0d80-03ea-11eb-8aa0-c46e8a6cdc13.png)
