### PR TITLE
Fix table width styling on pages rendered in markdown

### DIFF
--- a/resources/sass/_pages.scss
+++ b/resources/sass/_pages.scss
@@ -122,9 +122,6 @@ body.mce-fullscreen, body.markdown-fullscreen {
     max-width: 100%;
     height: auto !important;
   }
-  td {
-    word-break: break-word;
-  }
 
   // diffs
   ins,

--- a/resources/sass/_pages.scss
+++ b/resources/sass/_pages.scss
@@ -122,6 +122,9 @@ body.mce-fullscreen, body.markdown-fullscreen {
     max-width: 100%;
     height: auto !important;
   }
+  td {
+    word-break: break-word;
+  }
 
   // diffs
   ins,

--- a/resources/sass/_tables.scss
+++ b/resources/sass/_tables.scss
@@ -11,6 +11,7 @@ table {
     border: 1px solid #DDD;
     overflow: auto;
     line-height: 1.2;
+	word-break: break-word;
   }
   td p, th p {
     margin: 0;


### PR DESCRIPTION
PR to resolve #2732 
Tables generated by the markdown renderer don't honour the max-width property without applying word-break styling to the td elements. 
This has shown to fix the table overflow tested in Chrome, Edge, Opera, and Firefox