### PR TITLE
Adding nextcloud for third party auth

### DIFF
--- a/app/Auth/Access/SocialAuthService.php
+++ b/app/Auth/Access/SocialAuthService.php
@@ -46,6 +46,7 @@ class SocialAuthService
         'gitlab',
         'twitch',
         'discord',
+        'nextcloud',
     ];
 
     /**

--- a/app/Config/services.php
+++ b/app/Config/services.php
@@ -116,6 +116,16 @@ return [
         'auto_confirm'  => env('DISCORD_AUTO_CONFIRM_EMAIL', false),
     ],
 
+    'nextcloud' => [
+        'client_id'     => env('NEXTCLOUD_CLIENT_ID'),
+        'client_secret' => env('NEXTCLOUD_CLIENT_SECRET'),
+        'redirect'      => env('APP_URL') . '/login/service/nextcloud/callback',
+        'instance_uri'  => env('NEXTCLOUD_BASE_URI'),
+        'name'          => env('NEXTCLOUD_NAME', 'Nextcloud'),
+        'auto_register' => env('NEXTCLOUD_AUTO_REGISTER', false),
+        'auto_confirm'  => env('NEXTCLOUD_AUTO_CONFIRM_EMAIL', false),
+    ],
+
     'ldap' => [
         'server'                 => env('LDAP_SERVER', false),
         'dump_user_details'      => env('LDAP_DUMP_USER_DETAILS', false),

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -20,6 +20,7 @@ class EventServiceProvider extends ServiceProvider
             'SocialiteProviders\GitLab\GitLabExtendSocialite@handle',
             'SocialiteProviders\Twitch\TwitchExtendSocialite@handle',
             'SocialiteProviders\Discord\DiscordExtendSocialite@handle',
+            'SocialiteProviders\Nextcloud\NextcloudExtendSocialite@handle',
         ],
     ];
 

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "socialiteproviders/gitlab": "^4.1",
         "socialiteproviders/microsoft-azure": "^5.0.1",
         "socialiteproviders/okta": "^4.1",
+        "socialiteproviders/nextcloud": "^4.0",
         "socialiteproviders/slack": "^4.1",
         "socialiteproviders/twitch": "^5.3",
         "ssddanbrown/htmldiff": "^1.0.2"


### PR DESCRIPTION
**Request:**

We want to use our existing nextcloud instance for authentification.

**Solution:**

Add nextcloud to social providers by using the already implemented socialite providers library.