### PR TITLE
DRAFT: API endpoint for user management

### DIFF
--- a/app/Api/ListingResponseBuilder.php
+++ b/app/Api/ListingResponseBuilder.php
@@ -10,6 +10,7 @@ class ListingResponseBuilder
     protected $query;
     protected $request;
     protected $fields;
+    protected $hiddenFields;
 
     protected $filterOperators = [
         'eq'   => '=',
@@ -24,11 +25,12 @@ class ListingResponseBuilder
     /**
      * ListingResponseBuilder constructor.
      */
-    public function __construct(Builder $query, Request $request, array $fields)
+    public function __construct(Builder $query, Request $request, array $fields, array $hiddenFields )
     {
         $this->query = $query;
         $this->request = $request;
         $this->fields = $fields;
+        $this->hiddenFields = $hiddenFields;
     }
 
     /**
@@ -40,6 +42,7 @@ class ListingResponseBuilder
 
         $total = $filteredQuery->count();
         $data = $this->fetchData($filteredQuery);
+        $data = $data->makeVisible($this->hiddenFields);
 
         return response()->json([
             'data' => $data,

--- a/app/Auth/UserRepo.php
+++ b/app/Auth/UserRepo.php
@@ -62,6 +62,14 @@ class UserRepo
     }
 
     /**
+     * Get all users as Builder for API
+     */
+    public function getUsersBuilder(): Builder
+    {
+        $query = User::query()->select(['*']);
+        return $query;
+    }
+    /**
      * Get all the users with their permissions in a paginated format.
      */
     public function getAllUsersPaginatedAndSorted(int $count, array $sortData): LengthAwarePaginator

--- a/app/Auth/UserRepo.php
+++ b/app/Auth/UserRepo.php
@@ -64,9 +64,11 @@ class UserRepo
     /**
      * Get all users as Builder for API
      */
-    public function getUsersBuilder(): Builder
+    public function getUsersBuilder(int $id = null ) : Builder
     {
-        $query = User::query()->select(['*']);
+        $query = User::query()->select(['*'])
+            ->withLastActivityAt()
+            ->with(['roles', 'avatar']);
         return $query;
     }
     /**

--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -9,14 +9,15 @@ abstract class ApiController extends Controller
 {
 
     protected $rules = [];
+    protected $printHidden = [];
 
     /**
      * Provide a paginated listing JSON response in a standard format
      * taking into account any pagination parameters passed by the user.
      */
-    protected function apiListingResponse(Builder $query, array $fields): JsonResponse
+    protected function apiListingResponse(Builder $query, array $fields, array $protectedFieldsToPrint = []): JsonResponse
     {
-        $listing = new ListingResponseBuilder($query, request(), $fields);
+        $listing = new ListingResponseBuilder($query, request(), $fields, $protectedFieldsToPrint);
         return $listing->toResponse();
     }
 

--- a/app/Http/Controllers/Api/UserApiController.php
+++ b/app/Http/Controllers/Api/UserApiController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace BookStack\Http\Controllers\Api;
+
+use BookStack\Exceptions\PermissionsException;
+use BookStack\Auth\User;
+use BookStack\Auth\UserRepo;
+use Exception;
+use Illuminate\Http\Request;
+
+class UserApiController extends ApiController
+{
+    protected $user;
+    protected $userRepo;
+
+# TBD: Endpoints to create / update users
+#     protected $rules = [
+#         'create' => [
+#         ],
+#         'update' => [
+#         ],
+#     ];
+
+    public function __construct(User $user, UserRepo $userRepo)
+    {
+        $this->user = $user;
+        $this->userRepo = $userRepo;
+    }
+
+    /**
+     * Get a listing of pages visible to the user.
+     */
+    public function list()
+    {
+        $users = $this->userRepo->getUsersBuilder();
+
+        return $this->apiListingResponse($users, [
+            'id', 'name', 'slug',
+            'email', 'created_at', 'updated_at',
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/UserApiController.php
+++ b/app/Http/Controllers/Api/UserApiController.php
@@ -13,6 +13,10 @@ class UserApiController extends ApiController
     protected $user;
     protected $userRepo;
 
+    protected $printHidden = [
+        'email', 'created_at', 'updated_at', 'last_activity_at'
+    ];
+
 # TBD: Endpoints to create / update users
 #     protected $rules = [
 #         'create' => [
@@ -28,15 +32,30 @@ class UserApiController extends ApiController
     }
 
     /**
-     * Get a listing of pages visible to the user.
+     * Get a listing of users
      */
     public function list()
     {
+        $this->checkPermission('users-manage');
+
         $users = $this->userRepo->getUsersBuilder();
 
         return $this->apiListingResponse($users, [
-            'id', 'name', 'slug',
-            'email', 'created_at', 'updated_at',
-        ]);
+            'id', 'name', 'slug', 'email',
+            'created_at', 'updated_at', 'last_activity_at',
+        ], $this->printHidden);
+    }
+
+    /**
+     * View the details of a single user
+     */
+    public function read(string $id)
+    {
+        $this->checkPermission('users-manage');
+
+        $singleUser = $this->userRepo->getById($id);
+        $singleUser = $singleUser->makeVisible($this->printHidden);
+
+        return response()->json($singleUser);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -44,3 +44,5 @@ Route::post('shelves', 'BookshelfApiController@create');
 Route::get('shelves/{id}', 'BookshelfApiController@read');
 Route::put('shelves/{id}', 'BookshelfApiController@update');
 Route::delete('shelves/{id}', 'BookshelfApiController@delete');
+
+Route::get('users', 'UserApiController@list');

--- a/routes/api.php
+++ b/routes/api.php
@@ -46,3 +46,4 @@ Route::put('shelves/{id}', 'BookshelfApiController@update');
 Route::delete('shelves/{id}', 'BookshelfApiController@delete');
 
 Route::get('users', 'UserApiController@list');
+Route::get('users/{id}', 'UserApiController@read');


### PR DESCRIPTION
Hi,

I've found the need to get users (and their email) from the API for automation purposes. As there isn't an endpoint for user management yet, I thought I'd give it a shot and tried to implement it.

I'd like to get some feedback on whether I'm on the right track and should continue working on this.

**Disclaimer**: I haven't worked with Laravel ever before and my last contact with php was ~10 years ago. I'm grateful for any advice and pointers you can give me to improve the PR.

Tests and `CREATE`, `UPDATE`, `DELETE` operations are still WIP. I've seen someone request SCIM-Support (#2701) - I'd have to look into that.

**Current state:**
* GET: `/api/users` - Route (only accessible with `users-manage` permissions); lists all users + their roles
* GET: `/api/users/{id}` - Route (only accessible with `users-manage` permissions); lists details of a specific user

**Quick overview on my changes / thought process:**
- Add new routes for `users`
- Add new Controller `UserApiController`
- Use as much from existing `User` and `UserRepo`-classes as possible
  - obstacle: `apiListingResponse` requires a `Builder`-object, `User::getAll()` returns a collection
    - If I understood correctly, the collection contains all the data already, while the builder only contains the databasequery
    - solution: Implemented a new Function within `UserRepo` that returns a `Builder`-object
  - obstacle: some fields in the `User`-object are hidden, but need to be displayed, such as `email`
    - solution: added a new optional parameter to `apiListingResponse` that takes an array of fields that should be returned anyways (using `data->makeVisible()` in `ListingResponseBuilder::to_response`)