### PR TITLE
Fix issue with viewing export dropdown list

### DIFF
--- a/resources/sass/_layout.scss
+++ b/resources/sass/_layout.scss
@@ -272,6 +272,7 @@ body.flexbox {
     min-height: 50vh;
     overflow-y: scroll;
     overflow-x: hidden;
+    height: 100%;
     scrollbar-width: none;
     -ms-overflow-style: none;
     &::-webkit-scrollbar {
@@ -281,9 +282,6 @@ body.flexbox {
   .tri-layout-middle-contents {
     max-width: 940px;
     margin: 0 auto;
-  }
-  .tri-layout-right-contents {
-    height: 1000px;
   }
 }
 

--- a/resources/sass/_layout.scss
+++ b/resources/sass/_layout.scss
@@ -282,6 +282,9 @@ body.flexbox {
     max-width: 940px;
     margin: 0 auto;
   }
+  .tri-layout-right-contents {
+    height: 1000px;
+  }
 }
 
 @include smaller-than($l) {


### PR DESCRIPTION
There is issue with viewing all the export list.

Step to reproduce the issue:
1. Login to bookstack.
2. Open any book or page.
3. Click on export.
4. There are three list in the dropdown but only two can be visible third one is hidden.
