### PR TITLE
Search by User IP Adress in Audit Log

### DIFF
--- a/app/Http/Controllers/AuditLogController.php
+++ b/app/Http/Controllers/AuditLogController.php
@@ -46,7 +46,7 @@ class AuditLogController extends Controller
             $query->where('created_at', '<=', $listDetails['date_to']);
         }
         if ($listDetails['ip']) {
-            $query->where('ip', 'like', $listDetails['ip'] . "%");
+            $query->where('ip', 'like', $listDetails['ip'] . '%');
         }
 
         $activities = $query->paginate(100);

--- a/app/Http/Controllers/AuditLogController.php
+++ b/app/Http/Controllers/AuditLogController.php
@@ -46,7 +46,7 @@ class AuditLogController extends Controller
             $query->where('created_at', '<=', $listDetails['date_to']);
         }
         if ($listDetails['ip']) {
-            $query->where('ip', '=', $listDetails['ip']);
+            $query->where('ip', 'like', $listDetails['ip'] . "%");
         }
 
         $activities = $query->paginate(100);

--- a/app/Http/Controllers/AuditLogController.php
+++ b/app/Http/Controllers/AuditLogController.php
@@ -20,6 +20,7 @@ class AuditLogController extends Controller
             'date_from' => $request->get('date_from', ''),
             'date_to'   => $request->get('date_to', ''),
             'user'      => $request->get('user', ''),
+            'ip'        => $request->get('ip', ''),
         ];
 
         $query = Activity::query()
@@ -43,6 +44,9 @@ class AuditLogController extends Controller
         }
         if ($listDetails['date_to']) {
             $query->where('created_at', '<=', $listDetails['date_to']);
+        }
+        if ($listDetails['ip']) {
+            $query->where('ip', '=', $listDetails['ip']);
         }
 
         $activities = $query->paginate(100);

--- a/database/migrations/2021_11_26_070438_add_index_for_user_ip.php
+++ b/database/migrations/2021_11_26_070438_add_index_for_user_ip.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIndexForUserIp extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->index('ip', 'ip_address_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->dropIndex('ip_address_index');
+        });
+    }
+}

--- a/database/migrations/2021_11_26_070438_add_index_for_user_ip.php
+++ b/database/migrations/2021_11_26_070438_add_index_for_user_ip.php
@@ -14,7 +14,7 @@ class AddIndexForUserIp extends Migration
     public function up()
     {
         Schema::table('activities', function (Blueprint $table) {
-            $table->index('ip', 'ip_address_index');
+            $table->index('ip', 'activities_ip_index');
         });
     }
 
@@ -26,7 +26,7 @@ class AddIndexForUserIp extends Migration
     public function down()
     {
         Schema::table('activities', function (Blueprint $table) {
-            $table->dropIndex('ip_address_index');
+            $table->dropIndex('activities_ip_index');
         });
     }
 }

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -123,6 +123,7 @@ return [
     'audit_table_date' => 'Activity Date',
     'audit_date_from' => 'Date Range From',
     'audit_date_to' => 'Date Range To',
+    'ip_address' => 'IP',
 
     // Role Settings
     'roles' => 'Roles',

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -123,7 +123,6 @@ return [
     'audit_table_date' => 'Activity Date',
     'audit_date_from' => 'Date Range From',
     'audit_date_to' => 'Date Range To',
-    'ip_address' => 'IP',
 
     // Role Settings
     'roles' => 'Roles',

--- a/resources/views/settings/audit.blade.php
+++ b/resources/views/settings/audit.blade.php
@@ -51,7 +51,7 @@
 
                 <div class="form-group ml-auto">
                     <label for="ip">{{ trans('settings.audit_table_ip') }}</label>
-                    @include('form.text', ['name' => 'ip', 'model' => $listDetails['ip'] ? \BookStack\Actions\Activity::query()->where(['ip' => $listDetails['ip']])->first() : null])
+                    @include('form.text', ['name' => 'ip', 'model' => (object) $listDetails])
                     <input type="submit" style="display: none">
                 </div>
             </form>

--- a/resources/views/settings/audit.blade.php
+++ b/resources/views/settings/audit.blade.php
@@ -47,6 +47,13 @@
                     <label for="owner">{{ trans('settings.audit_table_user') }}</label>
                     @include('form.user-select', ['user' => $listDetails['user'] ? \BookStack\Auth\User::query()->find($listDetails['user']) : null, 'name' => 'user', 'compact' =>  true])
                 </div>
+
+
+                <div class="form-group ml-m"
+                     option:submit-on-change:filter='[name="ip"]'>
+                    <label for="owner">IP address</label>
+                    @include('form.text', ['name' => 'ip'])
+                </div>
             </form>
         </div>
 

--- a/resources/views/settings/audit.blade.php
+++ b/resources/views/settings/audit.blade.php
@@ -49,7 +49,7 @@
                 </div>
 
 
-                <div class="form-group ml-m">
+                <div class="form-group ml-auto">
                     <label for="ip">{{ trans('settings.ip_address') }}</label>
                     @include('form.text', ['name' => 'ip'])
                 </div>

--- a/resources/views/settings/audit.blade.php
+++ b/resources/views/settings/audit.blade.php
@@ -52,6 +52,7 @@
                 <div class="form-group ml-auto">
                     <label for="ip">{{ trans('settings.ip_address') }}</label>
                     @include('form.text', ['name' => 'ip'])
+                    <input type="submit" style="display: none">
                 </div>
             </form>
         </div>

--- a/resources/views/settings/audit.blade.php
+++ b/resources/views/settings/audit.blade.php
@@ -50,7 +50,7 @@
 
 
                 <div class="form-group ml-auto">
-                    <label for="ip">{{ trans('settings.ip_address') }}</label>
+                    <label for="ip">{{ trans('settings.audit_table_ip') }}</label>
                     @include('form.text', ['name' => 'ip', 'model' => $listDetails['ip'] ? \BookStack\Actions\Activity::query()->where(['ip' => $listDetails['ip']])->first() : null])
                     <input type="submit" style="display: none">
                 </div>

--- a/resources/views/settings/audit.blade.php
+++ b/resources/views/settings/audit.blade.php
@@ -41,7 +41,7 @@
                     </div>
                 @endforeach
 
-                <div class="form-group ml-auto"
+                <div class="form-group ml-auto mr-m"
                      component="submit-on-change"
                      option:submit-on-change:filter='[name="user"]'>
                     <label for="owner">{{ trans('settings.audit_table_user') }}</label>

--- a/resources/views/settings/audit.blade.php
+++ b/resources/views/settings/audit.blade.php
@@ -49,9 +49,8 @@
                 </div>
 
 
-                <div class="form-group ml-m"
-                     option:submit-on-change:filter='[name="ip"]'>
-                    <label for="owner">IP address</label>
+                <div class="form-group ml-m">
+                    <label for="ip">{{ trans('settings.ip_address') }}</label>
                     @include('form.text', ['name' => 'ip'])
                 </div>
             </form>

--- a/resources/views/settings/audit.blade.php
+++ b/resources/views/settings/audit.blade.php
@@ -51,7 +51,7 @@
 
                 <div class="form-group ml-auto">
                     <label for="ip">{{ trans('settings.ip_address') }}</label>
-                    @include('form.text', ['name' => 'ip'])
+                    @include('form.text', ['name' => 'ip', 'model' => $listDetails['ip'] ? \BookStack\Actions\Activity::query()->where(['ip' => $listDetails['ip']])->first() : null])
                     <input type="submit" style="display: none">
                 </div>
             </form>

--- a/tests/AuditLogTest.php
+++ b/tests/AuditLogTest.php
@@ -166,6 +166,24 @@ class AuditLogTest extends TestCase
         $resp->assertSee('192.123.45.1');
     }
 
+    public function test_ip_address_is_searchable()
+    {
+        config()->set('app.proxies', '*');
+        $editor = $this->getEditor();
+        /** @var Page $page */
+        $page = Page::query()->first();
+
+        $this->actingAs($editor)->put($page->getUrl(), [
+            'name' => 'Updated page',
+            'html' => '<p>Updated content</p>',
+        ], [
+            'X-Forwarded-For' => '192.123.45.1',
+        ])->assertRedirect($page->refresh()->getUrl());
+
+        $resp = $this->asAdmin()->get('/settings/audit?&ip=192.123');
+        $resp->assertSee('192.123.45.1');
+    }
+
     public function test_ip_address_not_logged_in_demo_mode()
     {
         config()->set('app.proxies', '*');


### PR DESCRIPTION
Features:

- add input field for searching IP address in audit log view.
    - add a hidden submit button in view. Form submits automatically after user press `Enter`
- add search type in audit log controller. IP address search in full string match. (use `=` not `like`)
- create index for user ip address (DB migration)

UI preview :

![擷取選取區域_003](https://user-images.githubusercontent.com/114491/143542384-90b215b9-c229-4571-9d97-6715e19da723.png)

----

Note: related with issue #2951