### PR TITLE
Improve 'LanguageTest::test_locales_config_key_set_properly'

### DIFF
--- a/.github/ISSUE_TEMPLATE/language_request.yml
+++ b/.github/ISSUE_TEMPLATE/language_request.yml
@@ -1,5 +1,5 @@
 name: Language Request
-description: Request a new language to be added to CrowdIn for you to translate
+description: Request a new language to be added to Crowdin for you to translate
 labels: [":earth_africa: Translations"]
 assignees:
   - ssddanbrown
@@ -23,7 +23,7 @@ body:
         This issue template is to request a new language be added to our [Crowdin translation management project](https://crowdin.com/project/bookstack).
         Please don't use this template to request a new language that you are not prepared to provide translations for.
       options:
-        - label: I confirm I'm offering to help translate for this new language via CrowdIn.
+        - label: I confirm I'm offering to help translate for this new language via Crowdin.
           required: true
   - type: markdown
     attributes:

--- a/tests/LanguageTest.php
+++ b/tests/LanguageTest.php
@@ -18,9 +18,11 @@ class LanguageTest extends TestCase
     public function test_locales_config_key_set_properly()
     {
         $configLocales = config('app.locales');
-        sort($configLocales);
-        sort($this->langs);
-        $this->assertEquals(implode(':', $configLocales), implode(':', $this->langs), 'app.locales configuration variable does not match those found in lang files');
+
+        $this->assertEmpty(
+            array_diff($configLocales, $this->langs),
+            'app.locales configuration variable does not match those found in lang files'
+        );
     }
 
     // Not part of standard phpunit test runs since we sometimes expect non-added langs.


### PR DESCRIPTION
Hey everyone!

In this PR I've updated the `LanguageTest::test_locales_config_key_set_properly` Unit test to better handle such cases when a new locale is added in Crowdin. 

As we can see [here](https://github.com/BookStackApp/BookStack/actions/runs/2468769080), a new locale was added in Crowdin and the test fails. The strict comparison is unnecessary. It should be enough to check if there are corresponding language folders to the config locales. Nothing happens if the lang folder will contain extra language.

In addition, I've made a minor fix of Crowdin name in the issue template 🙂 