### PR TITLE
Skip intermediate login page with single provider

### DIFF
--- a/app/Config/auth.php
+++ b/app/Config/auth.php
@@ -13,6 +13,11 @@ return [
     // Options: standard, ldap, saml2, oidc
     'method' => env('AUTH_METHOD', 'standard'),
 
+    // Automatically redirect to external login provider if only one provider is being used
+    // instead of displaying a single-button login page and requiring users to click through
+    // Supported methods: saml2, oidc
+    'auto_redirect' => env('AUTH_AUTO_REDIRECT', false),
+
     // Authentication Defaults
     // This option controls the default authentication "guard" and password
     // reset options for your application.

--- a/resources/views/auth/login-redirect.blade.php
+++ b/resources/views/auth/login-redirect.blade.php
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="{{ config('app.lang') }}"
+      dir="{{ config('app.rtl') ? 'rtl' : 'ltr' }}">
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+    <div id="loginredirect-wrapper" style="display:none">
+        @include('auth.parts.login-form-' . $authMethod)
+    </div>
+
+    <script nonce="{{ $cspNonce }}">
+        window.onload = function(){document.forms['login-form'].submit()};
+    </script>
+</body>
+</html>

--- a/tests/Auth/OidcTest.php
+++ b/tests/Auth/OidcTest.php
@@ -26,6 +26,7 @@ class OidcTest extends TestCase
 
         config()->set([
             'auth.method'                 => 'oidc',
+            'auth.auto_redirect'          => false,
             'auth.defaults.guard'         => 'oidc',
             'oidc.name'                   => 'SingleSignOn-Testing',
             'oidc.display_name_claims'    => ['name'],
@@ -109,6 +110,19 @@ class OidcTest extends TestCase
 
         $resp = $this->post('/register');
         $this->assertPermissionError($resp);
+    }
+
+    public function test_automatic_redirect_on_login()
+    {
+        config()->set([
+            'auth.auto_redirect'        => true,
+            'services.google.client_id' => false,
+            'services.github.client_id' => false,
+        ]);
+        $req = $this->get('/login');
+        $req->assertSeeText('SingleSignOn-Testing');
+        $req->assertElementExists('form[action$="/oidc/login"][method=POST] button');
+        $req->assertElementExists('div#loginredirect-wrapper');
     }
 
     public function test_login()


### PR DESCRIPTION
Resolves #3216, #2175

When a single authentication provider is configured, it is now possible to skip the intermediate user interaction on the /login page and redirect directly to the auth provider's actual login page, saving an extra click for users.
This new behaviour is disabled by default, and can be enabled by setting the AUTH_AUTO_REDIRECT environment variable to true.

This new behaviour only works for saml2 and oidc providers, and will not work if Social Auth providers are enabled.
This new behaviour will not be honoured for /login if argument ?logout=1 is passed (which is where users are redirected to after logout when AUTH_AUTO_REDIRECT is set to true).

This also introduces an overridden logout() function so post-logout redirection can be honoured (it appears redirectAfterLogout has not been honoured in Laravel since ~5.3 - see laravel/framework#15525)