### PR TITLE
Introduce an env variable for the session cookie path

### DIFF
--- a/.env.example.complete
+++ b/.env.example.complete
@@ -73,6 +73,7 @@ SESSION_DRIVER=file
 # Session configuration
 SESSION_LIFETIME=120
 SESSION_COOKIE_NAME=bookstack_session
+SESSION_COOKIE_PATH=/
 SESSION_SECURE_COOKIE=false
 
 # Cache key prefix

--- a/app/Config/session.php
+++ b/app/Config/session.php
@@ -59,7 +59,7 @@ return [
     // The session cookie path determines the path for which the cookie will
     // be regarded as available. Typically, this will be the root path of
     // your application but you are free to change this when necessary.
-    'path' => '/',
+    'path' => env('SESSION_COOKIE_PATH', '/'),
 
     // Session Cookie Domain
     // Here you may change the domain of the cookie used to identify a session


### PR DESCRIPTION
The session cookie path parameter can not configured by an env file. There are scenarios where you want to set the cookie path e.g. multi App Setups under the same domain. With this PR a new env variable ```SESSION_COOKIE_PATH``` is introduced. 