### PR TITLE
Docker: Fix PHP tests 

### DIFF
--- a/app/Config/database.php
+++ b/app/Config/database.php
@@ -81,10 +81,11 @@ return [
         'mysql_testing' => [
             'driver'    => 'mysql',
             'url' => env('TEST_DATABASE_URL'),
-            'host'      => '127.0.0.1',
+            'host'      => $mysql_host,
             'database'  => 'bookstack-test',
             'username'  => env('MYSQL_USER', 'bookstack-test'),
             'password'  => env('MYSQL_PASSWORD', 'bookstack-test'),
+            'port'      => $mysql_port,
             'charset'   => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
             'prefix'    => '',

--- a/dev/docker/entrypoint.app.sh
+++ b/dev/docker/entrypoint.app.sh
@@ -10,6 +10,7 @@ else
     composer install
     wait-for-it db:3306 -t 45
     php artisan migrate --database=mysql
+    php artisan migrate --database=mysql_testing
     chown -R www-data:www-data storage
     exec apache2-foreground
 fi

--- a/dev/docker/init.db/01.sql
+++ b/dev/docker/init.db/01.sql
@@ -1,0 +1,5 @@
+# create test database
+CREATE DATABASE IF NOT EXISTS `bookstack-test`;
+
+# grant rights
+GRANT ALL PRIVILEGES ON `bookstack-test`.* TO 'bookstack-test'@'%';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,13 @@ services:
   db:
     image: mysql:8
     environment:
-      MYSQL_DATABASE: bookstack-test
+      MYSQL_DATABASE: bookstack-dev
       MYSQL_USER: bookstack-test
       MYSQL_PASSWORD: bookstack-test
       MYSQL_RANDOM_ROOT_PASSWORD: 'true'
     command: --default-authentication-plugin=mysql_native_password
     volumes:
+      - ./dev/docker/init.db:/docker-entrypoint-initdb.d
       - db:/var/lib/mysql
   app:
     build:
@@ -25,7 +26,7 @@ services:
       DB_CONNECTION: mysql
       DB_HOST: db
       DB_PORT: 3306
-      DB_DATABASE: bookstack-test
+      DB_DATABASE: bookstack-dev
       DB_USERNAME: bookstack-test
       DB_PASSWORD: bookstack-test
       MAIL_DRIVER: smtp

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,7 +19,7 @@
         </whitelist>
     </filter>
     <php>
-        <server name="APP_ENV" value="testing"/>
+        <env name="APP_ENV" value="testing" force="true"/>
         <server name="APP_DEBUG" value="false"/>
         <server name="APP_LANG" value="en"/>
         <server name="APP_THEME" value="none"/>
@@ -29,7 +29,7 @@
         <server name="CACHE_DRIVER" value="array"/>
         <server name="SESSION_DRIVER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
-        <server name="DB_CONNECTION" value="mysql_testing"/>
+        <env name="DB_CONNECTION" value="mysql_testing" force="true"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="MAIL_DRIVER" value="array"/>
         <server name="LOG_CHANNEL" value="single"/>
@@ -56,5 +56,6 @@
         <server name="LOG_FAILED_LOGIN_MESSAGE" value=""/>
         <server name="LOG_FAILED_LOGIN_CHANNEL" value="testing"/>
         <server name="WKHTMLTOPDF" value="false"/>
+        <ini name="memory_limit" value="1024M"/>
     </php>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Below is a high-level road map view for BookStack to provide a sense of directio
 
 BookStack releases are each assigned a version number, such as "v0.25.2", in the format `v<phase>.<feature>.<patch>`. A change only in the `patch` number indicates a fairly minor release that mainly contains fixes and therefore is very unlikely to cause breakages upon update. A change in the `feature` number indicates a release which will generally bring new features in addition to fixes and enhancements. These releases have a small chance of introducing breaking changes upon update so it's worth checking for any notes in the [update guide](https://www.bookstackapp.com/docs/admin/updates/). A change in the `phase` indicates a much large change in BookStack that will likely incur breakages requiring manual intervention.
 
-Each BookStack release will have a [milestone](https://github.com/BookStackApp/BookStack/milestones) created with issues & pull requests assigned to it to define what will be in that release. Milestones are built up then worked through until complete at which point, after some testing and documentation updates, the release will be deployed. 
+Each BookStack release will have a [milestone](https://github.com/BookStackApp/BookStack/milestones) created with issues & pull requests assigned to it to define what will be in that release. Milestones are built up then worked through until complete at which point, after some testing and documentation updates, the release will be deployed.
 
 For feature releases, and some patch releases, the release will be accompanied by a post on the [BookStack blog](https://www.bookstackapp.com/blog/) which will provide additional detail on features, changes & updates otherwise the [GitHub release page](https://github.com/BookStackApp/BookStack/releases) will show a list of changes. You can sign up to be alerted to new BookStack blogs posts (once per week maximum) [at this link](https://updates.bookstackapp.com/signup/bookstack-news-and-updates).
 
@@ -96,13 +96,14 @@ If all the conditions are met, you can proceed with the following steps:
 1. **Copy `.env.example` to `.env`**, change `APP_KEY` to a random 32 char string and set `APP_ENV` to `local`.
 2. Make sure **port 8080 is unused** *or else* change `DEV_PORT` to a free port on your host.
 3. **Run `chgrp -R docker storage`**. The development container will chown the `storage` directory to the `www-data` user inside the container so BookStack can write to it. You need to change the group to your host's `docker` group here to not lose access to the `storage` directory.
-4. **Run `docker-compose up`** and wait until the image is built and all database migrations have been done.
-5. You can now login with `admin@admin.com` and `password` as password on `localhost:8080` (or another port if specified).
+4. **Run `echo -e "\n\nDOCKER_UID=$(id -u)" >> .env && echo "DOCKER_GID=$(id -g)" >> .env`** to add your UID/GID to the `.env` file. This is then used to set permissions inside the docker. This is necessary if you are working on Linux.
+5. **Run `docker-compose up`** and wait until the image is built and all database migrations have been done.
+6. You can now login with `admin@admin.com` and `password` as password on `localhost:8080` (or another port if specified).
 
 If needed, You'll be able to run any artisan commands via docker-compose like so:
 
  ```shell script
-docker-compose run app php artisan list 
+docker-compose run app php artisan list
 ```
 
 The docker-compose setup runs an instance of [MailHog](https://github.com/mailhog/MailHog) and sets environment variables to redirect any BookStack-sent emails to MailHog. You can view this mail via the MailHog web interface on `localhost:8025`. You can change the port MailHog is accessible on by setting a `DEV_MAIL_PORT` environment variable.

--- a/readme.md
+++ b/readme.md
@@ -96,18 +96,29 @@ If all the conditions are met, you can proceed with the following steps:
 1. **Copy `.env.example` to `.env`**, change `APP_KEY` to a random 32 char string and set `APP_ENV` to `local`.
 2. Make sure **port 8080 is unused** *or else* change `DEV_PORT` to a free port on your host.
 3. **Run `chgrp -R docker storage`**. The development container will chown the `storage` directory to the `www-data` user inside the container so BookStack can write to it. You need to change the group to your host's `docker` group here to not lose access to the `storage` directory.
-4. **Run `echo -e "\n\nDOCKER_UID=$(id -u)" >> .env && echo "DOCKER_GID=$(id -g)" >> .env`** to add your UID/GID to the `.env` file. This is then used to set permissions inside the docker. This is necessary if you are working on Linux.
-5. **Run `docker-compose up`** and wait until the image is built and all database migrations have been done.
-6. You can now login with `admin@admin.com` and `password` as password on `localhost:8080` (or another port if specified).
+4. **Run `docker-compose up`** and wait until the image is built and all database migrations have been done.
+5. You can now login with `admin@admin.com` and `password` as password on `localhost:8080` (or another port if specified).
 
 If needed, You'll be able to run any artisan commands via docker-compose like so:
 
- ```shell script
+```shell script
 docker-compose run app php artisan list
 ```
 
 The docker-compose setup runs an instance of [MailHog](https://github.com/mailhog/MailHog) and sets environment variables to redirect any BookStack-sent emails to MailHog. You can view this mail via the MailHog web interface on `localhost:8025`. You can change the port MailHog is accessible on by setting a `DEV_MAIL_PORT` environment variable.
 
+#### Running tests
+
+After starting the general development Docker, seed the testing database:
+ ```shell script
+# this is to be done only once
+docker-compose run app php artisan db:seed --class=DummyContentSeeder --database=mysql_testing
+```
+
+Once the database has been seeded, you can run the tests by:
+ ```shell script
+docker-compose run app php vendor/bin/phpunit
+```
 ## 🌎 Translations
 
 Translations for text within BookStack is managed through the [BookStack project on Crowdin](https://crowdin.com/project/bookstack). Some strings have colon-prefixed variables in such as `:userName`. Leave these values as they are as they will be replaced at run-time. Crowdin is the preferred way to provide translations, otherwise the raw translations files can be found within the `resources/lang` path.


### PR DESCRIPTION
This creates another mysql_testing database during db service setup

Replace server with env tags in phpunit.xml in order to force
override certain parameters when tests are run. See:
sebastianbergmann/phpunit#2353 for more
information.

Rename primary developer Docker database from bookstack-test to
bookstack-dev. bookstack-test is used as the mysql_testing database