### PR TITLE
Search Engine Improvement

### DIFF
--- a/app/Actions/Tag.php
+++ b/app/Actions/Tag.php
@@ -6,6 +6,12 @@ use BookStack\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
+/**
+ * @property int    $id
+ * @property string $name
+ * @property string $value
+ * @property int    $order
+ */
 class Tag extends Model
 {
     use HasFactory;

--- a/app/Console/Commands/RegenerateSearch.php
+++ b/app/Console/Commands/RegenerateSearch.php
@@ -2,6 +2,7 @@
 
 namespace BookStack\Console\Commands;
 
+use BookStack\Entities\Models\Entity;
 use BookStack\Entities\Tools\SearchIndex;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
@@ -22,6 +23,9 @@ class RegenerateSearch extends Command
      */
     protected $description = 'Re-index all content for searching';
 
+    /**
+     * @var SearchIndex
+     */
     protected $searchIndex;
 
     /**
@@ -45,8 +49,13 @@ class RegenerateSearch extends Command
             DB::setDefaultConnection($this->option('database'));
         }
 
-        $this->searchIndex->indexAllEntities();
+        $this->searchIndex->indexAllEntities(function (Entity $model, int $processed, int $total) {
+            $this->info('Indexed ' . class_basename($model) . ' entries (' . $processed . '/' . $total . ')');
+        });
+
         DB::setDefaultConnection($connection);
-        $this->comment('Search index regenerated');
+        $this->line('Search index regenerated!');
+
+        return static::SUCCESS;
     }
 }

--- a/app/Entities/Models/Book.php
+++ b/app/Entities/Models/Book.php
@@ -24,7 +24,7 @@ class Book extends Entity implements HasCoverImage
 {
     use HasFactory;
 
-    public $searchFactor = 2;
+    public $searchFactor = 1.5;
 
     protected $fillable = ['name', 'description'];
     protected $hidden = ['restricted', 'pivot', 'image_id', 'deleted_at'];

--- a/app/Entities/Models/Book.php
+++ b/app/Entities/Models/Book.php
@@ -24,7 +24,7 @@ class Book extends Entity implements HasCoverImage
 {
     use HasFactory;
 
-    public $searchFactor = 1.5;
+    public $searchFactor = 1.2;
 
     protected $fillable = ['name', 'description'];
     protected $hidden = ['restricted', 'pivot', 'image_id', 'deleted_at'];

--- a/app/Entities/Models/Bookshelf.php
+++ b/app/Entities/Models/Bookshelf.php
@@ -13,7 +13,7 @@ class Bookshelf extends Entity implements HasCoverImage
 
     protected $table = 'bookshelves';
 
-    public $searchFactor = 3;
+    public $searchFactor = 1.5;
 
     protected $fillable = ['name', 'description', 'image_id'];
 

--- a/app/Entities/Models/Bookshelf.php
+++ b/app/Entities/Models/Bookshelf.php
@@ -13,7 +13,7 @@ class Bookshelf extends Entity implements HasCoverImage
 
     protected $table = 'bookshelves';
 
-    public $searchFactor = 1.5;
+    public $searchFactor = 1.2;
 
     protected $fillable = ['name', 'description', 'image_id'];
 

--- a/app/Entities/Models/Chapter.php
+++ b/app/Entities/Models/Chapter.php
@@ -16,7 +16,7 @@ class Chapter extends BookChild
 {
     use HasFactory;
 
-    public $searchFactor = 1.3;
+    public $searchFactor = 1.5;
 
     protected $fillable = ['name', 'description', 'priority', 'book_id'];
     protected $hidden = ['restricted', 'pivot', 'deleted_at'];

--- a/app/Entities/Models/Chapter.php
+++ b/app/Entities/Models/Chapter.php
@@ -16,7 +16,7 @@ class Chapter extends BookChild
 {
     use HasFactory;
 
-    public $searchFactor = 1.5;
+    public $searchFactor = 1.2;
 
     protected $fillable = ['name', 'description', 'priority', 'book_id'];
     protected $hidden = ['restricted', 'pivot', 'deleted_at'];

--- a/app/Entities/Models/Entity.php
+++ b/app/Entities/Models/Entity.php
@@ -239,19 +239,11 @@ abstract class Entity extends Model implements Sluggable, Favouritable, Viewable
     }
 
     /**
-     * Get the body text of this entity.
-     */
-    public function getText(): string
-    {
-        return $this->{$this->textField} ?? '';
-    }
-
-    /**
      * Get an excerpt of this entity's descriptive content to the specified length.
      */
     public function getExcerpt(int $length = 100): string
     {
-        $text = $this->getText();
+        $text = $this->{$this->textField} ?? '';
 
         if (mb_strlen($text) > $length) {
             $text = mb_substr($text, 0, $length - 3) . '...';

--- a/app/Entities/Models/Page.php
+++ b/app/Entities/Models/Page.php
@@ -3,13 +3,13 @@
 namespace BookStack\Entities\Models;
 
 use BookStack\Entities\Tools\PageContent;
+use BookStack\Facades\Permissions;
 use BookStack\Uploads\Attachment;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Permissions;
 
 /**
  * Class Page.
@@ -64,10 +64,8 @@ class Page extends BookChild
 
     /**
      * Check if this page has a chapter.
-     *
-     * @return bool
      */
-    public function hasChapter()
+    public function hasChapter(): bool
     {
         return $this->chapter()->count() > 0;
     }

--- a/app/Entities/Repos/PageRepo.php
+++ b/app/Entities/Repos/PageRepo.php
@@ -157,8 +157,8 @@ class PageRepo
      */
     public function publishDraft(Page $draft, array $input): Page
     {
-        $this->baseRepo->update($draft, $input);
         $this->updateTemplateStatusAndContentFromInput($draft, $input);
+        $this->baseRepo->update($draft, $input);
 
         $draft->draft = false;
         $draft->revision_count = 1;

--- a/app/Entities/Tools/SearchIndex.php
+++ b/app/Entities/Tools/SearchIndex.php
@@ -46,7 +46,7 @@ class SearchIndex
      *
      * @param Entity[] $entities
      */
-    protected function indexEntities(array $entities)
+    public function indexEntities(array $entities)
     {
         $terms = [];
         foreach ($entities as $entity) {

--- a/app/Entities/Tools/SearchIndex.php
+++ b/app/Entities/Tools/SearchIndex.php
@@ -223,7 +223,7 @@ class SearchIndex
         if ($entity instanceof Page) {
             $bodyTermsMap = $this->generateTermScoreMapFromHtml($entity->html);
         } else {
-            $bodyTermsMap = $this->generateTermScoreMapFromText($entity->description, $entity->searchFactor);
+            $bodyTermsMap = $this->generateTermScoreMapFromText($entity->description ?? '', $entity->searchFactor);
         }
 
         $mergedScoreMap = $this->mergeTermScoreMaps($nameTermsMap, $bodyTermsMap, $tagTermsMap);

--- a/app/Entities/Tools/SearchIndex.php
+++ b/app/Entities/Tools/SearchIndex.php
@@ -4,7 +4,10 @@ namespace BookStack\Entities\Tools;
 
 use BookStack\Entities\EntityProvider;
 use BookStack\Entities\Models\Entity;
+use BookStack\Entities\Models\Page;
 use BookStack\Entities\Models\SearchTerm;
+use DOMDocument;
+use DOMNode;
 use Illuminate\Support\Collection;
 
 class SearchIndex
@@ -64,7 +67,8 @@ class SearchIndex
         SearchTerm::query()->truncate();
 
         foreach ($this->entityProvider->all() as $entityModel) {
-            $selectFields = ['id', 'name', $entityModel->textField];
+            $indexContentField = $entityModel instanceof Page ? 'html' : 'description';
+            $selectFields = ['id', 'name', $indexContentField];
             $total = $entityModel->newQuery()->withTrashed()->count();
             $chunkSize = 250;
             $processed = 0;
@@ -93,11 +97,70 @@ class SearchIndex
     }
 
     /**
-     * Create a scored term array from the given text.
+     * Create a scored term array from the given text, where the keys are the terms
+     * and the values are their scores.
      *
-     * @returns array{term: string, score: float}
+     * @returns array<string, int>
      */
-    protected function generateTermArrayFromText(string $text, int $scoreAdjustment = 1): array
+    protected function generateTermScoreMapFromText(string $text, int $scoreAdjustment = 1): array
+    {
+        $termMap = $this->textToTermCountMap($text);
+
+        foreach ($termMap as $term => $count) {
+            $termMap[$term] = $count * $scoreAdjustment;
+        }
+
+        return $termMap;
+    }
+
+    /**
+     * Create a scored term array from the given HTML, where the keys are the terms
+     * and the values are their scores.
+     *
+     * @returns array<string, int>
+     */
+    protected function generateTermScoreMapFromHtml(string $html): array
+    {
+        if (empty($html)) {
+            return [];
+        }
+
+        $scoresByTerm = [];
+        $elementScoreAdjustmentMap = [
+            'h1' => 10,
+            'h2' => 5,
+            'h3' => 4,
+            'h4' => 3,
+            'h5' => 2,
+            'h6' => 1.5,
+        ];
+
+        $html = '<body>' . $html . '</body>';
+        libxml_use_internal_errors(true);
+        $doc = new DOMDocument();
+        $doc->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+
+        $topElems = $doc->documentElement->childNodes->item(0)->childNodes;
+        /** @var DOMNode $child */
+        foreach ($topElems as $child) {
+            $nodeName = $child->nodeName;
+            $termCounts = $this->textToTermCountMap(trim($child->textContent));
+            foreach ($termCounts as $term => $count) {
+                $scoreChange = $count * ($elementScoreAdjustmentMap[$nodeName] ?? 1);
+                $scoresByTerm[$term] = ($scoresByTerm[$term] ?? 0) + $scoreChange;
+            }
+        }
+
+        return $scoresByTerm;
+    }
+
+    /**
+     * For the given text, return an array where the keys are the unique term words
+     * and the values are the frequency of that term.
+     *
+     * @returns array<string, int>
+     */
+    protected function textToTermCountMap(string $text): array
     {
         $tokenMap = []; // {TextToken => OccurrenceCount}
         $splitChars = " \n\t.,!?:;()[]{}<>`'\"";
@@ -111,34 +174,61 @@ class SearchIndex
             $token = strtok($splitChars);
         }
 
-        $terms = [];
-        foreach ($tokenMap as $token => $count) {
-            $terms[] = [
-                'term'  => $token,
-                'score' => $count * $scoreAdjustment,
-            ];
-        }
-
-        return $terms;
+        return $tokenMap;
     }
 
     /**
      * For the given entity, Generate an array of term data details.
      * Is the raw term data, not instances of SearchTerm models.
      *
-     * @returns array{term: string, score: float}[]
+     * @returns array{term: string, score: float, entity_id: int, entity_type: string}[]
      */
     protected function entityToTermDataArray(Entity $entity): array
     {
-        $nameTerms = $this->generateTermArrayFromText($entity->name, 40 * $entity->searchFactor);
-        $bodyTerms = $this->generateTermArrayFromText($entity->getText(), 1 * $entity->searchFactor);
-        $termData = array_merge($nameTerms, $bodyTerms);
+        $nameTermsMap = $this->generateTermScoreMapFromText($entity->name, 40 * $entity->searchFactor);
 
-        foreach ($termData as $index => $term) {
-            $termData[$index]['entity_type'] = $entity->getMorphClass();
-            $termData[$index]['entity_id'] = $entity->id;
+        if ($entity instanceof Page) {
+            $bodyTermsMap = $this->generateTermScoreMapFromHtml($entity->html);
+        } else {
+            $bodyTermsMap = $this->generateTermScoreMapFromText($entity->description, $entity->searchFactor);
         }
 
-        return $termData;
+        $mergedScoreMap = $this->mergeTermScoreMaps($nameTermsMap, $bodyTermsMap);
+
+        $dataArray = [];
+        $entityId = $entity->id;
+        $entityType = $entity->getMorphClass();
+        foreach ($mergedScoreMap as $term => $score) {
+            $dataArray[] = [
+                'term' => $term,
+                'score' => $score,
+                'entity_type' => $entityType,
+                'entity_id' => $entityId,
+            ];
+        }
+
+        return $dataArray;
+    }
+
+
+    /**
+     * For the given term data arrays, Merge their contents by term
+     * while combining any scores.
+     *
+     * @param array<string, int>[] ...$scoreMaps
+     *
+     * @returns array<string, int>
+     */
+    protected function mergeTermScoreMaps(...$scoreMaps): array
+    {
+        $mergedMap = [];
+
+        foreach ($scoreMaps as $scoreMap) {
+            foreach ($scoreMap as $term => $score) {
+                $mergedMap[$term] = ($mergedMap[$term] ?? 0) + $score;
+            }
+        }
+
+        return $mergedMap;
     }
 }

--- a/app/Entities/Tools/SearchIndex.php
+++ b/app/Entities/Tools/SearchIndex.php
@@ -13,6 +13,12 @@ use Illuminate\Support\Collection;
 
 class SearchIndex
 {
+    /**
+     * A list of delimiter characters used to break-up parsed content into terms for indexing.
+     *
+     * @var string
+     */
+    public static $delimiters = " \n\t.,!?:;()[]{}<>`'\"";
 
     /**
      * @var EntityProvider
@@ -189,7 +195,7 @@ class SearchIndex
     protected function textToTermCountMap(string $text): array
     {
         $tokenMap = []; // {TextToken => OccurrenceCount}
-        $splitChars = " \n\t.,!?:;()[]{}<>`'\"";
+        $splitChars = static::$delimiters;
         $token = strtok($text, $splitChars);
 
         while ($token !== false) {

--- a/app/Entities/Tools/SearchIndex.php
+++ b/app/Entities/Tools/SearchIndex.php
@@ -175,7 +175,7 @@ class SearchIndex
         $names = [];
         $values = [];
 
-        foreach($tags as $tag) {
+        foreach ($tags as $tag) {
             $names[] = $tag->name;
             $values[] = $tag->value;
         }
@@ -233,16 +233,15 @@ class SearchIndex
         $entityType = $entity->getMorphClass();
         foreach ($mergedScoreMap as $term => $score) {
             $dataArray[] = [
-                'term' => $term,
-                'score' => $score,
+                'term'        => $term,
+                'score'       => $score,
                 'entity_type' => $entityType,
-                'entity_id' => $entityId,
+                'entity_id'   => $entityId,
             ];
         }
 
         return $dataArray;
     }
-
 
     /**
      * For the given term data arrays, Merge their contents by term

--- a/app/Entities/Tools/SearchOptions.php
+++ b/app/Entities/Tools/SearchOptions.php
@@ -124,7 +124,6 @@ class SearchOptions
         return $terms;
     }
 
-
     /**
      * Parse a standard search term string into individual search terms and
      * extract any exact terms searches to be made.
@@ -136,7 +135,7 @@ class SearchOptions
         $terms = explode(' ', $termString);
         $indexDelimiters = SearchIndex::$delimiters;
         $parsed = [
-            'terms' => [],
+            'terms'  => [],
             'exacts' => [],
         ];
 

--- a/app/Entities/Tools/SearchOptions.php
+++ b/app/Entities/Tools/SearchOptions.php
@@ -57,15 +57,22 @@ class SearchOptions
 
         $instance = new SearchOptions();
         $inputs = $request->only(['search', 'types', 'filters', 'exact', 'tags']);
-        $instance->searches = explode(' ', $inputs['search'] ?? []);
-        $instance->exacts = array_filter($inputs['exact'] ?? []);
+
+        $parsedStandardTerms = static::parseStandardTermString($inputs['search'] ?? '');
+        $instance->searches = $parsedStandardTerms['terms'];
+        $instance->exacts = $parsedStandardTerms['exacts'];
+
+        array_push($instance->exacts, ...array_filter($inputs['exact'] ?? []));
+
         $instance->tags = array_filter($inputs['tags'] ?? []);
+
         foreach (($inputs['filters'] ?? []) as $filterKey => $filterVal) {
             if (empty($filterVal)) {
                 continue;
             }
             $instance->filters[$filterKey] = $filterVal === 'true' ? '' : $filterVal;
         }
+
         if (isset($inputs['types']) && count($inputs['types']) < 4) {
             $instance->filters['type'] = implode('|', $inputs['types']);
         }
@@ -102,11 +109,9 @@ class SearchOptions
         }
 
         // Parse standard terms
-        foreach (explode(' ', trim($searchString)) as $searchTerm) {
-            if ($searchTerm !== '') {
-                $terms['searches'][] = $searchTerm;
-            }
-        }
+        $parsedStandardTerms = static::parseStandardTermString($searchString);
+        array_push($terms['searches'], ...$parsedStandardTerms['terms']);
+        array_push($terms['exacts'], ...$parsedStandardTerms['exacts']);
 
         // Split filter values out
         $splitFilters = [];
@@ -117,6 +122,34 @@ class SearchOptions
         $terms['filters'] = $splitFilters;
 
         return $terms;
+    }
+
+
+    /**
+     * Parse a standard search term string into individual search terms and
+     * extract any exact terms searches to be made.
+     *
+     * @return array{terms: array<string>, exacts: array<string>}
+     */
+    protected static function parseStandardTermString(string $termString): array
+    {
+        $terms = explode(' ', $termString);
+        $indexDelimiters = SearchIndex::$delimiters;
+        $parsed = [
+            'terms' => [],
+            'exacts' => [],
+        ];
+
+        foreach ($terms as $searchTerm) {
+            if ($searchTerm === '') {
+                continue;
+            }
+
+            $parsedList = (strpbrk($searchTerm, $indexDelimiters) === false) ? 'terms' : 'exacts';
+            $parsed[$parsedList][] = $searchTerm;
+        }
+
+        return $parsed;
     }
 
     /**

--- a/app/Entities/Tools/SearchResultsFormatter.php
+++ b/app/Entities/Tools/SearchResultsFormatter.php
@@ -8,10 +8,10 @@ use Illuminate\Support\HtmlString;
 
 class SearchResultsFormatter
 {
-
     /**
      * For the given array of entities, Prepare the models to be shown in search result
      * output. This sets a series of additional attributes.
+     *
      * @param Entity[] $results
      */
     public function format(array $results, SearchOptions $options): void
@@ -32,7 +32,7 @@ class SearchResultsFormatter
         $terms = array_merge($options->exacts, $options->searches);
 
         $originalContentByNewAttribute = [
-            'preview_name' => $entity->name,
+            'preview_name'    => $entity->name,
             'preview_content' => $textContent,
         ];
 
@@ -49,7 +49,8 @@ class SearchResultsFormatter
 
     /**
      * Highlight tags which match the given terms.
-     * @param Tag[] $tags
+     *
+     * @param Tag[]    $tags
      * @param string[] $terms
      */
     protected function highlightTagsContainingTerms(array $tags, array $terms): void
@@ -104,6 +105,7 @@ class SearchResultsFormatter
      * adjacent or where they overlap.
      *
      * @param array<int, int> $matchPositions
+     *
      * @return array<int, int>
      */
     protected function sortAndMergeMatchPositions(array $matchPositions): array
@@ -118,7 +120,7 @@ class SearchResultsFormatter
                 $mergedRefs[$start] = $end;
                 $lastStart = $start;
                 $lastEnd = $end;
-            } else if ($end > $lastEnd) {
+            } elseif ($end > $lastEnd) {
                 $mergedRefs[$lastStart] = $end;
                 $lastEnd = $end;
             }
@@ -194,7 +196,7 @@ class SearchResultsFormatter
         $firstStart = $firstStart ?: 0;
         if ($remainder > 10 && $firstStart !== 0) {
             $padStart = max(0, $firstStart - $remainder);
-            $content = ($padStart === 0 ? '' : '...') . e(substr($originalText, $padStart,  $firstStart - $padStart)) . substr($content, 4);
+            $content = ($padStart === 0 ? '' : '...') . e(substr($originalText, $padStart, $firstStart - $padStart)) . substr($content, 4);
         }
 
         // Add ellipsis if we're not at the end
@@ -204,5 +206,4 @@ class SearchResultsFormatter
 
         return $content;
     }
-
 }

--- a/app/Entities/Tools/SearchResultsFormatter.php
+++ b/app/Entities/Tools/SearchResultsFormatter.php
@@ -2,6 +2,7 @@
 
 namespace BookStack\Entities\Tools;
 
+use BookStack\Actions\Tag;
 use BookStack\Entities\Models\Entity;
 use Illuminate\Support\HtmlString;
 
@@ -40,6 +41,34 @@ class SearchResultsFormatter
             $mergedRefs = $this->sortAndMergeMatchPositions($matchRefs);
             $formatted = $this->formatTextUsingMatchPositions($mergedRefs, $content);
             $entity->setAttribute($attributeName, new HtmlString($formatted));
+        }
+
+        $tags = $entity->relationLoaded('tags') ? $entity->tags->all() : [];
+        $this->highlightTagsContainingTerms($tags, $terms);
+    }
+
+    /**
+     * Highlight tags which match the given terms.
+     * @param Tag[] $tags
+     * @param string[] $terms
+     */
+    protected function highlightTagsContainingTerms(array $tags, array $terms): void
+    {
+        foreach ($tags as $tag) {
+            $tagName = strtolower($tag->name);
+            $tagValue = strtolower($tag->value);
+
+            foreach ($terms as $term) {
+                $termLower = strtolower($term);
+
+                if (strpos($tagName, $termLower) !== false) {
+                    $tag->setAttribute('highlight_name', true);
+                }
+
+                if (strpos($tagValue, $termLower) !== false) {
+                    $tag->setAttribute('highlight_value', true);
+                }
+            }
         }
     }
 

--- a/app/Entities/Tools/SearchResultsFormatter.php
+++ b/app/Entities/Tools/SearchResultsFormatter.php
@@ -141,11 +141,12 @@ class SearchResultsFormatter
      */
     protected function formatTextUsingMatchPositions(array $matchPositions, string $originalText, int $targetLength): string
     {
-        $contextRange = 32;
         $maxEnd = strlen($originalText);
-        $lastEnd = 0;
-        $firstStart = null;
         $fetchAll = ($targetLength === 0);
+        $contextLength = ($fetchAll ? 0 : 32);
+
+        $firstStart = null;
+        $lastEnd = 0;
         $content = '';
         $contentTextLength = 0;
 
@@ -155,8 +156,8 @@ class SearchResultsFormatter
 
         foreach ($matchPositions as $start => $end) {
             // Get our outer text ranges for the added context we want to show upon the result.
-            $contextStart = max($start - $contextRange, 0, $lastEnd);
-            $contextEnd = min($end + $contextRange, $maxEnd);
+            $contextStart = max($start - $contextLength, 0, $lastEnd);
+            $contextEnd = min($end + $contextLength, $maxEnd);
 
             // Adjust the start if we're going to be touching the previous match.
             $startDiff = $start - $lastEnd;

--- a/app/Entities/Tools/SearchResultsFormatter.php
+++ b/app/Entities/Tools/SearchResultsFormatter.php
@@ -30,11 +30,17 @@ class SearchResultsFormatter
         $textContent = $entity->$textProperty;
         $terms = array_merge($options->exacts, $options->searches);
 
-        $matchRefs = $this->getMatchPositions($textContent, $terms);
-        $mergedRefs = $this->sortAndMergeMatchPositions($matchRefs);
-        $content = $this->formatTextUsingMatchPositions($mergedRefs, $textContent);
+        $originalContentByNewAttribute = [
+            'preview_name' => $entity->name,
+            'preview_content' => $textContent,
+        ];
 
-        $entity->setAttribute('preview_content', new HtmlString($content));
+        foreach ($originalContentByNewAttribute as $attributeName => $content) {
+            $matchRefs = $this->getMatchPositions($content, $terms);
+            $mergedRefs = $this->sortAndMergeMatchPositions($matchRefs);
+            $formatted = $this->formatTextUsingMatchPositions($mergedRefs, $content);
+            $entity->setAttribute($attributeName, new HtmlString($formatted));
+        }
     }
 
     /**

--- a/app/Entities/Tools/SearchResultsFormatter.php
+++ b/app/Entities/Tools/SearchResultsFormatter.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace BookStack\Entities\Tools;
+
+use BookStack\Entities\Models\Entity;
+use Illuminate\Support\HtmlString;
+
+class SearchResultsFormatter
+{
+
+    /**
+     * For the given array of entities, Prepare the models to be shown in search result
+     * output. This sets a series of additional attributes.
+     * @param Entity[] $results
+     */
+    public function format(array $results, SearchOptions $options): void
+    {
+        foreach ($results as $result) {
+            $this->setSearchPreview($result, $options);
+        }
+    }
+
+    /**
+     * Update the given entity model to set attributes used for previews of the item
+     * primarily within search result lists.
+     */
+    protected function setSearchPreview(Entity $entity, SearchOptions $options)
+    {
+        $textProperty = $entity->textField;
+        $textContent = $entity->$textProperty;
+        $terms = array_merge($options->exacts, $options->searches);
+
+        $matchRefs = $this->getMatchPositions($textContent, $terms);
+        $mergedRefs = $this->sortAndMergeMatchPositions($matchRefs);
+        $content = $this->formatTextUsingMatchPositions($mergedRefs, $textContent);
+
+        $entity->setAttribute('preview_content', new HtmlString($content));
+    }
+
+    /**
+     * Get positions of the given terms within the given text.
+     * Is in the array format of [int $startIndex => int $endIndex] where the indexes
+     * are positions within the provided text.
+     *
+     * @return array<int, int>
+     */
+    protected function getMatchPositions(string $text, array $terms): array
+    {
+        $matchRefs = [];
+        $text = strtolower($text);
+
+        foreach ($terms as $term) {
+            $offset = 0;
+            $term = strtolower($term);
+            $pos = strpos($text, $term, $offset);
+            while ($pos !== false) {
+                $end = $pos + strlen($term);
+                $matchRefs[$pos] = $end;
+                $offset = $end;
+                $pos = strpos($text, $term, $offset);
+            }
+        }
+
+        return $matchRefs;
+    }
+
+    /**
+     * Sort the given match positions before merging them where they're
+     * adjacent or where they overlap.
+     *
+     * @param array<int, int> $matchPositions
+     * @return array<int, int>
+     */
+    protected function sortAndMergeMatchPositions(array $matchPositions): array
+    {
+        ksort($matchPositions);
+        $mergedRefs = [];
+        $lastStart = 0;
+        $lastEnd = 0;
+
+        foreach ($matchPositions as $start => $end) {
+            if ($start > $lastEnd) {
+                $mergedRefs[$start] = $end;
+                $lastStart = $start;
+                $lastEnd = $end;
+            } else if ($end > $lastEnd) {
+                $mergedRefs[$lastStart] = $end;
+                $lastEnd = $end;
+            }
+        }
+
+        return $mergedRefs;
+    }
+
+    /**
+     * Format the given original text, returning a version where terms are highlighted within.
+     * Returned content is in HTML text format.
+     */
+    protected function formatTextUsingMatchPositions(array $matchPositions, string $originalText): string
+    {
+        $contextRange = 32;
+        $targetLength = 260;
+        $maxEnd = strlen($originalText);
+        $lastEnd = 0;
+        $firstStart = null;
+        $content = '';
+
+        foreach ($matchPositions as $start => $end) {
+            // Get our outer text ranges for the added context we want to show upon the result.
+            $contextStart = max($start - $contextRange, 0, $lastEnd);
+            $contextEnd = min($end + $contextRange, $maxEnd);
+
+            // Adjust the start if we're going to be touching the previous match.
+            $startDiff = $start - $lastEnd;
+            if ($startDiff < 0) {
+                $contextStart = $start;
+                $content = substr($content, 0, strlen($content) + $startDiff);
+            }
+
+            // Add ellipsis between results
+            if ($contextStart !== 0 && $contextStart !== $start) {
+                $content .= ' ...';
+            }
+
+            // Add our content including the bolded matching text
+            $content .= e(substr($originalText, $contextStart, $start - $contextStart));
+            $content .= '<strong>' . e(substr($originalText, $start, $end - $start)) . '</strong>';
+            $content .= e(substr($originalText, $end, $contextEnd - $end));
+
+            // Update our last end position
+            $lastEnd = $contextEnd;
+
+            // Update the first start position if it's not already been set
+            if (is_null($firstStart)) {
+                $firstStart = $contextStart;
+            }
+
+            // Stop if we're near our target
+            if (strlen($content) >= $targetLength - 10) {
+                break;
+            }
+        }
+
+        // Just copy out the content if we haven't moved along anywhere.
+        if ($lastEnd === 0) {
+            $content = e(substr($originalText, 0, $targetLength));
+            $lastEnd = $targetLength;
+        }
+
+        // Pad out the end if we're low
+        $remainder = $targetLength - strlen($content);
+        if ($remainder > 10) {
+            $content .= e(substr($originalText, $lastEnd, $remainder));
+            $lastEnd += $remainder;
+        }
+
+        // Pad out the start if we're still low
+        $remainder = $targetLength - strlen($content);
+        $firstStart = $firstStart ?: 0;
+        if ($remainder > 10 && $firstStart !== 0) {
+            $padStart = max(0, $firstStart - $remainder);
+            $content = ($padStart === 0 ? '' : '...') . e(substr($originalText, $padStart,  $firstStart - $padStart)) . substr($content, 4);
+        }
+
+        // Add ellipsis if we're not at the end
+        if ($lastEnd < $maxEnd) {
+            $content .= '...';
+        }
+
+        return $content;
+    }
+
+}

--- a/app/Entities/Tools/SearchRunner.php
+++ b/app/Entities/Tools/SearchRunner.php
@@ -237,6 +237,8 @@ class SearchRunner
      * Create a select statement, with prepared bindings, for the given
      * set of scored search terms.
      *
+     * @param array<string, float> $scoredTerms
+     *
      * @return array{statement: string, bindings: string[]}
      */
     protected function selectForScoredTerms(array $scoredTerms): array
@@ -258,6 +260,13 @@ class SearchRunner
         ];
     }
 
+    /**
+     * For the terms in the given search options, query their popularity across all
+     * search terms then provide that back as score adjustment multiplier applicable
+     * for their rarity. Returns an array of float multipliers, keyed by term.
+     *
+     * @return array<string, float>
+     */
     protected function getTermAdjustments(SearchOptions $options): array
     {
         if (isset($this->termAdjustmentCache[$options])) {

--- a/app/Entities/Tools/SearchRunner.php
+++ b/app/Entities/Tools/SearchRunner.php
@@ -141,13 +141,13 @@ class SearchRunner
         $relations = ['tags'];
 
         if ($entityModelInstance instanceof BookChild) {
-            $relations['book'] = function(BelongsTo $query) {
+            $relations['book'] = function (BelongsTo $query) {
                 $query->visible();
             };
         }
 
         if ($entityModelInstance instanceof Page) {
-            $relations['chapter'] = function(BelongsTo $query) {
+            $relations['chapter'] = function (BelongsTo $query) {
                 $query->visible();
             };
         }
@@ -310,7 +310,7 @@ class SearchRunner
         if (empty($termCounts)) {
             return [];
         }
-        
+
         $multipliers = [];
         $max = max(array_values($termCounts));
 

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -4,8 +4,8 @@ namespace BookStack\Http\Controllers;
 
 use BookStack\Entities\Queries\Popular;
 use BookStack\Entities\Tools\SearchOptions;
+use BookStack\Entities\Tools\SearchResultsFormatter;
 use BookStack\Entities\Tools\SearchRunner;
-use BookStack\Entities\Tools\ShelfContext;
 use BookStack\Entities\Tools\SiblingFetcher;
 use Illuminate\Http\Request;
 
@@ -14,18 +14,14 @@ class SearchController extends Controller
     protected $searchRunner;
     protected $entityContextManager;
 
-    public function __construct(
-        SearchRunner $searchRunner,
-        ShelfContext $entityContextManager
-    ) {
+    public function __construct(SearchRunner $searchRunner) {
         $this->searchRunner = $searchRunner;
-        $this->entityContextManager = $entityContextManager;
     }
 
     /**
      * Searches all entities.
      */
-    public function search(Request $request)
+    public function search(Request $request, SearchResultsFormatter $formatter)
     {
         $searchOpts = SearchOptions::fromRequest($request);
         $fullSearchString = $searchOpts->toString();
@@ -35,6 +31,7 @@ class SearchController extends Controller
         $nextPageLink = url('/search?term=' . urlencode($fullSearchString) . '&page=' . ($page + 1));
 
         $results = $this->searchRunner->searchEntities($searchOpts, 'all', $page, 20);
+        $formatter->format($results['results']->all(), $searchOpts);
 
         return view('search.all', [
             'entities'     => $results['results'],

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -14,7 +14,8 @@ class SearchController extends Controller
     protected $searchRunner;
     protected $entityContextManager;
 
-    public function __construct(SearchRunner $searchRunner) {
+    public function __construct(SearchRunner $searchRunner)
+    {
         $this->searchRunner = $searchRunner;
     }
 

--- a/database/seeders/LargeContentSeeder.php
+++ b/database/seeders/LargeContentSeeder.php
@@ -33,8 +33,9 @@ class LargeContentSeeder extends Seeder
 
         $largeBook->pages()->saveMany($pages);
         $largeBook->chapters()->saveMany($chapters);
+        $all = array_merge([$largeBook], array_values($pages->all()), array_values($chapters->all()));
 
-        app()->make(PermissionService::class)->buildJointPermissions();
-        app()->make(SearchIndex::class)->indexAllEntities();
+        app()->make(PermissionService::class)->buildJointPermissionsForEntity($largeBook);
+        app()->make(SearchIndex::class)->indexEntities($all);
     }
 }

--- a/database/seeders/LargeContentSeeder.php
+++ b/database/seeders/LargeContentSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use BookStack\Auth\Permissions\PermissionService;
 use BookStack\Auth\Role;
 use BookStack\Auth\User;
+use BookStack\Entities\Models\Book;
 use BookStack\Entities\Models\Chapter;
 use BookStack\Entities\Models\Page;
 use BookStack\Entities\Tools\SearchIndex;
@@ -25,12 +26,15 @@ class LargeContentSeeder extends Seeder
         $editorRole = Role::getRole('editor');
         $editorUser->attachRole($editorRole);
 
-        $largeBook = \BookStack\Entities\Models\Book::factory()->create(['name' => 'Large book' . Str::random(10), 'created_by' => $editorUser->id, 'updated_by' => $editorUser->id]);
+        /** @var Book $largeBook */
+        $largeBook = Book::factory()->create(['name' => 'Large book' . Str::random(10), 'created_by' => $editorUser->id, 'updated_by' => $editorUser->id]);
         $pages = Page::factory()->count(200)->make(['created_by' => $editorUser->id, 'updated_by' => $editorUser->id]);
         $chapters = Chapter::factory()->count(50)->make(['created_by' => $editorUser->id, 'updated_by' => $editorUser->id]);
+
         $largeBook->pages()->saveMany($pages);
         $largeBook->chapters()->saveMany($chapters);
-        app(PermissionService::class)->buildJointPermissions();
-        app(SearchIndex::class)->indexAllEntities();
+
+        app()->make(PermissionService::class)->buildJointPermissions();
+        app()->make(SearchIndex::class)->indexAllEntities();
     }
 }

--- a/resources/sass/_blocks.scss
+++ b/resources/sass/_blocks.scss
@@ -262,6 +262,10 @@
   }
 }
 
+.tag-name.highlight, .tag-value.highlight {
+  font-weight: bold;
+}
+
 .tag-list div:last-child .tag-item {
   margin-bottom: 0;
 }

--- a/resources/views/entities/list-item-basic.blade.php
+++ b/resources/views/entities/list-item-basic.blade.php
@@ -2,7 +2,7 @@
 <a href="{{ $entity->getUrl() }}" class="{{$type}} {{$type === 'page' && $entity->draft ? 'draft' : ''}} {{$classes ?? ''}} entity-list-item" data-entity-type="{{$type}}" data-entity-id="{{$entity->id}}">
     <span role="presentation" class="icon text-{{$type}}">@icon($type)</span>
     <div class="content">
-            <h4 class="entity-list-item-name break-text">{{ $entity->name }}</h4>
+            <h4 class="entity-list-item-name break-text">{{ $entity->preview_name ?? $entity->name }}</h4>
             {{ $slot ?? '' }}
     </div>
 </a>

--- a/resources/views/entities/list-item.blade.php
+++ b/resources/views/entities/list-item.blade.php
@@ -3,9 +3,9 @@
 <div class="entity-item-snippet">
 
     @if($showPath ?? false)
-        @if($entity->book_id)
+        @if($entity->relationLoaded('book') && $entity->book)
             <span class="text-book">{{ $entity->book->getShortName(42) }}</span>
-            @if($entity->chapter_id)
+            @if($entity->relationLoaded('chapter') && $entity->chapter)
                 <span class="text-muted entity-list-item-path-sep">@icon('chevron-right')</span> <span class="text-chapter">{{ $entity->chapter->getShortName(42) }}</span>
             @endif
         @endif

--- a/resources/views/entities/list-item.blade.php
+++ b/resources/views/entities/list-item.blade.php
@@ -11,7 +11,7 @@
         @endif
     @endif
 
-    <p class="text-muted break-text">{{ $entity->getExcerpt() }}</p>
+    <p class="text-muted break-text">{{ $entity->preview_content ?? $entity->getExcerpt() }}</p>
 </div>
 
 @if(($showTags ?? false) && $entity->tags->count() > 0)

--- a/resources/views/entities/tag.blade.php
+++ b/resources/views/entities/tag.blade.php
@@ -1,9 +1,9 @@
 <div class="tag-item primary-background-light" data-name="{{ $tag->name }}" data-value="{{ $tag->value }}">
     @if($linked ?? true)
-        <div class="tag-name"><a href="{{ $tag->nameUrl() }}">@icon('tag'){{ $tag->name }}</a></div>
-        @if($tag->value) <div class="tag-value"><a href="{{ $tag->valueUrl() }}">{{$tag->value}}</a></div> @endif
+        <div class="tag-name {{ $tag->highlight_name ? 'highlight' : '' }}"><a href="{{ $tag->nameUrl() }}">@icon('tag'){{ $tag->name }}</a></div>
+        @if($tag->value) <div class="tag-value {{ $tag->highlight_value ? 'highlight' : '' }}"><a href="{{ $tag->valueUrl() }}">{{$tag->value}}</a></div> @endif
     @else
-        <div class="tag-name"><span>@icon('tag'){{ $tag->name }}</span></div>
-        @if($tag->value) <div class="tag-value"><span>{{$tag->value}}</span></div> @endif
+        <div class="tag-name {{ $tag->highlight_name ? 'highlight' : '' }}"><span>@icon('tag'){{ $tag->name }}</span></div>
+        @if($tag->value) <div class="tag-value {{ $tag->highlight_value ? 'highlight' : '' }}"><span>{{$tag->value}}</span></div> @endif
     @endif
 </div>

--- a/tests/Entity/EntitySearchTest.php
+++ b/tests/Entity/EntitySearchTest.php
@@ -18,20 +18,17 @@ class EntitySearchTest extends TestCase
 
         $search = $this->asEditor()->get('/search?term=' . urlencode($page->name));
         $search->assertSee('Search Results');
-
-        $title = strip_tags($search->getElementHtml('.entity-list-item-name'));
-        $this->assertEquals($page->name, $title);
+        $search->assertSeeText($page->name, true);
     }
 
     public function test_bookshelf_search()
     {
         /** @var Bookshelf $shelf */
         $shelf = Bookshelf::query()->first();
-        $search = $this->asEditor()->get('/search?term=' . urlencode(mb_substr($shelf->name, 0, 3)) . '  {type:bookshelf}');
-        $search->assertStatus(200);
 
-        $title = strip_tags($search->getElementHtml('.entity-list-item-name'));
-        $this->assertEquals($shelf->name, $title);
+        $search = $this->asEditor()->get('/search?term=' . urlencode($shelf->name) . '  {type:bookshelf}');
+        $search->assertSee('Search Results');
+        $search->assertSeeText($shelf->name, true);
     }
 
     public function test_invalid_page_search()

--- a/tests/Entity/EntitySearchTest.php
+++ b/tests/Entity/EntitySearchTest.php
@@ -7,7 +7,6 @@ use BookStack\Entities\Models\Book;
 use BookStack\Entities\Models\Bookshelf;
 use BookStack\Entities\Models\Chapter;
 use BookStack\Entities\Models\Page;
-use BookStack\Entities\Models\SearchTerm;
 use Tests\TestCase;
 
 class EntitySearchTest extends TestCase
@@ -410,5 +409,4 @@ class EntitySearchTest extends TestCase
         $search->assertSee('My &lt;cool&gt; <strong>TestPageContent</strong>', false);
         $search->assertSee('My supercool &lt;great&gt; <strong>TestPageContent</strong> page', false);
     }
-
 }

--- a/tests/Entity/EntitySearchTest.php
+++ b/tests/Entity/EntitySearchTest.php
@@ -383,4 +383,32 @@ class EntitySearchTest extends TestCase
         $this->assertEquals(3, $scoreByTerm->get('Animal'));
         $this->assertEquals(3, $scoreByTerm->get('SuperImportant'));
     }
+
+    public function test_matching_terms_in_search_results_are_highlighted()
+    {
+        $this->newPage(['name' => 'My Meowie Cat', 'html' => '<p>A superimportant page about meowieable animals</p>', 'tags' => [
+            ['name' => 'Animal', 'value' => 'MeowieCat'],
+            ['name' => 'SuperImportant'],
+        ]]);
+
+        $search = $this->asEditor()->get('/search?term=SuperImportant+Meowie');
+        // Title
+        $search->assertSee('My <strong>Meowie</strong> Cat', false);
+        // Content
+        $search->assertSee('A <strong>superimportant</strong> page about <strong>meowie</strong>able animals', false);
+        // Tag name
+        $search->assertElementContains('.tag-name.highlight', 'SuperImportant');
+        // Tag value
+        $search->assertElementContains('.tag-value.highlight', 'MeowieCat');
+    }
+
+    public function test_html_entities_in_item_details_remains_escaped_in_search_results()
+    {
+        $this->newPage(['name' => 'My <cool> TestPageContent', 'html' => '<p>My supercool &lt;great&gt; TestPageContent page</p>']);
+
+        $search = $this->asEditor()->get('/search?term=TestPageContent');
+        $search->assertSee('My &lt;cool&gt; <strong>TestPageContent</strong>', false);
+        $search->assertSee('My supercool &lt;great&gt; <strong>TestPageContent</strong> page', false);
+    }
+
 }

--- a/tests/Entity/EntitySearchTest.php
+++ b/tests/Entity/EntitySearchTest.php
@@ -302,4 +302,22 @@ class EntitySearchTest extends TestCase
         $search->assertSeeText($page->name);
         $search->assertSee($page->getUrl());
     }
+
+    public function test_search_ranks_common_words_lower()
+    {
+        $this->newPage(['name' => 'Test page A', 'html' => '<p>dog biscuit dog dog</p>']);
+        $this->newPage(['name' => 'Test page B', 'html' => '<p>cat biscuit</p>']);
+
+        $search = $this->asEditor()->get('/search?term=cat+dog+biscuit');
+        $search->assertElementContains('.entity-list > .page', 'Test page A', 1);
+        $search->assertElementContains('.entity-list > .page', 'Test page B', 2);
+
+        for ($i = 0; $i < 2; $i++) {
+            $this->newPage(['name' => 'Test page ' . $i, 'html' => '<p>dog</p>']);
+        }
+
+        $search = $this->asEditor()->get('/search?term=cat+dog+biscuit');
+        $search->assertElementContains('.entity-list > .page', 'Test page B', 1);
+        $search->assertElementContains('.entity-list > .page', 'Test page A', 2);
+    }
 }

--- a/tests/Entity/EntitySearchTest.php
+++ b/tests/Entity/EntitySearchTest.php
@@ -119,6 +119,18 @@ class EntitySearchTest extends TestCase
         $exactSearchB->assertStatus(200)->assertDontSee($page->name);
     }
 
+    public function test_search_terms_with_delimiters_are_converted_to_exact_matches()
+    {
+        $this->asEditor();
+        $page = $this->newPage(['name' => 'Delimiter test', 'html' => '<p>1.1 2,2 3?3 4:4 5;5 (8) &lt;9&gt; "10" \'11\' `12`</p>']);
+        $terms = explode(' ', '1.1 2,2 3?3 4:4 5;5 (8) <9> "10" \'11\' `12`');
+
+        foreach ($terms as $term) {
+            $search = $this->get('/search?term=' . urlencode($term));
+            $search->assertSee($page->name);
+        }
+    }
+
     public function test_search_filters()
     {
         $page = $this->newPage(['name' => 'My new test quaffleachits', 'html' => 'this is about an orange donkey danzorbhsing']);

--- a/tests/Entity/EntitySearchTest.php
+++ b/tests/Entity/EntitySearchTest.php
@@ -334,8 +334,7 @@ class EntitySearchTest extends TestCase
             <h6>TermG</h6>
         ']);
 
-        $entityRelationCols = ['entity_id' => $page->id, 'entity_type' => 'BookStack\\Page'];
-        $scoreByTerm = SearchTerm::query()->where($entityRelationCols)->pluck('score', 'term');
+        $scoreByTerm = $page->searchTerms()->pluck('score', 'term');
 
         $this->assertEquals(1, $scoreByTerm->get('TermA'));
         $this->assertEquals(10, $scoreByTerm->get('TermB'));
@@ -354,10 +353,22 @@ class EntitySearchTest extends TestCase
             <p>TermA</p>
         ']);
 
-        $entityRelationCols = ['entity_id' => $page->id, 'entity_type' => 'BookStack\\Page'];
-        $scoreByTerm = SearchTerm::query()->where($entityRelationCols)->pluck('score', 'term');
+        $scoreByTerm = $page->searchTerms()->pluck('score', 'term');
 
         // Scores 40 for being in the name then 1 for being in the content
         $this->assertEquals(41, $scoreByTerm->get('TermA'));
+    }
+
+    public function test_tag_names_and_values_are_indexed_for_search()
+    {
+        $page = $this->newPage(['name' => 'PageA', 'html' => '<p>content</p>', 'tags' => [
+            ['name' => 'Animal', 'value' => 'MeowieCat'],
+            ['name' => 'SuperImportant'],
+        ]]);
+
+        $scoreByTerm = $page->searchTerms()->pluck('score', 'term');
+        $this->assertEquals(5, $scoreByTerm->get('MeowieCat'));
+        $this->assertEquals(3, $scoreByTerm->get('Animal'));
+        $this->assertEquals(3, $scoreByTerm->get('SuperImportant'));
     }
 }

--- a/tests/Entity/EntitySearchTest.php
+++ b/tests/Entity/EntitySearchTest.php
@@ -18,15 +18,20 @@ class EntitySearchTest extends TestCase
 
         $search = $this->asEditor()->get('/search?term=' . urlencode($page->name));
         $search->assertSee('Search Results');
-        $search->assertSee($page->name);
+
+        $title = strip_tags($search->getElementHtml('.entity-list-item-name'));
+        $this->assertEquals($page->name, $title);
     }
 
     public function test_bookshelf_search()
     {
-        $shelf = Bookshelf::first();
+        /** @var Bookshelf $shelf */
+        $shelf = Bookshelf::query()->first();
         $search = $this->asEditor()->get('/search?term=' . urlencode(mb_substr($shelf->name, 0, 3)) . '  {type:bookshelf}');
         $search->assertStatus(200);
-        $search->assertSee($shelf->name);
+
+        $title = strip_tags($search->getElementHtml('.entity-list-item-name'));
+        $this->assertEquals($shelf->name, $title);
     }
 
     public function test_invalid_page_search()


### PR DESCRIPTION
This PR tracks ideas and progress for a series of improvements to be made for the search system.

### Enhancements

- **Term relative frequency based ranking**
  - Related: #2894,  #2840
  - _Adjust search scores based on the relative use of the given terms so that a common word has a lesser impact on search score compared to a relatively rarely-used word._
  - [x] Implementation - 7405613f8d800999713f14f125bacd1132e14818
  - [x] Testing - da17004c3ee95a13afd1ea1b460ac2eae4262e87
  - [x] A lot of raw SQL used here, Double check all is escaped correctly. 
- **Adjust existing scoring to boost titles/names further**
  - Related:  #2840
  - [x] Implementation - 9f3261398207d3c4d77d20f54ac160f61209c1e1
- **Content parsing for heading boosting**
  - _Boost terms used in header formats (h1, h2, h3...). Will need to see if performance hit from parsing is viable, Including when doing a system-re-index operation. (Maybe add a progress bar?)_
  - [x] Implementation - f28daa01d9d43d36c12b075bddca92be9e8f85e4
  - [x] Testing
- **Match tags for standard terms**
  - Related:  #1577
  - _Include tag names and values as indexed search terms so that they can be search without specifically using a tag search_
  - [x] Implementation - 99587a0be63556a6915ac2728d8236da2f61c288
  - [x] Testing
- **Auto-convert terms with parse delimiters to exact matches**
  - Related: #2095, #2088
  - _Currently using a normal term for something with term parse delimiters (eg. `192.168.1.1`) will have no results since the used search query won't match any term in the database. Instead we should convert such queries to exact searches for convenience._
  - [x] Implementation - 7d0724e2888f768149b425efcdc185a1c7a4be02
  - [x] Testing
- **Highlight/show terms within search result listing**
  - Related: #1891,  #997
  - _We should show the terms highlighted within the preview content for search results. Will just be an estimate of how it matched but even an estimation should prove useful. Ideally should also highlight tags_
  - Implementation:
    - [x] Text preview content - f30b937bb02eea92c078ea9644e3b70bd63974d8
    - [x] Item titles - ab4e99bb187fb4273dcad2fa3c731ba46e49a585
    - [x] Tags - 339518e2a6ad1cee717d821afe9238d0ac9792ed
  - [x] Testing - 63d8d72d7ecdba31903bee4c2295f2d0a2149e0d

### Fixes & Tweaks
- [x] Added progress visibility on regen-search command. -  820be162f5bfb31f69f0122a61755fdd8623275f
- [x] Prevent page HTML being returned in search query for efficiency. - b0b6f466c18f88ba0474778624195e1719c82532
- [x] Load relations in query to prevent view-time loading currently leading to n+1 situation. - bc472ca2d7f0f01b035cb17a414c9e7eef9a5576
- [x] General code refactorings
  - e1b8fe45b0271e66adbcc06c7d75ddb1a80b4556
  - 9e0164f4f45cb68f9dccf96db28c8b05ed493be7

### Docs

- Need to advise about running the search regen command to re-index according to new scoring.