### PR TITLE
chore(dev): add xdebug support for docker setup

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update -y \
     && apt-get install -y git zip unzip libpng-dev libldap2-dev libzip-dev wait-for-it \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
     && docker-php-ext-install pdo_mysql gd ldap zip \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
     && a2enmod rewrite \
     && sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
     && sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf

--- a/dev/docker/php/conf.d/xdebug.ini
+++ b/dev/docker/php/conf.d/xdebug.ini
@@ -1,0 +1,7 @@
+zend_extension=xdebug
+
+[xdebug]
+xdebug.mode=debug
+xdebug.client_host=host.docker.internal
+xdebug.start_with_request=yes
+xdebug.client_port=9090

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,10 @@ services:
       - ${DEV_PORT:-8080}:80
     volumes:
       - ./:/app
+      - ./dev/docker/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
     entrypoint: /app/dev/docker/entrypoint.app.sh
+    extra_hosts:
+    - "host.docker.internal:host-gateway"
   node:
     image: node:alpine
     working_dir: /app

--- a/readme.md
+++ b/readme.md
@@ -156,6 +156,11 @@ Once the database has been migrated & seeded, you can run the tests like so:
 docker-compose run app php vendor/bin/phpunit
 ```
 
+#### Debugging
+
+The docker-compose setup ships with Xdebug, which you can listen to on port 9090.
+NB : For some editors like Visual Studio Code, you might need to map your workspace folder to the /app folder within the docker container for this to work.
+
 ## 🌎 Translations
 
 Translations for text within BookStack is managed through the [BookStack project on Crowdin](https://crowdin.com/project/bookstack). Some strings have colon-prefixed variables in such as `:userName`. Leave these values as they are as they will be replaced at run-time. Crowdin is the preferred way to provide translations, otherwise the raw translations files can be found within the `resources/lang` path.


### PR DESCRIPTION
Add xdebug support in the docker compose setup.
Works well with my my setup (vscode), should work fine for other IDE as well.

If this looks good, I will provide documentation in the README.md and other relevant places (?).