### PR TITLE
Fixes padding issues of the sidebar's items

### DIFF
--- a/resources/sass/_lists.scss
+++ b/resources/sass/_lists.scss
@@ -201,6 +201,7 @@
   .entity-list-item-name {
     font-size: 1em;
     margin: 0;
+    margin-right: $-m;
   }
   .chapter-child-menu {
     font-size: .8rem;
@@ -410,7 +411,7 @@ ul.pagination {
 }
 
 .entity-list-item, .icon-list-item {
-  padding: $-s $-m;
+  padding: $-s 0 $-s $-m;
   display: flex;
   align-items: center;
   background-color: transparent;


### PR DESCRIPTION
Hello!

Using this amazing platform I realized there was a very minor graphical bug that was still bothering me.
What I found is that the text item is padded on one side but not on the other. While I can totally understand the reason of way it works like this and the code is cleaner to understand, I believe it's a bit odd to see the text this much close to the border of the item's area.
![Schermata da 2021-10-10 21-08-55](https://user-images.githubusercontent.com/8852116/138372500-0117c9c5-7f41-470e-9465-55651e9329cb.png)
![Schermata da 2021-10-10 21-09-07](https://user-images.githubusercontent.com/8852116/138372505-4bba4b21-290e-4bbb-b466-fb975e71b886.png)
![Schermata da 2021-10-10 21-09-16](https://user-images.githubusercontent.com/8852116/138372507-df55e884-684c-42ad-91d9-19ca539fe5a0.png)

So I tweaked the `scss` code in such a way of putting that padding where I think it should be for the sake of consistency with the rest of the interface. Basically I removed the padding from the `a` item and I put it to the text `h4` item.
![Schermata da 2021-10-21 01-31-51](https://user-images.githubusercontent.com/8852116/138372854-55b436cf-53e9-4994-ae9e-cf0109f42d7f.png)
![Schermata da 2021-10-21 01-31-56](https://user-images.githubusercontent.com/8852116/138372856-35f107ea-7b6d-46f0-b54e-ae916e30b716.png)
![Schermata da 2021-10-21 01-32-01](https://user-images.githubusercontent.com/8852116/138372879-cdb2d77e-163a-4024-8071-31167b40cde1.png)
![Schermata da 2021-10-21 01-32-07](https://user-images.githubusercontent.com/8852116/138372881-86c37dcf-f80b-4b2a-b6d2-e78937ae5650.png)

I applied this change to the platform that I am running and I wanted to share it with you in case you believe that the current behavior is not how it should be. If, instead, you think this is not an issue or you want to apply a different solution, feel free to ignore this PR.

As always, thanks for your time and work! :D
