### PR TITLE
Docker: Fix permission with node service by adding node as user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
   node:
     image: node:alpine
     working_dir: /app
+    user: node
     volumes:
       - ./:/app
     entrypoint: /app/dev/docker/entrypoint.node.sh


### PR DESCRIPTION
See: https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user

Fixes the following error:

glob error:
[Error: EACCES: permission denied, scandir '/root/.npm/_logs'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'scandir',
  path: '/root/.npm/_logs'
}