### PR TITLE
API - Search pages by slug

### DIFF
--- a/app/Http/Controllers/Api/PageApiController.php
+++ b/app/Http/Controllers/Api/PageApiController.php
@@ -15,6 +15,9 @@ class PageApiController extends ApiController
     protected PageRepo $pageRepo;
 
     protected $rules = [
+        'list' => [
+            'slug' => [ 'string' ]
+        ],
         'create' => [
             'book_id'    => ['required_without:chapter_id', 'integer'],
             'chapter_id' => ['required_without:book_id', 'integer'],
@@ -41,9 +44,13 @@ class PageApiController extends ApiController
     /**
      * Get a listing of pages visible to the user.
      */
-    public function list()
+    public function list(Request $request)
     {
         $pages = Page::visible();
+
+        if($request->has('slug')) {
+            $pages->where('slug', '=', $request->get('slug'));
+        }
 
         return $this->apiListingResponse($pages, [
             'id', 'book_id', 'chapter_id', 'name', 'slug', 'priority',

--- a/dev/api/requests/pages-list.http
+++ b/dev/api/requests/pages-list.http
@@ -1,0 +1,2 @@
+GET /api/pages/list
+GET /api/pages/list?slug=a-chapter-for-cats


### PR DESCRIPTION
I have a specific need where I need to take a wiki url and make it work "backwards" by searching for the slug and then determining the book. We have hundreds of articles and pulling back hundreds of articles every time to start comparing slugs and books would make it cumbersome and resource intensive.

I've never used Laravel before, but I think I got the code added in correctly and I think I got the API docs page updated as well. Couldn't get docker working, but I did live testing on the repo I'm hosting on my server and the changes worked as I hoped they would. Tweak whatever you need to tweak.