### PR TITLE
Allow image filename has more than one dot (".")

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -159,6 +159,6 @@ abstract class Controller extends BaseController
      */
     protected function getImageValidationRules(): string
     {
-        return 'image_extension|no_double_extension|mimes:jpeg,png,gif,webp';
+        return 'image_extension|mimes:jpeg,png,gif,webp';
     }
 }


### PR DESCRIPTION
I found an image validator in `Controller.php`. The rule denied double filename extension (filename which has more then one ".").

This patch should resolve #2306 and #2217. 