### PR TITLE
Import thumbnail photos when LDAP users are created.

### DIFF
--- a/app/Auth/Access/Guards/LdapSessionGuard.php
+++ b/app/Auth/Access/Guards/LdapSessionGuard.php
@@ -117,7 +117,17 @@ class LdapSessionGuard extends ExternalBaseSessionGuard
             'password' => Str::random(32),
         ];
 
-        return $this->registrationService->registerUser($details, null, false);
+        $user = $this->registrationService->registerUser($details, null, false);
+
+        if (config('services.ldap.import_thumbnail_photos')) {
+            $imageService = app()->make(ImageService::class);
+            $image = $imageService->saveNewFromBase64Uri('data:image/jpg;base64,'.base64_encode($ldapUserDetails['avatar']), $ldapUserDetails['uid'].'.jpg', 'user');
+
+            $user['image_id'] = $image->id;
+            $user->save();
+        }
+
+        return $user;
     }
 
 }

--- a/app/Auth/Access/LdapService.php
+++ b/app/Auth/Access/LdapService.php
@@ -76,6 +76,7 @@ class LdapService extends ExternalAuthService
         $idAttr = $this->config['id_attribute'];
         $emailAttr = $this->config['email_attribute'];
         $displayNameAttr = $this->config['display_name_attribute'];
+        $thumbnailAttr = $this->config['thumbnail_attribute'];
 
         $user = $this->getUserWithAttributes($userName, ['cn', 'dn', $idAttr, $emailAttr, $displayNameAttr]);
 

--- a/app/Auth/Access/LdapService.php
+++ b/app/Auth/Access/LdapService.php
@@ -89,6 +89,7 @@ class LdapService extends ExternalAuthService
             'name'  => $this->getUserResponseProperty($user, $displayNameAttr, $userCn),
             'dn'    => $user['dn'],
             'email' => $this->getUserResponseProperty($user, $emailAttr, null),
+            'avatar'=> $this->getUserResponseProperty($user, $thumbnailAttr, null),
         ];
 
         if ($this->config['dump_user_details']) {

--- a/app/Config/services.php
+++ b/app/Config/services.php
@@ -132,6 +132,8 @@ return [
         'group_attribute' => env('LDAP_GROUP_ATTRIBUTE', 'memberOf'),
         'remove_from_groups' => env('LDAP_REMOVE_FROM_GROUPS', false),
         'tls_insecure' => env('LDAP_TLS_INSECURE', false),
+        'import_thumbnail_photos' => env('LDAP_IMPORT_THUMBNAIL_PHOTOS', false),
+        'thumbnail_attribute' => env('LDAP_THUMBNAIL_ATTRIBUTE', 'thumbnailPhoto'),
     ],
 
 ];


### PR DESCRIPTION
My BookStack instance is using Active Directory for authentication. We wanted to be able to automatically import the user photos that we already have stored in Active Directory.

This change, controlled by config values in the config/services.php file, allows for user avatars to be imported from the LDAP thumbnailPhoto attribute. Users can still update their images from the profile page.