### PR TITLE
User can create markdown page even system is in wysiwyg mode

### DIFF
--- a/resources/lang/en/entities.php
+++ b/resources/lang/en/entities.php
@@ -173,6 +173,7 @@ return [
     'x_pages' => ':count Page|:count Pages',
     'pages_popular' => 'Popular Pages',
     'pages_new' => 'New Page',
+    'pages_markdown_new' => 'New Markdown',
     'pages_attachments' => 'Attachments',
     'pages_navigation' => 'Page Navigation',
     'pages_delete' => 'Delete Page',

--- a/resources/lang/zh_CN/entities.php
+++ b/resources/lang/zh_CN/entities.php
@@ -173,6 +173,7 @@ return [
     'x_pages' => ':count个页面',
     'pages_popular' => '热门页面',
     'pages_new' => '新页面',
+    'pages_markdown_new' => '新 Markdown',
     'pages_attachments' => '附件',
     'pages_navigation' => '页面导航',
     'pages_delete' => '删除页面',

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -46,6 +46,12 @@
                                 <span class="icon">@icon('page')</span>
                                 <span>{{ trans('entities.books_empty_create_page') }}</span>
                             </a>
+                            @if(setting('app-editor') === 'wysiwyg')
+                                <a href="{{ $book->getUrl('/create-markdown-page') }}" class="icon-list-item text-page">
+                                    <span class="icon">@icon('page')</span>
+                                    <span>{{ trans('entities.pages_markdown_new') }}</span>
+                                </a>
+                            @endif
                         @endif
                         @if(userCan('chapter-create', $book))
                             <a href="{{ $book->getUrl('/create-chapter') }}" class="icon-list-item text-chapter">
@@ -90,6 +96,12 @@
                     <span>@icon('add')</span>
                     <span>{{ trans('entities.pages_new') }}</span>
                 </a>
+                @if(setting('app-editor') === 'wysiwyg')
+                    <a href="{{ $book->getUrl('/create-markdown-page') }}" class="icon-list-item text-page">
+                        <span>@icon('add')</span>
+                        <span>{{ trans('entities.pages_markdown_new') }}</span>
+                    </a>
+                @endif
             @endif
             @if(userCan('chapter-create', $book))
                 <a href="{{ $book->getUrl('/create-chapter') }}" class="icon-list-item">

--- a/resources/views/chapters/show.blade.php
+++ b/resources/views/chapters/show.blade.php
@@ -40,6 +40,12 @@
                                 <span class="icon">@icon('page')</span>
                                 <span>{{ trans('entities.books_empty_create_page') }}</span>
                             </a>
+                            @if(setting('app-editor') === 'wysiwyg')
+                                <a href="{{ $chapter->getUrl('/create-markdown-page') }}" class="icon-list-item text-page">
+                                    <span class="icon">@icon('page')</span>
+                                    <span>{{ trans('entities.pages_markdown_new') }}</span>
+                                </a>
+                            @endif
                         @endif
                         @if(userCan('book-update', $book))
                             <a href="{{ $book->getUrl('/sort') }}" class="icon-list-item text-book">
@@ -98,6 +104,12 @@
                     <span>@icon('add')</span>
                     <span>{{ trans('entities.pages_new') }}</span>
                 </a>
+                @if(setting('app-editor') === 'wysiwyg')
+                    <a href="{{ $chapter->getUrl('/create-markdown-page') }}" class="icon-list-item">
+                        <span class="icon">@icon('add')</span>
+                        <span>{{ trans('entities.pages_markdown_new') }}</span>
+                    </a>
+                @endif
             @endif
 
             <hr class="primary-background"/>

--- a/resources/views/pages/edit.blade.php
+++ b/resources/views/pages/edit.blade.php
@@ -15,7 +15,7 @@
             @if(!isset($isDraft))
                 <input type="hidden" name="_method" value="PUT">
             @endif
-            @include('pages.parts.form', ['model' => $page])
+            @include('pages.parts.form', ['model' => $page, 'isMarkdown' => $isMarkdown])
             @include('pages.parts.editor-toolbox')
         </form>
     </div>

--- a/resources/views/pages/parts/form.blade.php
+++ b/resources/views/pages/parts/form.blade.php
@@ -78,12 +78,12 @@
     <div class="edit-area flex-fill flex">
 
         {{--WYSIWYG Editor--}}
-        @if(setting('app-editor') === 'wysiwyg')
+        @if(setting('app-editor') === 'wysiwyg' && !$isMarkdown)
             @include('pages.parts.wysiwyg-editor', ['model' => $model])
         @endif
 
         {{--Markdown Editor--}}
-        @if(setting('app-editor') === 'markdown')
+        @if(setting('app-editor') === 'markdown' || $isMarkdown)
             @include('pages.parts.markdown-editor', ['model' => $model])
         @endif
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -86,6 +86,7 @@ Route::middleware('auth')->group(function () {
 
     // Pages
     Route::get('/books/{bookSlug}/create-page', [PageController::class, 'create']);
+    Route::get('/books/{bookSlug}/create-markdown-page', [PageController::class, 'createMarkdown']);
     Route::post('/books/{bookSlug}/create-guest-page', [PageController::class, 'createAsGuest']);
     Route::get('/books/{bookSlug}/draft/{pageId}', [PageController::class, 'editDraft']);
     Route::post('/books/{bookSlug}/draft/{pageId}', [PageController::class, 'store']);
@@ -116,6 +117,7 @@ Route::middleware('auth')->group(function () {
 
     // Chapters
     Route::get('/books/{bookSlug}/chapter/{chapterSlug}/create-page', [PageController::class, 'create']);
+    Route::get('/books/{bookSlug}/chapter/{chapterSlug}/create-markdown-page', [PageController::class, 'createMarkdown']);
     Route::post('/books/{bookSlug}/chapter/{chapterSlug}/create-guest-page', [PageController::class, 'createAsGuest']);
     Route::get('/books/{bookSlug}/create-chapter', [ChapterController::class, 'create']);
     Route::post('/books/{bookSlug}/create-chapter', [ChapterController::class, 'store']);


### PR DESCRIPTION
On current BookStack App, if you chose to use WYSIWYG, you cannot create Markdown page any more.

However, in a lot of companies there are both developers and other users, which developers may prefer Markdown and others use WYSIWYG.

I add a "New Markdown" link below "New Page" so user can choose which kind of page to create.