### PR TITLE
Add Pandoc to API

### DIFF
--- a/app/Entities/Tools/ExportFormatter.php
+++ b/app/Entities/Tools/ExportFormatter.php
@@ -71,6 +71,54 @@ class ExportFormatter
     }
 
     /**
+     * Convert a page to a plain HTML file with original HREFs.
+     * Includes required CSS.
+     * @throws Throwable
+     */
+    public function pageToHtml(Page $page)
+    {
+        $page->html = (new PageContent($page))->render();
+        $pageHtml = view('pages.export', [
+            'page' => $page,
+            'format' => 'html',
+        ])->render();
+        return $pageHtml;
+    }
+
+    /**
+     * Convert a chapter to a plain HTML file with original HREFs.
+     * @throws Throwable
+     */
+    public function chapterToHtml(Chapter $chapter)
+    {
+        $pages = $chapter->getVisiblePages();
+        $pages->each(function ($page) {
+            $page->html = (new PageContent($page))->render();
+        });
+        $html = view('chapters.export', [
+            'chapter' => $chapter,
+            'pages' => $pages,
+            'format' => 'html',
+        ])->render();
+        return $html;
+    }
+
+    /**
+     * Convert a book to a plain HTML file with original HREFs.
+     * @throws Throwable
+     */
+    public function bookToHtml(Book $book)
+    {
+        $bookTree = (new BookContents($book))->getTree(false, true);
+        $html = view('books.export', [
+            'book' => $book,
+            'bookChildren' => $bookTree,
+            'format' => 'html',
+        ])->render();
+        return $html;
+    }
+
+    /**
      * Convert a page to a PDF file.
      * @throws Throwable
      */

--- a/app/Http/Controllers/Api/BookExportApiController.php
+++ b/app/Http/Controllers/Api/BookExportApiController.php
@@ -36,6 +36,17 @@ class BookExportApiController extends ApiController
     }
 
     /**
+     * Export a book as a plain HTML file with original HREFs.
+     * @throws Throwable
+     */
+    public function exportPlainHtml(int $id)
+    {
+        $book = Book::visible()->findOrFail($id);
+        $htmlContent = $this->exportFormatter->bookToHtml($book);
+        return $this->downloadResponse($htmlContent, $book->slug . '.html');
+    }
+
+    /**
      * Export a book as a plain text file.
      */
     public function exportPlainText(int $id)

--- a/app/Http/Controllers/Api/ChapterExportApiController.php
+++ b/app/Http/Controllers/Api/ChapterExportApiController.php
@@ -40,6 +40,17 @@ class ChapterExportApiController extends ApiController
     }
 
     /**
+     * Export a chapter as a plain HTML file with original HREFs.
+     * @throws Throwable
+     */
+    public function exportPlainHtml(int $id)
+    {
+        $chapter = Chapter::visible()->findOrFail($id);
+        $htmlContent = $this->exportFormatter->chapterToHtml($chapter);
+        return $this->downloadResponse($htmlContent, $chapter->slug . '.html');
+    }
+
+    /**
      * Export a chapter as a plain text file.
      */
     public function exportPlainText(int $id)

--- a/app/Http/Controllers/Api/PageExportApiController.php
+++ b/app/Http/Controllers/Api/PageExportApiController.php
@@ -36,6 +36,17 @@ class PageExportApiController extends ApiController
     }
 
     /**
+     * Export a page as a plain HTML file with original HREFs.
+     * @throws Throwable
+     */
+    public function exportPlainHtml(int $id)
+    {
+        $page = Page::visible()->findOrFail($id);
+        $htmlContent = $this->exportFormatter->pageToHtml($page);
+        return $this->downloadResponse($htmlContent, $page->slug . '.html');
+    }
+
+    /**
      * Export a page as a plain text file.
      */
     public function exportPlainText(int $id)

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ Route::put('books/{id}', 'BookApiController@update');
 Route::delete('books/{id}', 'BookApiController@delete');
 
 Route::get('books/{id}/export/html', 'BookExportApiController@exportHtml');
+Route::get('books/{id}/export/plainhtml', 'BookExportApiController@exportPlainHtml');
 Route::get('books/{id}/export/pdf', 'BookExportApiController@exportPdf');
 Route::get('books/{id}/export/plaintext', 'BookExportApiController@exportPlainText');
 
@@ -26,6 +27,7 @@ Route::put('chapters/{id}', 'ChapterApiController@update');
 Route::delete('chapters/{id}', 'ChapterApiController@delete');
 
 Route::get('chapters/{id}/export/html', 'ChapterExportApiController@exportHtml');
+Route::get('chapters/{id}/export/plainhtml', 'ChapterExportApiController@exportPlainHtml');
 Route::get('chapters/{id}/export/pdf', 'ChapterExportApiController@exportPdf');
 Route::get('chapters/{id}/export/plaintext', 'ChapterExportApiController@exportPlainText');
 
@@ -36,6 +38,7 @@ Route::put('pages/{id}', 'PageApiController@update');
 Route::delete('pages/{id}', 'PageApiController@delete');
 
 Route::get('pages/{id}/export/html', 'PageExportApiController@exportHtml');
+Route::get('pages/{id}/export/plainhtml', 'PageExportApiController@exportPlainHtml');
 Route::get('pages/{id}/export/pdf', 'PageExportApiController@exportPdf');
 Route::get('pages/{id}/export/plaintext', 'PageExportApiController@exportPlainText');
 


### PR DESCRIPTION
This is a proposed endpoint to resolve: https://github.com/BookStackApp/BookStack/issues/2491

As can be seen from the conversation in that thread, adding more complex means of exporting HTML (i.e. via Pandoc or other third party means) may be complex to integrate and to maintain. 

Instead, this API endpoint provides the HTML file with its original HREFs that point back to the server hosting BookStack. It provides a much lighter weight file due to images not being encoded into the file, and provides users more options to build on BookStack with their own third party solutions to processing exported content than can be achieved with contained HTML.

My personal use case, as an example, will be to then process this output via Pandoc or WGET to generate an offline version which I have more control over the formats/content/sizes. It will also allow me greater control over extracting embedded videos. 

Note: This is for discussion over whether it would be merged. The following further commits are required at a minimum before ready:

- [x] Integrate the new endpoint in to the API docs (appears to auto generate them, haven't identified how yet).
- [ ] Consider the endpoint names. My suggestion would be to rename the current exportHtml (which is the original contained HTML endpoint) to `exportContainedHtml` and then have this new endpoint as `exportHtml`.

Would be helpful hear whether this is within the scope of the project before putting in these other changes.  

I would welcome edits from maintainers directly into the repo if you so desire. 