### PR TITLE
Tiny header

### DIFF
--- a/resources/lang/pt/editor.php
+++ b/resources/lang/pt/editor.php
@@ -31,7 +31,7 @@ return [
     'header_large' => 'Cabeçalho grande',
     'header_medium' => 'Cabeçalho médio',
     'header_small' => 'Cabeçalho pequeno',
-    'header_tiny' => 'Cabeçalho pequeno',
+    'header_tiny' => 'Cabeçalho minúsculo',
     'paragraph' => 'Parágrafo',
     'blockquote' => 'Citação',
     'inline_code' => 'Código embutido',


### PR DESCRIPTION
Had the same translation as the small header. Corrected the translation.