### PR TITLE
added custom page header and page count footers to export

### DIFF
--- a/resources/views/books/export.blade.php
+++ b/resources/views/books/export.blade.php
@@ -20,6 +20,8 @@
         ul.contents ul li {
             list-style: circle;
         }
+
+
         @media screen {
             .page-break {
                 border-top: 1px solid #DDD;
@@ -30,6 +32,9 @@
     @include('partials.custom-head')
 </head>
 <body>
+
+@include('partials.export-header-footer')
+
 
 <div class="page-content">
 

--- a/resources/views/chapters/export.blade.php
+++ b/resources/views/chapters/export.blade.php
@@ -23,6 +23,8 @@
 </head>
 <body>
 
+@include('partials.export-header-footer')
+
 <div class="page-content">
 
     <h1 style="font-size: 4.8em">{{$chapter->name}}</h1>

--- a/resources/views/pages/export.blade.php
+++ b/resources/views/pages/export.blade.php
@@ -33,6 +33,8 @@
 </head>
 <body>
 
+@include('partials.export-header-footer')
+
 <div id="page-show">
     <div class="page-content">
 

--- a/resources/views/partials/export-header-footer.blade.php
+++ b/resources/views/partials/export-header-footer.blade.php
@@ -1,0 +1,27 @@
+{{--
+
+    Fills in the header and footers styled in partials/export-styles.blade.php
+
+    Relies on the following in .env
+
+    EXPORT_HEADER_PAGE_SLUG=header
+    EXPORT_SHOW_PAGE_NUMBERS=true
+
+--}}
+
+
+@if(env("EXPORT_HEADER_PAGE_SLUG"))
+<div class="header">
+    @php
+        $PAGE = new \BookStack\Entities\Page();
+        $page = $PAGE::where("slug", "=", env("EXPORT_HEADER_PAGE_SLUG"))->first();
+        $page->html = (new \BookStack\Entities\Managers\PageContent($page))->render();
+    @endphp
+    {!! $page->html !!}
+</div>
+@endif
+@if(env('EXPORT_SHOW_PAGE_NUMBERS'))
+<div class="footer">
+    Page <span class="pagenum"></span>
+</div>
+@endif

--- a/resources/views/partials/export-styles.blade.php
+++ b/resources/views/partials/export-styles.blade.php
@@ -2,6 +2,23 @@
     @if (!app()->environment('testing'))
         {!! file_get_contents(public_path('/dist/export-styles.css')) !!}
     @endif
+
+        .header,
+        .footer {
+            width: 100%;
+            text-align: center;
+            position: fixed;
+        }
+        .header {
+            top: 0px;
+        }
+        .footer {
+            bottom: 0px;
+        }
+        .pagenum:before {
+            content: counter(page);
+        }
+
 </style>
 
 @if ($format === 'pdf')


### PR DESCRIPTION
#493 

[submitting as a PR for visibility/feedback]

Hey @ssddanbrown - I've pushed a branch ( https://github.com/injektion/BookStack/tree/exportheaders ) which might help with this... For exports, it'll display a page number in the footer and allow users to create a page to include as a header on every page.

Most of the juice is in partials/export-header-footer.blade.php which is now included in all the /views/[books|chapters|pages]/export.blade.php and checks for a couple .env variables

```
EXPORT_HEADER_PAGE_SLUG=header
EXPORT_SHOW_PAGE_NUMBERS=true
```

There's some extra CSS added to partials/export-styles.blade.php which sets up a counter for pages, and if the .env is true will drop it into a footer div

```
        .pagenum:before {
            content: counter(page);
        }

```
As for the header, I'm currently letting the user define a page as their header, and then in partials/export-header-footer.blade.php using the slug of that page to import a header....

```
@if(env("EXPORT_HEADER_PAGE_SLUG"))
<div class="header">
    @php
        $PAGE = new \BookStack\Entities\Page();
        $page = $PAGE::where("slug", "=", env("EXPORT_HEADER_PAGE_SLUG"))->first();
        $page->html = (new \BookStack\Entities\Managers\PageContent($page))->render();
    @endphp
    {!! $page->html !!}
</div>
@endif
```

It's working fine to allow the user to create their own headers, add some page numbering, and export, but I think there's probably a better flow to how to get the user to define the page to use as their header (configuration page?)... Do you have any recommendations on where you'd like to see the header get defined, or do you think this will work for those who want it?  Additional features or configurations you'd need to include this?