### PR TITLE
Allow mastodon certification for footer label

### DIFF
--- a/resources/views/common/footer.blade.php
+++ b/resources/views/common/footer.blade.php
@@ -1,7 +1,13 @@
 @if(count(setting('app-footer-links', [])) > 0)
 <footer>
     @foreach(setting('app-footer-links', []) as $link)
-        <a href="{{ $link['url'] }}" target="_blank" rel="noopener">{{ strpos($link['label'], 'trans::') === 0 ? trans(str_replace('trans::', '', $link['label'])) : $link['label'] }}</a>
+        <a href="{{ $link['url'] }}" target="_blank"
+        @if(strpos(strtolower($link['label']), 'mastodon') !== false)
+            rel="noopener me"
+        @else
+            rel="noopener"
+        @endif
+        >{{ strpos($link['label'], 'trans::') === 0 ? trans(str_replace('trans::', '', $link['label'])) : $link['label'] }}</a>
     @endforeach
 </footer>
 @endif


### PR DESCRIPTION
Add footer tag relationship `me` if label contains 'Mastodon' (insensitive case).
It allows the certification of mastodon profile.