### PR TITLE
Add Colorpicker for table background and border

### DIFF
--- a/resources/js/wysiwyg/config.js
+++ b/resources/js/wysiwyg/config.js
@@ -110,6 +110,7 @@ function gatherPlugins(options) {
         "about",
         "details",
         "tasklist",
+        "colorpicker",
         options.textDirection === 'rtl' ? 'directionality' : '',
     ];
 


### PR DESCRIPTION
Enable the colorpicker plugin in tinyMCE (used in table cell background color and such)
![image](https://user-images.githubusercontent.com/375633/183256293-bfd574ba-8efb-432a-8618-e14c58338ee8.png)
