### PR TITLE
Made `ApiController` non-abstract

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -5,7 +5,7 @@ use BookStack\Http\Controllers\Controller;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 
-abstract class ApiController extends Controller
+class ApiController extends Controller
 {
 
     protected $rules = [];


### PR DESCRIPTION
This fixes `php artisan route:list` (controllers can't be abstract because then they're not instantiable)
I haven't tested the full API functionality, as I don't use this (yet). I don't think this will cause any problems though.