### PR TITLE
Added cache breaker to tinymce loading systems

### DIFF
--- a/resources/js/wysiwyg/config.js
+++ b/resources/js/wysiwyg/config.js
@@ -221,11 +221,15 @@ export function build(options) {
     // Build toolbar content
     const {toolbar, groupButtons: toolBarGroupButtons} = buildToolbar(options);
 
+    // BookStack Version
+    const version = document.querySelector('script[src*="/dist/app.js"]').getAttribute('src').split('?version=')[1];
+
     // Return config object
     return {
         width: '100%',
         height: '100%',
         selector: '#html-editor',
+        cache_suffix: '?version=' + version,
         content_css: [
             window.baseUrl('/dist/styles.css'),
         ],


### PR DESCRIPTION
Fixes scenario where a bunch of plugin errors would show.

Takes the version from BookStack app.js paths instead of tinyMCE version since things external from TinyMCE could be loaded using this.
