### PR TITLE
Add RFC2307 LDAP server compatibility

### DIFF
--- a/.env.example.complete
+++ b/.env.example.complete
@@ -202,6 +202,7 @@ LDAP_EMAIL_ATTRIBUTE=mail
 LDAP_DISPLAY_NAME_ATTRIBUTE=cn
 LDAP_FOLLOW_REFERRALS=true
 LDAP_DUMP_USER_DETAILS=false
+LDAP_RFC2307_COMPATIBILITY=false
 
 # LDAP group sync configuration
 # Refer to https://www.bookstackapp.com/docs/admin/ldap-auth/

--- a/app/Auth/Access/LdapService.php
+++ b/app/Auth/Access/LdapService.php
@@ -63,7 +63,13 @@ class LdapService extends ExternalAuthService
             return null;
         }
 
-        return $users[0];
+        $rfc2307compatibility = $this->config['rfc2307compatibility'];
+        
+        if ($users['count'] > 1 && $rfc2307compatibility) {
+            return $users[1];
+        } else {
+            return $users[0];
+        }
     }
 
     /**

--- a/app/Config/services.php
+++ b/app/Config/services.php
@@ -133,6 +133,7 @@ return [
         'remove_from_groups' => env('LDAP_REMOVE_FROM_GROUPS', false),
         'tls_insecure' => env('LDAP_TLS_INSECURE', false),
         'start_tls' => env('LDAP_START_TLS', false),
+        'rfc2307compatibility' => env('LDAP_RFC2307_COMPATIBILITY', false),
     ],
 
 ];


### PR DESCRIPTION
FreeIPA (possibly others?) returns multiple records for individual users for RFC2307 compatibility. This prevents BookStack from enumerating groups, and completely breaks LDAP group synchronization.

As a workaround, adding LDAP_RFC2307_COMPATIBILITY environment variable (defaults to false). If set to true, and more than one record is returned during a group membership search, BookStack will use the second record set.
Will also require updating the Docs page at https://www.bookstackapp.com/docs/admin/ldap-auth/