### PR TITLE
Added clarifying text to OIDC environment variables.

### DIFF
--- a/.env.example.complete
+++ b/.env.example.complete
@@ -134,7 +134,7 @@ STORAGE_S3_ENDPOINT=https://my-custom-s3-compatible.service.com:8001
 STORAGE_URL=false
 
 # Authentication method to use
-# Can be 'standard', 'ldap' or 'saml2'
+# Can be 'standard', 'ldap', 'saml2' or 'oidc'
 AUTH_METHOD=standard
 
 # Social authentication configuration
@@ -241,16 +241,50 @@ SAML2_USER_TO_GROUPS=false
 SAML2_GROUP_ATTRIBUTE=group
 SAML2_REMOVE_FROM_GROUPS=false
 
-# OpenID Connect authentication configuration
+## OpenID Connect authentication configuration
+
+# Set the display name to be shown on the login button.
+# (Login with <name>)
 OIDC_NAME=SSO
+
+# Name of the claims(s) to use for the user's display name.
+# Can have multiple attributes listed, separated with a '|' in which 
+# case those values will be joined with a space.
+# Example: OIDC_DISPLAY_NAME_CLAIMS=given_name|family_name
 OIDC_DISPLAY_NAME_CLAIMS=name
-OIDC_CLIENT_ID=null
-OIDC_CLIENT_SECRET=null
-OIDC_ISSUER=null
-OIDC_ISSUER_DISCOVER=false
-OIDC_PUBLIC_KEY=null
-OIDC_AUTH_ENDPOINT=null
-OIDC_TOKEN_ENDPOINT=null
+
+# OAuth Client ID to access the identity provider
+OIDC_CLIENT_ID=abc123
+
+# OAuth Client Secret to access the identity provider
+OIDC_CLIENT_SECRET=def456
+
+# Issuer URL
+# Must start with 'https://'
+OIDC_ISSUER=https://instance.authsystem.example.com
+
+# Enable auto-discovery of endpoints and token keys.
+# As per the standard, expects the service to serve a 
+# `<issuer>/.well-known/openid-configuration` endpoint.
+OIDC_ISSUER_DISCOVER=true
+
+############################################################
+## NOTE: The below are only needed if not using the above ##
+##       auto-discovery option.                           ##
+############################################################
+
+# Path to identity provider token signing public RSA key
+OIDC_PUBLIC_KEY=file:///keys/idp-public-key.pem
+
+# Full URL to the OIDC authorize endpoint
+OIDC_AUTH_ENDPOINT=https://instance.authsystem.example.com/v1/authorize
+
+# Full URL to the OIDC token endpoint
+OIDC_TOKEN_ENDPOINT=https://instance.authsystem.example.com/v1/token
+
+# Dump out the details fetched from the identity provider.
+# Only set this option to true if debugging since it will block logins
+# and potentially show private details.
 OIDC_DUMP_USER_DETAILS=false
 
 # Disable default third-party services such as Gravatar and Draw.IO


### PR DESCRIPTION
Clarifying text is now in sync with code snippets that are also available on bookstack documentation website.

I realize that there are now two areas to maintain the same information, which in future might lead to two different versions. In my opinion, the .env.example.complete should always be leading above the code snippets on the website (as this is delivered with a Bookstack install and is first point of reference when configuring).