### PR TITLE
Set taborder for TOTP Verification

### DIFF
--- a/resources/views/mfa/parts/verify-totp.blade.php
+++ b/resources/views/mfa/parts/verify-totp.blade.php
@@ -6,6 +6,7 @@
     {{ csrf_field() }}
     <input type="text"
            name="code"
+           tabindex="0"
            placeholder="{{ trans('auth.mfa_gen_totp_provide_code_here') }}"
            class="input-fill-width {{ $errors->has('code') ? 'neg' : '' }}">
     @if($errors->has('code'))

--- a/resources/views/mfa/parts/verify-totp.blade.php
+++ b/resources/views/mfa/parts/verify-totp.blade.php
@@ -6,7 +6,7 @@
     {{ csrf_field() }}
     <input type="text"
            name="code"
-           tabindex="0"
+           autofocus
            placeholder="{{ trans('auth.mfa_gen_totp_provide_code_here') }}"
            class="input-fill-width {{ $errors->has('code') ? 'neg' : '' }}">
     @if($errors->has('code'))


### PR DESCRIPTION
Adding tabindex=0 means when pressing tab the focus goes right to the TOTP input field.  When using a Password Manager this makes it easier than having to hit tab 3X to get the right focus.