### PR TITLE
Add base64 image blob support

### DIFF
--- a/app/Entities/Tools/PageContent.php
+++ b/app/Entities/Tools/PageContent.php
@@ -1,9 +1,13 @@
 <?php namespace BookStack\Entities\Tools;
 
+use BookStack\Auth\Permissions\PermissionService;
 use BookStack\Entities\Models\Page;
 use BookStack\Entities\Tools\Markdown\CustomStrikeThroughExtension;
 use BookStack\Facades\Theme;
 use BookStack\Theming\ThemeEvents;
+use BookStack\Uploads\Image;
+use BookStack\Uploads\ImageRepo;
+use BookStack\Uploads\ImageService;
 use DOMDocument;
 use DOMNodeList;
 use DOMXPath;
@@ -30,6 +34,7 @@ class PageContent
      */
     public function setNewHTML(string $html)
     {
+        $html = $this->saveBase64Images($this->page, $html);
         $this->page->html = $this->formatHtml($html);
         $this->page->text = $this->toPlainText();
         $this->page->markdown = '';
@@ -58,6 +63,60 @@ class PageContent
         $environment = Theme::dispatch(ThemeEvents::COMMONMARK_ENVIRONMENT_CONFIGURE, $environment) ?? $environment;
         $converter = new CommonMarkConverter([], $environment);
         return $converter->convertToHtml($markdown);
+    }
+
+    /**
+     * Convert all base64 image data to saved images
+     */
+    public function saveBase64Images(Page $page, string $htmlText): string
+    {
+        if ($htmlText == '') {
+            return $htmlText;
+        }
+
+        libxml_use_internal_errors(true);
+        $doc = new DOMDocument();
+        $doc->loadHTML(mb_convert_encoding($htmlText, 'HTML-ENTITIES', 'UTF-8'));
+        $container = $doc->documentElement;
+        $body = $container->childNodes->item(0);
+        $childNodes = $body->childNodes;
+        $xPath = new DOMXPath($doc);
+
+        // Get all img elements with image data blobs
+        $imageNodes = $xPath->query('//img[contains(@src, \'data:image\')]');
+        foreach($imageNodes as $imageNode) {
+            $imageSrc = $imageNode->getAttribute('src');
+
+            # Parse base64 data
+            $result = preg_match('"data:image/[a-zA-Z]*(;base64,[a-zA-Z0-9+/\\= ]*)"', $imageSrc, $matches);
+
+            if($result === 1) {
+                $base64ImageData = $matches[1];
+
+                $image = new Image();
+                $imageService = app()->make(ImageService::class);
+                $permissionService = app(PermissionService::class);
+                $imageRepo = new ImageRepo(new Image(), $imageService, $permissionService, $page);
+
+                # Use existing saveDrawing method used for Drawio diagrams
+                $image = $imageRepo->saveDrawing($base64ImageData, $page->id);
+                
+                // Create a new img element with the saved image URI
+                $newNode = $doc->createElement('img');
+                $newNode->setAttribute('src', $image->path);
+
+                // Replace the old img element
+                $imageNode->parentNode->replaceChild($newNode, $imageNode);
+            }
+        }
+
+        // Generate inner html as a string
+        $html = '';
+        foreach ($childNodes as $childNode) {
+            $html .= $doc->saveHTML($childNode);
+        }
+
+        return $html;
     }
 
     /**


### PR DESCRIPTION
**Overview**

This allows usage of base64 image blobs in pages by parsing them from posts during submission and saving them as images. This ties almost entirely into existing code.

Based on our discussion in #2631, I think this solution would be preferable.

**Benefits**
Even if this exact pull request isn't accepted, a solution with this design has many benefits.

- Avoids storing images as text blobs in the database, instead saving them as native BookStack images.
- Integrated directly into BookStock rather than tied to WYSIWYG editors, which could change in the future.
- Allows importing image data via the API. Export formats from knowledge systems (including BookStack's own) often use base64 image blobs. Importing with them with the API is currently more difficult than necessary.
- Allows copying and pasting from external sources with multiple images. The end-user doesn't need to think or know about what their datasource is or their image formats are. This is a huge benefit to usability when working with complex source information that includes images.
- Handled server-side rather than client-side. Client-side restrictions can be easily bypassed, deliberately and accidentally.

**TODO**
- [ ] saveBase64Images functionality could be moved into formatHtml. The current design was to give a clear separation from existing code, as well as give imageRepo access to the Page object.
- [ ] This method relies heavily on the Drawio saveDrawing method. The Drawio class could be abstracted a bit. The directory and file naming in particular are very Drawio-centric.
- [ ] To fully support this client-side, the Javascript restrictions on image blobs will need to be removed.