### PR TITLE
Including parent information in recycle bin

### DIFF
--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -92,6 +92,7 @@ return [
     'recycle_bin' => 'Recycle Bin',
     'recycle_bin_desc' => 'Here you can restore items that have been deleted or choose to permanently remove them from the system. This list is unfiltered unlike similar activity lists in the system where permission filters are applied.',
     'recycle_bin_deleted_item' => 'Deleted Item',
+    'recycle_bin_deleted_parent' => 'Parent',
     'recycle_bin_deleted_by' => 'Deleted By',
     'recycle_bin_deleted_at' => 'Deletion Time',
     'recycle_bin_permanently_delete' => 'Permanently Delete',

--- a/resources/views/settings/recycle-bin/index.blade.php
+++ b/resources/views/settings/recycle-bin/index.blade.php
@@ -39,7 +39,8 @@
 
             <table class="table">
                 <tr>
-                    <th width="50%">{{ trans('settings.recycle_bin_deleted_item') }}</th>
+                    <th width="30%">{{ trans('settings.recycle_bin_deleted_item') }}</th>
+                    <th width="20%">{{ trans('settings.recycle_bin_deleted_parent') }}</th>
                     <th width="20%">{{ trans('settings.recycle_bin_deleted_by') }}</th>
                     <th width="15%">{{ trans('settings.recycle_bin_deleted_at') }}</th>
                     <th width="15%"></th>
@@ -74,6 +75,16 @@
                         <div class="pl-xl block inline">
                             <div class="text-page">
                                 @icon('page') {{ trans_choice('entities.x_pages', $deletion->deletable->pages()->withTrashed()->count()) }}
+                            </div>
+                        </div>
+                        @endif
+                    </td>
+                    <td>
+                        @if($deletion->deletable->getParent())
+                        <div class="table-entity-item">
+                            <span role="presentation" class="icon text-{{$deletion->deletable->getParent()->getType()}}">@icon($deletion->deletable->getParent()->getType())</span>
+                            <div class="text-{{ $deletion->deletable->getParent()->getType() }}">
+                                {{ $deletion->deletable->getParent()->name }}
                             </div>
                         </div>
                         @endif


### PR DESCRIPTION
According to issue #2594 when a child item has been deleted and the parent item also gets deleted, there is no way to see the parent information in order to recover child item. This PR includes parent information in recycle bin to help user recover child elements.

![screen1](https://user-images.githubusercontent.com/6619045/115107621-6809c380-9f81-11eb-855b-f3f7027bd99b.jpg)