### PR TITLE
Support custom commands via logical theme system

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,11 +2,8 @@
 
 namespace BookStack\Console;
 
-use BookStack\Facades\Theme;
-use BookStack\Theming\ThemeService;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
-use Symfony\Component\Console\Command\Command;
 
 class Kernel extends ConsoleKernel
 {
@@ -38,13 +35,6 @@ class Kernel extends ConsoleKernel
      */
     protected function commands()
     {
-        // Default framework command loading from 'Commands' directory
         $this->load(__DIR__ . '/Commands');
-
-        // Load any user commands that have been registered via the theme system.
-        $themeService = $this->app->make(ThemeService::class);
-        foreach ($themeService->getRegisteredCommands() as $command) {
-            $this->registerCommand($command);
-        }
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,8 +2,11 @@
 
 namespace BookStack\Console;
 
+use BookStack\Facades\Theme;
+use BookStack\Theming\ThemeService;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use Symfony\Component\Console\Command\Command;
 
 class Kernel extends ConsoleKernel
 {
@@ -35,6 +38,13 @@ class Kernel extends ConsoleKernel
      */
     protected function commands()
     {
+        // Default framework command loading from 'Commands' directory
         $this->load(__DIR__ . '/Commands');
+
+        // Load any user commands that have been registered via the theme system.
+        $themeService = $this->app->make(ThemeService::class);
+        foreach ($themeService->getRegisteredCommands() as $command) {
+            $this->registerCommand($command);
+        }
     }
 }

--- a/app/Theming/ThemeService.php
+++ b/app/Theming/ThemeService.php
@@ -3,16 +3,12 @@
 namespace BookStack\Theming;
 
 use BookStack\Auth\Access\SocialAuthService;
+use Illuminate\Contracts\Console\Kernel;
 use Symfony\Component\Console\Command\Command;
 
 class ThemeService
 {
     protected $listeners = [];
-
-    /**
-     * @var Command[]
-     */
-    protected $commands = [];
 
     /**
      * Listen to a given custom theme event,
@@ -54,15 +50,9 @@ class ThemeService
      */
     public function registerCommand(Command $command)
     {
-        $this->commands[] = $command;
-    }
-
-    /**
-     * Get the custom commands that have been registered.
-     */
-    public function getRegisteredCommands(): array
-    {
-        return $this->commands;
+        /** @var \Illuminate\Foundation\Console\Kernel $consoleKernel */
+        $consoleKernel = app()->make(Kernel::class);
+        $consoleKernel->registerCommand($command);
     }
 
     /**

--- a/app/Theming/ThemeService.php
+++ b/app/Theming/ThemeService.php
@@ -3,10 +3,16 @@
 namespace BookStack\Theming;
 
 use BookStack\Auth\Access\SocialAuthService;
+use Symfony\Component\Console\Command\Command;
 
 class ThemeService
 {
     protected $listeners = [];
+
+    /**
+     * @var Command[]
+     */
+    protected $commands = [];
 
     /**
      * Listen to a given custom theme event,
@@ -41,6 +47,22 @@ class ThemeService
         }
 
         return null;
+    }
+
+    /**
+     * Register a new custom artisan command to be available.
+     */
+    public function registerCommand(Command $command)
+    {
+        $this->commands[] = $command;
+    }
+
+    /**
+     * Get the custom commands that have been registered.
+     */
+    public function getRegisteredCommands(): array
+    {
+        return $this->commands;
     }
 
     /**

--- a/dev/docs/logical-theme-system.md
+++ b/dev/docs/logical-theme-system.md
@@ -77,6 +77,32 @@ Theme::listen(ThemeEvents::APP_BOOT, function($app) {
 });
 ```
 
+## Custom Commands
+
+The logical theme system supports adding custom [artisan commands](https://laravel.com/docs/8.x/artisan) to BookStack. These can be registered in your `functions.php` file by calling `Theme::registerCommand($command)`, where `$command` is an instance of `\Symfony\Component\Console\Command\Command`. 
+
+Below is an example of registering a command that could then be ran using `php artisan bookstack:meow` on the command line.
+
+```php
+<?php
+
+use BookStack\Facades\Theme;
+use Illuminate\Console\Command;
+
+class MeowCommand extends Command
+{
+    protected $signature = 'bookstack:meow';
+    protected $description = 'Say meow on the command line';
+
+    public function handle()
+    {
+        $this->line('Meow there!');
+    }
+}
+
+Theme::registerCommand(new MeowCommand);
+```
+
 ## Custom Socialite Service Example
 
 The below shows an example of adding a custom reddit socialite service to BookStack. 

--- a/tests/ThemeTest.php
+++ b/tests/ThemeTest.php
@@ -7,8 +7,10 @@ use BookStack\Entities\Models\Page;
 use BookStack\Entities\Tools\PageContent;
 use BookStack\Facades\Theme;
 use BookStack\Theming\ThemeEvents;
+use Illuminate\Console\Command;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use League\CommonMark\ConfigurableEnvironmentInterface;
 
@@ -206,6 +208,16 @@ class ThemeTest extends TestCase
         $this->assertStringContainsString('donkey=donut', $redirect);
     }
 
+    public function test_register_command_allows_provided_command_to_be_usable_via_artisan()
+    {
+        Theme::registerCommand(new MyCustomCommand);
+
+        Artisan::call('bookstack:test-custom-command', []);
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Command ran!', $output);
+    }
+
     protected function usingThemeFolder(callable $callback)
     {
         // Create a folder and configure a theme
@@ -218,5 +230,12 @@ class ThemeTest extends TestCase
 
         // Cleanup the custom theme folder we created
         File::deleteDirectory($themeFolderPath);
+    }
+}
+
+class MyCustomCommand extends Command {
+    protected $signature = 'bookstack:test-custom-command';
+    public function handle() {
+        $this->line('Command ran!');
     }
 }


### PR DESCRIPTION
Added initial work to support registering commands through the logical
theme system. Includes docs changes and example.

Related to #2288