### PR TITLE
Made it possible to configure draw.io/diagrams.net integration

### DIFF
--- a/resources/js/services/drawio.js
+++ b/resources/js/services/drawio.js
@@ -43,6 +43,8 @@ function drawReceive(event) {
         drawEventSave(message);
     } else if (message.event === 'export') {
         drawEventExport(message);
+    } else if (message.event === 'configure') {
+        drawEventConfigure();
     }
 }
 
@@ -61,6 +63,12 @@ function drawEventInit() {
     onInit().then(xml => {
         drawPostMessage({action: 'load', autosave: 1, xml: xml});
     });
+}
+
+function drawEventConfigure() {
+    const config = {};
+    window.$events.emitPublic(iFrame, 'editor-drawio::configure', {config});
+    drawPostMessage({action: 'configure', config});
 }
 
 function drawEventClose() {

--- a/resources/views/pages/parts/form.blade.php
+++ b/resources/views/pages/parts/form.blade.php
@@ -1,7 +1,7 @@
 <div component="page-editor" class="page-editor flex-fill flex"
      option:page-editor:drafts-enabled="{{ $draftsEnabled ? 'true' : 'false' }}"
      @if(config('services.drawio'))
-        drawio-url="{{ is_string(config('services.drawio')) ? config('services.drawio') : 'https://embed.diagrams.net/?embed=1&proto=json&spin=1' }}"
+        drawio-url="{{ is_string(config('services.drawio')) ? config('services.drawio') : 'https://embed.diagrams.net/?embed=1&proto=json&spin=1&configure=1' }}"
      @endif
      @if($model->name === trans('entities.pages_initial_name'))
         option:page-editor:has-default-title="true"

--- a/tests/Uploads/DrawioTest.php
+++ b/tests/Uploads/DrawioTest.php
@@ -71,7 +71,7 @@ class DrawioTest extends TestCase
         $editor = $this->getEditor();
 
         $resp = $this->actingAs($editor)->get($page->getUrl('/edit'));
-        $resp->assertSee('drawio-url="https://embed.diagrams.net/?embed=1&amp;proto=json&amp;spin=1"', false);
+        $resp->assertSee('drawio-url="https://embed.diagrams.net/?embed=1&amp;proto=json&amp;spin=1&amp;configure=1"', false);
 
         config()->set('services.drawio', false);
         $resp = $this->actingAs($editor)->get($page->getUrl('/edit'));


### PR DESCRIPTION
Added new editor public event to hook into draw.io configuration step.
Required change of embed url to trigger the configure step.

Closes #3381

### Docs Updates

- Update references to the default diagrams.net embed url.
  -  Now `https://embed.diagrams.net/?embed=1&proto=json&spin=1&configure=1`.
- Add example of using this new public event to the existing editor events list.

### Example Event Usage

```html
<script>
    window.addEventListener('editor-drawio::configure', event => {
        const config = event.detail.config;
        config.sidebarWidth = 900;
    });
</script>
```

### References 

- https://www.diagrams.net/doc/faq/configure-diagram-editor
- https://desk.draw.io/support/solutions/articles/16000042544
- https://github.com/jgraph/drawio-integration