### PR TITLE
Fixing default config lookup for bookshelves_view_type in BookshelfController

### DIFF
--- a/app/Http/Controllers/BookshelfController.php
+++ b/app/Http/Controllers/BookshelfController.php
@@ -103,7 +103,7 @@ class BookshelfController extends Controller
 
         Views::add($shelf);
         $this->entityContextManager->setShelfContext($shelf->id);
-        $view = setting()->getForCurrentUser('bookshelf_view_type');
+        $view = setting()->getForCurrentUser('bookshelves_view_type');
 
         $this->setPageTitle($shelf->getShortName());
         return view('shelves.show', [

--- a/tests/User/UserProfileTest.php
+++ b/tests/User/UserProfileTest.php
@@ -126,7 +126,7 @@ class UserProfileTest extends BrowserKitTest
     {
         $editor = $this->getEditor();
         $shelf = Bookshelf::query()->first();
-        setting()->putUser($editor, 'bookshelf_view_type', 'list');
+        setting()->putUser($editor, 'bookshelves_view_type', 'list');
 
         $this->actingAs($editor)->visit($shelf->getUrl())
             ->pageNotHasElement('.featured-image-container')


### PR DESCRIPTION
A wrong setting key (`bookshelf_view_type`) was used. So the configured default in `.env` was not used. This PR fixes this issue.

How to reproduce:

- Set `APP_VIEWS_BOOKSHELVES=list` in `.env` File
- Use a new user and open a random bookshelf (/shelves/{slug})

Expected: See books as list.

What actually happens: Default grid view is shown.