### PR TITLE
Minor capitalisation fix for Estonian

### DIFF
--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -248,7 +248,7 @@ return [
         'de_informal' => 'Deutsch (Du)',
         'es' => 'Español',
         'es_AR' => 'Español Argentina',
-        'et' => 'Eesti Keel',
+        'et' => 'Eesti keel',
         'fr' => 'Français',
         'he' => 'עברית',
         'hr' => 'Hrvatski',


### PR DESCRIPTION
There's a small typo in the name of the language, as shown in the language dropdown menu. The word "Keel" should be in lowercase. As I understand, these strings aren't visible in Crowdin, so I hope a PR is the proper way to submit a fix for this.

refs #2979 