### PR TITLE
Concurrent page editing: more warnings

### DIFF
--- a/app/Entities/Tools/PageEditActivity.php
+++ b/app/Entities/Tools/PageEditActivity.php
@@ -26,6 +26,7 @@ class PageEditActivity
      */
     public function hasActiveEditing(): bool
     {
+        $value = $this->activePageEditingQuery(60)->count();
         return $this->activePageEditingQuery(60)->count() > 0;
     }
 
@@ -41,6 +42,16 @@ class PageEditActivity
         $timeMessage = trans('entities.pages_draft_edit_active.time_b', ['minCount'=> 60]);
 
         return trans('entities.pages_draft_edit_active.message', ['start' => $userMessage, 'time' => $timeMessage]);
+    }
+
+    /**
+     * Check if the page has been updated since the draft has been saved.
+     *
+     * @return bool
+     */
+    public function hasPageBeenUpdatedSinceDraftSaved(PageRevision $draft): bool
+    {
+        return $draft->page->updated_at->timestamp >= $draft->updated_at->timestamp;
     }
 
     /**

--- a/app/Entities/Tools/PageEditActivity.php
+++ b/app/Entities/Tools/PageEditActivity.php
@@ -1,4 +1,4 @@
-<?php
+a<?php
 
 namespace BookStack\Entities\Tools;
 
@@ -26,7 +26,6 @@ class PageEditActivity
      */
     public function hasActiveEditing(): bool
     {
-        $value = $this->activePageEditingQuery(60)->count();
         return $this->activePageEditingQuery(60)->count() > 0;
     }
 

--- a/app/Entities/Tools/PageEditActivity.php
+++ b/app/Entities/Tools/PageEditActivity.php
@@ -1,4 +1,4 @@
-a<?php
+<?php
 
 namespace BookStack\Entities\Tools;
 

--- a/resources/js/components/page-editor.js
+++ b/resources/js/components/page-editor.js
@@ -119,6 +119,9 @@ class PageEditor {
             }
             this.draftNotifyChange(`${resp.data.message} ${Dates.utcTimeStampToLocalTime(resp.data.timestamp)}`);
             this.autoSave.last = Date.now();
+            if (resp.data.warning.length > 0) {
+                window.$events.emit('warning', resp.data.warning);
+            }
         } catch (err) {
             // Save the editor content in LocalStorage as a last resort, just in case.
             try {


### PR DESCRIPTION
Currently, warnings are displayed if two users are editing the same page at the same moment. More precisely, a warning is displayed if a second user starts editing a page when a first user has already opened the editor AND saved a first draft. If those two people open the page at the same moment (thus no draft is saved yet), they get no warning.

This patch adds a warning each time a draft is saved, when several users are editing the same page (with a draft already saved for each of them) or when the edited draft is older than the last page version.