### PR TITLE
Show tags of all search results

### DIFF
--- a/resources/sass/_blocks.scss
+++ b/resources/sass/_blocks.scss
@@ -227,7 +227,7 @@
   border: 1px solid #CCC;
   overflow: hidden;
   font-size: 0.85em;
-  a, a:hover, a:active {
+  a, span, a:hover, a:active {
     padding: 4px 8px;
     @include lightDark(color, #777, #999);
     transition: background-color ease-in-out 80ms;

--- a/resources/views/components/tag-list.blade.php
+++ b/resources/views/components/tag-list.blade.php
@@ -1,6 +1,11 @@
 @foreach($entity->tags as $tag)
     <div class="tag-item primary-background-light">
-        <div class="tag-name"><a href="{{ url('/search?term=%5B' . urlencode($tag->name) .'%5D') }}">@icon('tag'){{ $tag->name }}</a></div>
-        @if($tag->value) <div class="tag-value"><a href="{{ url('/search?term=%5B' . urlencode($tag->name) .'%3D' . urlencode($tag->value) . '%5D') }}">{{$tag->value}}</a></div> @endif
+        @if($disableLinks ?? false)
+            <div class="tag-name"><span>@icon('tag'){{ $tag->name }}</span></div>
+            @if($tag->value) <div class="tag-value"><span>{{$tag->value}}</span></div> @endif
+        @else
+            <div class="tag-name"><a href="{{ url('/search?term=%5B' . urlencode($tag->name) .'%5D') }}">@icon('tag'){{ $tag->name }}</a></div>
+            @if($tag->value) <div class="tag-value"><a href="{{ url('/search?term=%5B' . urlencode($tag->name) .'%3D' . urlencode($tag->value) . '%5D') }}">{{$tag->value}}</a></div> @endif
+        @endif
     </div>
 @endforeach

--- a/resources/views/partials/entity-list-item-basic.blade.php
+++ b/resources/views/partials/entity-list-item-basic.blade.php
@@ -2,6 +2,9 @@
 <a href="{{ $entity->getUrl() }}" class="{{$type}} {{$type === 'page' && $entity->draft ? 'draft' : ''}} {{$classes ?? ''}} entity-list-item" data-entity-type="{{$type}}" data-entity-id="{{$entity->id}}">
     <span role="presentation" class="icon text-{{$type}}">@icon($type)</span>
     <div class="content">
+            @if($entity->tags->count() > 0 and $showTags ?? false)
+                    @include('components.tag-list', ['entity' => $entity, 'disableLinks' => True ])
+            @endif
             <h4 class="entity-list-item-name break-text">{{ $entity->name }}</h4>
             {{ $slot ?? '' }}
     </div>

--- a/resources/views/partials/entity-list-item.blade.php
+++ b/resources/views/partials/entity-list-item.blade.php
@@ -1,4 +1,4 @@
-@component('partials.entity-list-item-basic', ['entity' => $entity])
+@component('partials.entity-list-item-basic', ['entity' => $entity, 'showTags' => $showTags])
 <div class="entity-item-snippet">
 
     @if($showPath ?? false)

--- a/resources/views/partials/entity-list.blade.php
+++ b/resources/views/partials/entity-list.blade.php
@@ -1,7 +1,7 @@
 @if(count($entities) > 0)
     <div class="entity-list {{ $style ?? '' }}">
         @foreach($entities as $index => $entity)
-            @include('partials.entity-list-item', ['entity' => $entity, 'showPath' => $showPath ?? false])
+            @include('partials.entity-list-item', ['entity' => $entity, 'showPath' => $showPath ?? false, 'showTags' => $showTags ?? false])
         @endforeach
     </div>
 @else

--- a/resources/views/search/all.blade.php
+++ b/resources/views/search/all.blade.php
@@ -74,7 +74,7 @@
 
                     <h6 class="text-muted">{{ trans_choice('entities.search_total_results_found', $totalResults, ['count' => $totalResults]) }}</h6>
                     <div class="book-contents">
-                        @include('partials.entity-list', ['entities' => $entities, 'showPath' => true])
+                        @include('partials.entity-list', ['entities' => $entities, 'showPath' => true, 'showTags' => true])
                     </div>
 
                     @if($hasNextPage)


### PR DESCRIPTION
This is a basic implementation of #2462.

It's rather similar to the `$showPath` property that you can attach to any `entity-list`. Now there's another property called `$showTags` that adds all tags to the list items. I've only enabled it for the search results page, but this might come in handy in other circumstances too.

Obviously the search results link to the corresponding shelf/book/chapter/page, but the tags also contain links. This is an issue since nesting `<a>` elements is not allowed. To avoid this I've added a `$disableLinks` property to `tag-list`, which replaces the tag links with `<span>` elements.