### PR TITLE
Add prev and next button to navigate through different pages

### DIFF
--- a/app/Entities/Models/Page.php
+++ b/app/Entities/Models/Page.php
@@ -126,4 +126,13 @@ class Page extends BookChild
         $refreshed->html = (new PageContent($refreshed))->render();
         return $refreshed;
     }
+    /**
+     * Get the parent chapter ID.
+     */
+    public function getParentChapter()
+    {
+        $chapterId = $this->chapter()->visible()
+        ->get('id');
+        return $chapterId;
+    }
 }

--- a/app/Entities/Repos/PageRepo.php
+++ b/app/Entities/Repos/PageRepo.php
@@ -467,4 +467,10 @@ class PageRepo
             ->where('page_id', '=', $page->id)
             ->orderBy('created_at', 'desc');
     }
+    /**
+     * Get page details by chapter ID.
+     */
+    public function getPageByChapterID(int $id){
+        return Page::visible()->where('chapter_id', '=', $id)->get(['id','slug']);
+    }
 }

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -142,6 +142,38 @@ class PageController extends Controller
             $page->load(['comments.createdBy']);
         }
 
+        $chapterId = $page->getParentChapter();
+        $allPageSlugs = $this->pageRepo->getPageByChapterID($chapterId[0]->id);
+        $pos = 0;
+        foreach ($allPageSlugs as $slug){
+            if($pageSlug === $slug->slug){
+                $currPagePos = $pos;
+            }
+            $pos++;
+            $pageUrl = $this->pageRepo->getBySlug($bookSlug, $slug->slug);
+            $urlLink[] = $pageUrl->getUrl();
+        }
+        for($i=0; $i <= $currPagePos; $i++){
+            $nextCount = $i+1;
+            $prevCount = $i-1;
+            $prevPage = '#';
+            $nextPage = '#';
+            if($nextCount < count($urlLink)){
+                $nextPage = $urlLink[$nextCount];
+            }
+            if($currPagePos == $i && $currPagePos != 0){
+                $prevPage = $urlLink[$prevCount];    
+            }
+        }
+
+        $disablePrev = "";
+        $disableNxt = "";
+        if($prevPage == "#"){
+            $disablePrev = "disabled";
+        }
+        if($nextPage == "#"){
+            $disableNxt = "disabled";
+        }
         Views::add($page);
         $this->setPageTitle($page->getShortName());
         return view('pages.show', [
@@ -150,7 +182,11 @@ class PageController extends Controller
             'current' => $page,
             'sidebarTree' => $sidebarTree,
             'commentsEnabled' => $commentsEnabled,
-            'pageNav' => $pageNav
+            'pageNav' => $pageNav,
+            'prevPage' => $prevPage,
+            'nextPage' => $nextPage,
+            'disablePrev' => $disablePrev,
+            'disableNxt' => $disableNxt
         ]);
     }
 

--- a/resources/sass/_layout.scss
+++ b/resources/sass/_layout.scss
@@ -62,6 +62,9 @@
 }
 
 @include smaller-than($m) {
+  .grid.third.prev-next:not(.no-break) {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
   .grid.third:not(.no-break) {
     grid-template-columns: 1fr 1fr;
   }
@@ -81,11 +84,23 @@
   .grid.right-focus.reverse-collapse > *:nth-child(1) {
     order: 1;
   }
+  .grid.third:not(.no-break) .text-m-left {
+    margin-left: 20%;
+  }
+  .grid.third:not(.no-break) .text-m-right {
+    margin-left: 45%;
+  }
 }
 
 @include smaller-than($s) {
   .grid.third:not(.no-break) {
     grid-template-columns: 1fr;
+  }
+  .grid.third:not(.no-break) .text-m-left {
+    margin-left: 18%;
+  }
+  .grid.third:not(.no-break) .text-m-right {
+    margin-left: 20%;
   }
 }
 
@@ -358,4 +373,8 @@ body.flexbox {
     margin-inline-start: 0;
     margin-inline-end: 0;
   }
+}
+
+.prev-next-btn {
+  height: 50px;
 }

--- a/resources/sass/_text.scss
+++ b/resources/sass/_text.scss
@@ -112,6 +112,12 @@ a {
   }
 }
 
+a.disabled {
+  pointer-events: none;
+  cursor: default;
+  opacity: 0.6;
+}
+
 .blended-links a {
   color: inherit;
   svg {

--- a/resources/views/pages/show.blade.php
+++ b/resources/views/pages/show.blade.php
@@ -16,6 +16,18 @@
             @include('pages.page-display')
         </div>
     </main>
+       
+    <div class="prev-next-btn">
+        <div class="grid third no-row-gap prev-next">
+            <div class="text-m-left">
+                <a class="{{ $disablePrev }}" href="{{ $prevPage }}">Previous Page</a>
+            </div>
+            <div></div>
+            <div class="text-m-right">
+                <a class="{{ $disableNxt }}" href="{{ $nextPage }}">Next Page</a>
+            </div>
+        </div>
+    </div>
 
     @if ($commentsEnabled)
         <div class="container small p-none comments-container mb-l print-hidden">


### PR DESCRIPTION
- Added feature to navigate through the different pages.
- This will help the user to navigate through different pages without scrolling above and clicking on the page.
- User can directly switch to the next page from the bottom of the page.
- This feature will be more helpful if the user using mobile/tab then, the user doesn't have to switch to the info tab from the content tab to view the next page.
![bookstack1](https://user-images.githubusercontent.com/57482557/105949293-789d5280-6092-11eb-88a5-ca60decc14d0.png)

- After the implementation of this feature user can view the next or previous page without switching to the info tab from the content tab.

![bookstack2](https://user-images.githubusercontent.com/57482557/105949307-7dfa9d00-6092-11eb-8ef6-203df23b39d2.png)

Prev and Next button functionality can be seen in the attached video below:

https://user-images.githubusercontent.com/57482557/105948778-98804680-6091-11eb-9eff-893d7b3482e6.mp4
