### PR TITLE
Testing cleanup

### DIFF
--- a/app/Api/ListingResponseBuilder.php
+++ b/app/Api/ListingResponseBuilder.php
@@ -2,7 +2,6 @@
 
 namespace BookStack\Api;
 
-use BookStack\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\JsonResponse;

--- a/tests/Actions/AuditLogTest.php
+++ b/tests/Actions/AuditLogTest.php
@@ -6,8 +6,6 @@ use BookStack\Actions\Activity;
 use BookStack\Actions\ActivityLogger;
 use BookStack\Actions\ActivityType;
 use BookStack\Auth\UserRepo;
-use BookStack\Entities\Models\Chapter;
-use BookStack\Entities\Models\Page;
 use BookStack\Entities\Repos\PageRepo;
 use BookStack\Entities\Tools\TrashCan;
 use Carbon\Carbon;
@@ -15,8 +13,7 @@ use Tests\TestCase;
 
 class AuditLogTest extends TestCase
 {
-    /** @var ActivityLogger */
-    protected $activityService;
+    protected ActivityLogger $activityService;
 
     protected function setUp(): void
     {

--- a/tests/Actions/AuditLogTest.php
+++ b/tests/Actions/AuditLogTest.php
@@ -46,7 +46,7 @@ class AuditLogTest extends TestCase
     {
         $admin = $this->getAdmin();
         $this->actingAs($admin);
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->activityService->add(ActivityType::PAGE_CREATE, $page);
         $activity = Activity::query()->orderBy('id', 'desc')->first();
 
@@ -60,7 +60,7 @@ class AuditLogTest extends TestCase
     public function test_shows_name_for_deleted_items()
     {
         $this->actingAs($this->getAdmin());
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $pageName = $page->name;
         $this->activityService->add(ActivityType::PAGE_CREATE, $page);
 
@@ -76,7 +76,7 @@ class AuditLogTest extends TestCase
     {
         $viewer = $this->getViewer();
         $this->actingAs($viewer);
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->activityService->add(ActivityType::PAGE_CREATE, $page);
 
         $this->actingAs($this->getAdmin());
@@ -89,7 +89,7 @@ class AuditLogTest extends TestCase
     public function test_filters_by_key()
     {
         $this->actingAs($this->getAdmin());
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->activityService->add(ActivityType::PAGE_CREATE, $page);
 
         $resp = $this->get('settings/audit');
@@ -102,7 +102,7 @@ class AuditLogTest extends TestCase
     public function test_date_filters()
     {
         $this->actingAs($this->getAdmin());
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->activityService->add(ActivityType::PAGE_CREATE, $page);
 
         $yesterday = (Carbon::now()->subDay()->format('Y-m-d'));
@@ -126,11 +126,11 @@ class AuditLogTest extends TestCase
         $admin = $this->getAdmin();
         $editor = $this->getEditor();
         $this->actingAs($admin);
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->activityService->add(ActivityType::PAGE_CREATE, $page);
 
         $this->actingAs($editor);
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $this->activityService->add(ActivityType::CHAPTER_UPDATE, $chapter);
 
         $resp = $this->actingAs($admin)->get('settings/audit?user=' . $admin->id);
@@ -146,8 +146,7 @@ class AuditLogTest extends TestCase
     {
         config()->set('app.proxies', '*');
         $editor = $this->getEditor();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->actingAs($editor)->put($page->getUrl(), [
             'name' => 'Updated page',
@@ -171,8 +170,7 @@ class AuditLogTest extends TestCase
     {
         config()->set('app.proxies', '*');
         $editor = $this->getEditor();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->actingAs($editor)->put($page->getUrl(), [
             'name' => 'Updated page',
@@ -198,8 +196,7 @@ class AuditLogTest extends TestCase
         config()->set('app.proxies', '*');
         config()->set('app.env', 'demo');
         $editor = $this->getEditor();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->actingAs($editor)->put($page->getUrl(), [
             'name' => 'Updated page',
@@ -222,8 +219,7 @@ class AuditLogTest extends TestCase
         config()->set('app.proxies', '*');
         config()->set('app.ip_address_precision', 2);
         $editor = $this->getEditor();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->actingAs($editor)->put($page->getUrl(), [
             'name' => 'Updated page',

--- a/tests/Actions/WebhookCallTest.php
+++ b/tests/Actions/WebhookCallTest.php
@@ -7,7 +7,6 @@ use BookStack\Actions\ActivityType;
 use BookStack\Actions\DispatchWebhookJob;
 use BookStack\Actions\Webhook;
 use BookStack\Auth\User;
-use BookStack\Entities\Models\Page;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;

--- a/tests/Actions/WebhookCallTest.php
+++ b/tests/Actions/WebhookCallTest.php
@@ -88,8 +88,7 @@ class WebhookCallTest extends TestCase
             '*' => Http::response('', 200),
         ]);
         $webhook = $this->newWebhook(['active' => true, 'endpoint' => 'https://wh.example.com'], ['all']);
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $editor = $this->getEditor();
 
         $this->runEvent(ActivityType::PAGE_UPDATE, $page, $editor);

--- a/tests/Actions/WebhookFormatTesting.php
+++ b/tests/Actions/WebhookFormatTesting.php
@@ -32,8 +32,7 @@ class WebhookFormatTesting extends TestCase
 
     public function test_page_create_and_update_events_show_revision_info()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asEditor()->put($page->getUrl(), ['name' => 'Updated page', 'html' => 'new page html', 'summary' => 'Update a']);
 
         $data = $this->getWebhookData(ActivityType::PAGE_UPDATE, $page);

--- a/tests/Actions/WebhookFormatTesting.php
+++ b/tests/Actions/WebhookFormatTesting.php
@@ -5,9 +5,6 @@ namespace Tests\Actions;
 use BookStack\Actions\ActivityType;
 use BookStack\Actions\Webhook;
 use BookStack\Actions\WebhookFormatter;
-use BookStack\Entities\Models\Book;
-use BookStack\Entities\Models\Chapter;
-use BookStack\Entities\Models\Page;
 use Illuminate\Support\Arr;
 use Tests\TestCase;
 
@@ -16,9 +13,9 @@ class WebhookFormatTesting extends TestCase
     public function test_entity_events_show_related_user_info()
     {
         $events = [
-            ActivityType::BOOK_UPDATE    => Book::query()->first(),
-            ActivityType::CHAPTER_CREATE => Chapter::query()->first(),
-            ActivityType::PAGE_MOVE      => Page::query()->first(),
+            ActivityType::BOOK_UPDATE    => $this->entities->book(),
+            ActivityType::CHAPTER_CREATE => $this->entities->chapter(),
+            ActivityType::PAGE_MOVE      => $this->entities->page(),
         ];
 
         foreach ($events as $event => $entity) {

--- a/tests/Api/AttachmentsApiTest.php
+++ b/tests/Api/AttachmentsApiTest.php
@@ -53,7 +53,7 @@ class AttachmentsApiTest extends TestCase
 
         $page->restricted = true;
         $page->save();
-        $this->regenEntityPermissions($page);
+        $this->entities->regenPermissions($page);
 
         $resp = $this->getJson($this->baseEndpoint . '?count=1&sort=+id');
         $resp->assertJsonMissing(['data' => [
@@ -264,7 +264,7 @@ class AttachmentsApiTest extends TestCase
         $page->draft = true;
         $page->owned_by = $editor->id;
         $page->save();
-        $this->regenEntityPermissions($page);
+        $this->entities->regenPermissions($page);
 
         $attachment = $this->createAttachmentForPage($page, [
             'name'  => 'my attachment',

--- a/tests/Api/AttachmentsApiTest.php
+++ b/tests/Api/AttachmentsApiTest.php
@@ -17,7 +17,7 @@ class AttachmentsApiTest extends TestCase
     public function test_index_endpoint_returns_expected_book()
     {
         $this->actingAsApiEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $attachment = $this->createAttachmentForPage($page, [
             'name'     => 'My test attachment',
             'external' => true,
@@ -37,8 +37,7 @@ class AttachmentsApiTest extends TestCase
     public function test_attachments_listing_based_upon_page_visibility()
     {
         $this->actingAsApiEditor();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $attachment = $this->createAttachmentForPage($page, [
             'name'     => 'My test attachment',
             'external' => true,
@@ -66,8 +65,7 @@ class AttachmentsApiTest extends TestCase
     public function test_create_endpoint_for_link_attachment()
     {
         $this->actingAsApiAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $details = [
             'name'        => 'My attachment',
@@ -85,8 +83,7 @@ class AttachmentsApiTest extends TestCase
     public function test_create_endpoint_for_upload_attachment()
     {
         $this->actingAsApiAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $file = $this->getTestFile('textfile.txt');
 
         $details = [
@@ -106,8 +103,7 @@ class AttachmentsApiTest extends TestCase
     public function test_upload_limit_restricts_attachment_uploads()
     {
         $this->actingAsApiAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         config()->set('app.upload_limit', 1);
 
@@ -130,8 +126,7 @@ class AttachmentsApiTest extends TestCase
     public function test_name_needed_to_create()
     {
         $this->actingAsApiAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $details = [
             'uploaded_to' => $page->id,
@@ -146,8 +141,7 @@ class AttachmentsApiTest extends TestCase
     public function test_link_or_file_needed_to_create()
     {
         $this->actingAsApiAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $details = [
             'name'        => 'my attachment',
@@ -165,8 +159,7 @@ class AttachmentsApiTest extends TestCase
     public function test_message_shown_if_file_is_not_a_valid_file()
     {
         $this->actingAsApiAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $details = [
             'name'        => 'my attachment',
@@ -182,8 +175,7 @@ class AttachmentsApiTest extends TestCase
     public function test_read_endpoint_for_link_attachment()
     {
         $this->actingAsApiAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $attachment = $this->createAttachmentForPage($page, [
             'name'  => 'my attachment',
@@ -216,8 +208,7 @@ class AttachmentsApiTest extends TestCase
     public function test_read_endpoint_for_file_attachment()
     {
         $this->actingAsApiAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $file = $this->getTestFile('textfile.txt');
 
         $details = [
@@ -259,8 +250,7 @@ class AttachmentsApiTest extends TestCase
         $this->actingAsApiAdmin();
         $editor = $this->getEditor();
 
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->draft = true;
         $page->owned_by = $editor->id;
         $page->save();
@@ -280,8 +270,7 @@ class AttachmentsApiTest extends TestCase
     public function test_update_endpoint()
     {
         $this->actingAsApiAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $attachment = $this->createAttachmentForPage($page);
 
         $details = [
@@ -298,8 +287,7 @@ class AttachmentsApiTest extends TestCase
     public function test_update_link_attachment_to_file()
     {
         $this->actingAsApiAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $attachment = $this->createAttachmentForPage($page);
         $file = $this->getTestFile('textfile.txt');
 
@@ -318,8 +306,7 @@ class AttachmentsApiTest extends TestCase
     public function test_update_file_attachment_to_link()
     {
         $this->actingAsApiAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $file = $this->getTestFile('textfile.txt');
         $this->call('POST', $this->baseEndpoint, ['name' => 'My file attachment', 'uploaded_to' => $page->id], [], ['file' => $file]);
         /** @var Attachment $attachment */
@@ -346,8 +333,7 @@ class AttachmentsApiTest extends TestCase
     public function test_delete_endpoint()
     {
         $this->actingAsApiAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $attachment = $this->createAttachmentForPage($page);
 
         $resp = $this->deleteJson("{$this->baseEndpoint}/{$attachment->id}");

--- a/tests/Api/BooksApiTest.php
+++ b/tests/Api/BooksApiTest.php
@@ -68,7 +68,7 @@ class BooksApiTest extends TestCase
     public function test_read_endpoint()
     {
         $this->actingAsApiEditor();
-        $book = Book::visible()->first();
+        $book = $this->entities->book();
 
         $resp = $this->getJson($this->baseEndpoint . "/{$book->id}");
 
@@ -91,8 +91,7 @@ class BooksApiTest extends TestCase
     public function test_read_endpoint_includes_chapter_and_page_contents()
     {
         $this->actingAsApiEditor();
-        /** @var Book $book */
-        $book = Book::visible()->has('chapters')->has('pages')->first();
+        $book = $this->entities->bookHasChaptersAndPages();
         $chapter = $book->chapters()->first();
         $chapterPage = $chapter->pages()->first();
 
@@ -123,7 +122,7 @@ class BooksApiTest extends TestCase
     public function test_update_endpoint()
     {
         $this->actingAsApiEditor();
-        $book = Book::visible()->first();
+        $book = $this->entities->book();
         $details = [
             'name'        => 'My updated API book',
             'description' => 'A book created via the API',
@@ -140,7 +139,7 @@ class BooksApiTest extends TestCase
     public function test_update_increments_updated_date_if_only_tags_are_sent()
     {
         $this->actingAsApiEditor();
-        $book = Book::visible()->first();
+        $book = $this->entities->book();
         DB::table('books')->where('id', '=', $book->id)->update(['updated_at' => Carbon::now()->subWeek()]);
 
         $details = [
@@ -156,7 +155,7 @@ class BooksApiTest extends TestCase
     {
         $this->actingAsApiEditor();
         /** @var Book $book */
-        $book = Book::visible()->first();
+        $book = $this->entities->book();
         $this->assertNull($book->cover);
         $file = $this->getTestImage('image.png');
 
@@ -191,7 +190,7 @@ class BooksApiTest extends TestCase
     public function test_delete_endpoint()
     {
         $this->actingAsApiEditor();
-        $book = Book::visible()->first();
+        $book = $this->entities->book();
         $resp = $this->deleteJson($this->baseEndpoint . "/{$book->id}");
 
         $resp->assertStatus(204);
@@ -201,7 +200,7 @@ class BooksApiTest extends TestCase
     public function test_export_html_endpoint()
     {
         $this->actingAsApiEditor();
-        $book = Book::visible()->first();
+        $book = $this->entities->book();
 
         $resp = $this->get($this->baseEndpoint . "/{$book->id}/export/html");
         $resp->assertStatus(200);
@@ -212,7 +211,7 @@ class BooksApiTest extends TestCase
     public function test_export_plain_text_endpoint()
     {
         $this->actingAsApiEditor();
-        $book = Book::visible()->first();
+        $book = $this->entities->book();
 
         $resp = $this->get($this->baseEndpoint . "/{$book->id}/export/plaintext");
         $resp->assertStatus(200);
@@ -223,7 +222,7 @@ class BooksApiTest extends TestCase
     public function test_export_pdf_endpoint()
     {
         $this->actingAsApiEditor();
-        $book = Book::visible()->first();
+        $book = $this->entities->book();
 
         $resp = $this->get($this->baseEndpoint . "/{$book->id}/export/pdf");
         $resp->assertStatus(200);
@@ -249,7 +248,7 @@ class BooksApiTest extends TestCase
         $this->actingAsApiEditor();
         $this->removePermissionFromUser($this->getEditor(), 'content-export');
 
-        $book = Book::visible()->first();
+        $book = $this->entities->book();
         foreach ($types as $type) {
             $resp = $this->get($this->baseEndpoint . "/{$book->id}/export/{$type}");
             $this->assertPermissionError($resp);

--- a/tests/Api/ChaptersApiTest.php
+++ b/tests/Api/ChaptersApiTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Api;
 
-use BookStack\Entities\Models\Book;
 use BookStack\Entities\Models\Chapter;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -95,7 +94,7 @@ class ChaptersApiTest extends TestCase
     public function test_read_endpoint()
     {
         $this->actingAsApiEditor();
-        $chapter = Chapter::visible()->first();
+        $chapter = $this->entities->chapter();
         $page = $chapter->pages()->first();
 
         $resp = $this->getJson($this->baseEndpoint . "/{$chapter->id}");
@@ -127,7 +126,7 @@ class ChaptersApiTest extends TestCase
     public function test_update_endpoint()
     {
         $this->actingAsApiEditor();
-        $chapter = Chapter::visible()->first();
+        $chapter = $this->entities->chapter();
         $details = [
             'name'        => 'My updated API chapter',
             'description' => 'A chapter created via the API',
@@ -152,7 +151,7 @@ class ChaptersApiTest extends TestCase
     public function test_update_increments_updated_date_if_only_tags_are_sent()
     {
         $this->actingAsApiEditor();
-        $chapter = Chapter::visible()->first();
+        $chapter = $this->entities->chapter();
         DB::table('chapters')->where('id', '=', $chapter->id)->update(['updated_at' => Carbon::now()->subWeek()]);
 
         $details = [
@@ -167,7 +166,7 @@ class ChaptersApiTest extends TestCase
     public function test_delete_endpoint()
     {
         $this->actingAsApiEditor();
-        $chapter = Chapter::visible()->first();
+        $chapter = $this->entities->chapter();
         $resp = $this->deleteJson($this->baseEndpoint . "/{$chapter->id}");
 
         $resp->assertStatus(204);
@@ -177,7 +176,7 @@ class ChaptersApiTest extends TestCase
     public function test_export_html_endpoint()
     {
         $this->actingAsApiEditor();
-        $chapter = Chapter::visible()->first();
+        $chapter = $this->entities->chapter();
 
         $resp = $this->get($this->baseEndpoint . "/{$chapter->id}/export/html");
         $resp->assertStatus(200);
@@ -188,7 +187,7 @@ class ChaptersApiTest extends TestCase
     public function test_export_plain_text_endpoint()
     {
         $this->actingAsApiEditor();
-        $chapter = Chapter::visible()->first();
+        $chapter = $this->entities->chapter();
 
         $resp = $this->get($this->baseEndpoint . "/{$chapter->id}/export/plaintext");
         $resp->assertStatus(200);
@@ -199,7 +198,7 @@ class ChaptersApiTest extends TestCase
     public function test_export_pdf_endpoint()
     {
         $this->actingAsApiEditor();
-        $chapter = Chapter::visible()->first();
+        $chapter = $this->entities->chapter();
 
         $resp = $this->get($this->baseEndpoint . "/{$chapter->id}/export/pdf");
         $resp->assertStatus(200);

--- a/tests/Api/ChaptersApiTest.php
+++ b/tests/Api/ChaptersApiTest.php
@@ -34,7 +34,7 @@ class ChaptersApiTest extends TestCase
     public function test_create_endpoint()
     {
         $this->actingAsApiEditor();
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $details = [
             'name'        => 'My API chapter',
             'description' => 'A chapter created via the API',
@@ -64,7 +64,7 @@ class ChaptersApiTest extends TestCase
     public function test_chapter_name_needed_to_create()
     {
         $this->actingAsApiEditor();
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $details = [
             'book_id'     => $book->id,
             'description' => 'A chapter created via the API',

--- a/tests/Api/PagesApiTest.php
+++ b/tests/Api/PagesApiTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Api;
 
-use BookStack\Entities\Models\Book;
 use BookStack\Entities\Models\Chapter;
 use BookStack\Entities\Models\Page;
 use Carbon\Carbon;
@@ -95,11 +94,11 @@ class PagesApiTest extends TestCase
             'chapter_id' => ['The chapter id field is required when book id is not present.'],
         ]));
 
-        $chapter = Chapter::visible()->first();
+        $chapter = $this->entities->chapter();
         $resp = $this->postJson($this->baseEndpoint, array_merge($details, ['chapter_id' => $chapter->id]));
         $resp->assertStatus(200);
 
-        $book = Book::visible()->first();
+        $book = $this->entities->book();
         $resp = $this->postJson($this->baseEndpoint, array_merge($details, ['book_id' => $book->id]));
         $resp->assertStatus(200);
     }
@@ -107,7 +106,7 @@ class PagesApiTest extends TestCase
     public function test_markdown_can_be_provided_for_create()
     {
         $this->actingAsApiEditor();
-        $book = Book::visible()->first();
+        $book = $this->entities->book();
         $details = [
             'book_id'  => $book->id,
             'name'     => 'My api page',
@@ -126,7 +125,7 @@ class PagesApiTest extends TestCase
     public function test_read_endpoint()
     {
         $this->actingAsApiEditor();
-        $page = Page::visible()->first();
+        $page = $this->entities->page();
 
         $resp = $this->getJson($this->baseEndpoint . "/{$page->id}");
         $resp->assertStatus(200);
@@ -149,7 +148,7 @@ class PagesApiTest extends TestCase
     public function test_read_endpoint_provides_rendered_html()
     {
         $this->actingAsApiEditor();
-        $page = Page::visible()->first();
+        $page = $this->entities->page();
         $page->html = "<p>testing</p><script>alert('danger')</script><h1>Hello</h1>";
         $page->save();
 
@@ -163,7 +162,7 @@ class PagesApiTest extends TestCase
     public function test_update_endpoint()
     {
         $this->actingAsApiEditor();
-        $page = Page::visible()->first();
+        $page = $this->entities->page();
         $details = [
             'name' => 'My updated API page',
             'html' => '<p>A page created via the API</p>',
@@ -189,7 +188,7 @@ class PagesApiTest extends TestCase
     public function test_providing_new_chapter_id_on_update_will_move_page()
     {
         $this->actingAsApiEditor();
-        $page = Page::visible()->first();
+        $page = $this->entities->page();
         $chapter = Chapter::visible()->where('book_id', '!=', $page->book_id)->first();
         $details = [
             'name'       => 'My updated API page',
@@ -208,7 +207,7 @@ class PagesApiTest extends TestCase
     public function test_providing_move_via_update_requires_page_create_permission_on_new_parent()
     {
         $this->actingAsApiEditor();
-        $page = Page::visible()->first();
+        $page = $this->entities->page();
         $chapter = Chapter::visible()->where('book_id', '!=', $page->book_id)->first();
         $this->entities->setPermissions($chapter, ['view'], [$this->getEditor()->roles()->first()]);
         $details = [
@@ -224,7 +223,7 @@ class PagesApiTest extends TestCase
     public function test_update_endpoint_does_not_wipe_content_if_no_html_or_md_provided()
     {
         $this->actingAsApiEditor();
-        $page = Page::visible()->first();
+        $page = $this->entities->page();
         $originalContent = $page->html;
         $details = [
             'name' => 'My updated API page',
@@ -245,7 +244,7 @@ class PagesApiTest extends TestCase
     public function test_update_increments_updated_date_if_only_tags_are_sent()
     {
         $this->actingAsApiEditor();
-        $page = Page::visible()->first();
+        $page = $this->entities->page();
         DB::table('pages')->where('id', '=', $page->id)->update(['updated_at' => Carbon::now()->subWeek()]);
 
         $details = [
@@ -262,7 +261,7 @@ class PagesApiTest extends TestCase
     public function test_delete_endpoint()
     {
         $this->actingAsApiEditor();
-        $page = Page::visible()->first();
+        $page = $this->entities->page();
         $resp = $this->deleteJson($this->baseEndpoint . "/{$page->id}");
 
         $resp->assertStatus(204);
@@ -272,7 +271,7 @@ class PagesApiTest extends TestCase
     public function test_export_html_endpoint()
     {
         $this->actingAsApiEditor();
-        $page = Page::visible()->first();
+        $page = $this->entities->page();
 
         $resp = $this->get($this->baseEndpoint . "/{$page->id}/export/html");
         $resp->assertStatus(200);
@@ -283,7 +282,7 @@ class PagesApiTest extends TestCase
     public function test_export_plain_text_endpoint()
     {
         $this->actingAsApiEditor();
-        $page = Page::visible()->first();
+        $page = $this->entities->page();
 
         $resp = $this->get($this->baseEndpoint . "/{$page->id}/export/plaintext");
         $resp->assertStatus(200);
@@ -294,7 +293,7 @@ class PagesApiTest extends TestCase
     public function test_export_pdf_endpoint()
     {
         $this->actingAsApiEditor();
-        $page = Page::visible()->first();
+        $page = $this->entities->page();
 
         $resp = $this->get($this->baseEndpoint . "/{$page->id}/export/pdf");
         $resp->assertStatus(200);
@@ -304,7 +303,7 @@ class PagesApiTest extends TestCase
     public function test_export_markdown_endpoint()
     {
         $this->actingAsApiEditor();
-        $page = Page::visible()->first();
+        $page = $this->entities->page();
 
         $resp = $this->get($this->baseEndpoint . "/{$page->id}/export/markdown");
         $resp->assertStatus(200);
@@ -318,7 +317,7 @@ class PagesApiTest extends TestCase
         $this->actingAsApiEditor();
         $this->removePermissionFromUser($this->getEditor(), 'content-export');
 
-        $page = Page::visible()->first();
+        $page = $this->entities->page();
         foreach ($types as $type) {
             $resp = $this->get($this->baseEndpoint . "/{$page->id}/export/{$type}");
             $this->assertPermissionError($resp);

--- a/tests/Api/PagesApiTest.php
+++ b/tests/Api/PagesApiTest.php
@@ -35,7 +35,7 @@ class PagesApiTest extends TestCase
     public function test_create_endpoint()
     {
         $this->actingAsApiEditor();
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $details = [
             'name'    => 'My API page',
             'book_id' => $book->id,
@@ -67,7 +67,7 @@ class PagesApiTest extends TestCase
     public function test_page_name_needed_to_create()
     {
         $this->actingAsApiEditor();
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $details = [
             'book_id' => $book->id,
             'html'    => '<p>A page created via the API</p>',

--- a/tests/Api/PagesApiTest.php
+++ b/tests/Api/PagesApiTest.php
@@ -210,7 +210,7 @@ class PagesApiTest extends TestCase
         $this->actingAsApiEditor();
         $page = Page::visible()->first();
         $chapter = Chapter::visible()->where('book_id', '!=', $page->book_id)->first();
-        $this->setEntityRestrictions($chapter, ['view'], [$this->getEditor()->roles()->first()]);
+        $this->entities->setPermissions($chapter, ['view'], [$this->getEditor()->roles()->first()]);
         $details = [
             'name'       => 'My updated API page',
             'chapter_id' => $chapter->id,

--- a/tests/Api/RecycleBinApiTest.php
+++ b/tests/Api/RecycleBinApiTest.php
@@ -50,8 +50,8 @@ class RecycleBinApiTest extends TestCase
     {
         $admin = $this->getAdmin();
 
-        $page = Page::query()->first();
-        $book = Book::query()->first();
+        $page = $this->entities->page();
+        $book = $this->entities->book();
         $this->actingAs($admin)->delete($page->getUrl());
         $this->delete($book->getUrl());
 
@@ -139,7 +139,7 @@ class RecycleBinApiTest extends TestCase
 
     public function test_restore_endpoint()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asAdmin()->delete($page->getUrl());
         $page->refresh();
 
@@ -163,7 +163,7 @@ class RecycleBinApiTest extends TestCase
 
     public function test_destroy_endpoint()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asAdmin()->delete($page->getUrl());
         $page->refresh();
 

--- a/tests/Api/RecycleBinApiTest.php
+++ b/tests/Api/RecycleBinApiTest.php
@@ -4,7 +4,6 @@ namespace Tests\Api;
 
 use BookStack\Entities\Models\Book;
 use BookStack\Entities\Models\Deletion;
-use BookStack\Entities\Models\Page;
 use Illuminate\Support\Collection;
 use Tests\TestCase;
 
@@ -111,7 +110,7 @@ class RecycleBinApiTest extends TestCase
     public function test_index_endpoint_returns_parent()
     {
         $admin = $this->getAdmin();
-        $page = Page::query()->whereHas('chapter')->with('chapter')->first();
+        $page = $this->entities->pageWithinChapter();
 
         $this->actingAs($admin)->delete($page->getUrl());
         $deletion = Deletion::query()->orderBy('id')->first();

--- a/tests/Api/SearchApiTest.php
+++ b/tests/Api/SearchApiTest.php
@@ -38,8 +38,7 @@ class SearchApiTest extends TestCase
 
     public function test_all_endpoint_returns_entity_url()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->update(['name' => 'name with superuniquevalue within']);
         $page->indexForSearch();
 
@@ -52,8 +51,7 @@ class SearchApiTest extends TestCase
 
     public function test_all_endpoint_returns_items_with_preview_html()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $book->update(['name' => 'name with superuniquevalue within', 'description' => 'Description with superuniquevalue within']);
         $book->indexForSearch();
 

--- a/tests/Api/UsersApiTest.php
+++ b/tests/Api/UsersApiTest.php
@@ -239,7 +239,7 @@ class UsersApiTest extends TestCase
         $user = User::query()->where('id', '!=', $this->getAdmin()->id)
             ->whereNull('system_name')
             ->first();
-        $entityChain = $this->createEntityChainBelongingToUser($user);
+        $entityChain = $this->entities->createChainBelongingToUser($user);
         /** @var User $newOwner */
         $newOwner = User::query()->where('id', '!=', $user->id)->first();
 

--- a/tests/Auth/AuthTest.php
+++ b/tests/Auth/AuthTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Auth;
 
 use BookStack\Auth\Access\Mfa\MfaSession;
-use BookStack\Entities\Models\Page;
 use Illuminate\Testing\TestResponse;
 use Tests\TestCase;
 

--- a/tests/Auth/AuthTest.php
+++ b/tests/Auth/AuthTest.php
@@ -58,8 +58,7 @@ class AuthTest extends TestCase
     public function test_login_redirects_to_initially_requested_url_correctly()
     {
         config()->set('app.url', 'http://localhost');
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->get($page->getUrl())->assertRedirect(url('/login'));
         $this->login('admin@admin.com', 'password')

--- a/tests/Commands/ClearActivityCommandTest.php
+++ b/tests/Commands/ClearActivityCommandTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Commands;
 
 use BookStack\Actions\ActivityType;
-use BookStack\Entities\Models\Page;
 use BookStack\Facades\Activity;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;

--- a/tests/Commands/ClearActivityCommandTest.php
+++ b/tests/Commands/ClearActivityCommandTest.php
@@ -14,8 +14,7 @@ class ClearActivityCommandTest extends TestCase
     public function test_clear_activity_command()
     {
         $this->asEditor();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         Activity::add(ActivityType::PAGE_UPDATE, $page);
 
         $this->assertDatabaseHas('activities', [

--- a/tests/Commands/CopyShelfPermissionsCommandTest.php
+++ b/tests/Commands/CopyShelfPermissionsCommandTest.php
@@ -22,7 +22,7 @@ class CopyShelfPermissionsCommandTest extends TestCase
         $this->assertFalse(boolval($child->restricted), 'Child book should not be restricted by default');
         $this->assertTrue($child->permissions()->count() === 0, 'Child book should have no permissions by default');
 
-        $this->setEntityRestrictions($shelf, ['view', 'update'], [$editorRole]);
+        $this->entities->setPermissions($shelf, ['view', 'update'], [$editorRole]);
         $this->artisan('bookstack:copy-shelf-permissions', [
             '--slug' => $shelf->slug,
         ]);
@@ -43,7 +43,7 @@ class CopyShelfPermissionsCommandTest extends TestCase
         $this->assertFalse(boolval($child->restricted), 'Child book should not be restricted by default');
         $this->assertTrue($child->permissions()->count() === 0, 'Child book should have no permissions by default');
 
-        $this->setEntityRestrictions($shelf, ['view', 'update'], [$editorRole]);
+        $this->entities->setPermissions($shelf, ['view', 'update'], [$editorRole]);
         $this->artisan('bookstack:copy-shelf-permissions --all')
             ->expectsQuestion('Permission settings for all shelves will be cascaded. Books assigned to multiple shelves will receive only the permissions of it\'s last processed shelf. Are you sure you want to proceed?', 'y');
         $child = $shelf->books()->first();

--- a/tests/Commands/CopyShelfPermissionsCommandTest.php
+++ b/tests/Commands/CopyShelfPermissionsCommandTest.php
@@ -16,7 +16,7 @@ class CopyShelfPermissionsCommandTest extends TestCase
 
     public function test_copy_shelf_permissions_command_using_slug()
     {
-        $shelf = Bookshelf::first();
+        $shelf = $this->entities->shelf();
         $child = $shelf->books()->first();
         $editorRole = $this->getEditor()->roles()->first();
         $this->assertFalse(boolval($child->restricted), 'Child book should not be restricted by default');

--- a/tests/Commands/CopyShelfPermissionsCommandTest.php
+++ b/tests/Commands/CopyShelfPermissionsCommandTest.php
@@ -36,7 +36,7 @@ class CopyShelfPermissionsCommandTest extends TestCase
 
     public function test_copy_shelf_permissions_command_using_all()
     {
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
         Bookshelf::query()->where('id', '!=', $shelf->id)->delete();
         $child = $shelf->books()->first();
         $editorRole = $this->getEditor()->roles()->first();

--- a/tests/Commands/RegenerateReferencesCommandTest.php
+++ b/tests/Commands/RegenerateReferencesCommandTest.php
@@ -10,8 +10,7 @@ class RegenerateReferencesCommandTest extends TestCase
 {
     public function test_regenerate_references_command()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $book = $page->book;
 
         $page->html = '<a href="' . $book->getUrl() . '">Book Link</a>';

--- a/tests/Commands/RegenerateReferencesCommandTest.php
+++ b/tests/Commands/RegenerateReferencesCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Commands;
 
-use BookStack\Entities\Models\Page;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 

--- a/tests/Commands/UpdateUrlCommandTest.php
+++ b/tests/Commands/UpdateUrlCommandTest.php
@@ -10,7 +10,7 @@ class UpdateUrlCommandTest extends TestCase
 {
     public function test_command_updates_page_content()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->html = '<a href="https://example.com/donkeys"></a>';
         $page->save();
 

--- a/tests/Commands/UpdateUrlCommandTest.php
+++ b/tests/Commands/UpdateUrlCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Commands;
 
-use BookStack\Entities\Models\Page;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Tests\TestCase;
 

--- a/tests/Entity/BookShelfTest.php
+++ b/tests/Entity/BookShelfTest.php
@@ -39,7 +39,7 @@ class BookShelfTest extends TestCase
     {
         $user = User::factory()->create();
         $this->giveUserPermissions($user, ['image-create-all']);
-        $shelf = Bookshelf::first();
+        $shelf = $this->entities->shelf();
         $userRole = $user->roles()->first();
 
         $resp = $this->actingAs($user)->get('/');
@@ -130,7 +130,7 @@ class BookShelfTest extends TestCase
 
     public function test_shelf_view()
     {
-        $shelf = Bookshelf::first();
+        $shelf = $this->entities->shelf();
         $resp = $this->asEditor()->get($shelf->getUrl());
         $resp->assertStatus(200);
         $resp->assertSeeText($shelf->name);
@@ -143,7 +143,7 @@ class BookShelfTest extends TestCase
 
     public function test_shelf_view_shows_action_buttons()
     {
-        $shelf = Bookshelf::first();
+        $shelf = $this->entities->shelf();
         $resp = $this->asAdmin()->get($shelf->getUrl());
         $resp->assertSee($shelf->getUrl('/create-book'));
         $resp->assertSee($shelf->getUrl('/edit'));
@@ -201,7 +201,7 @@ class BookShelfTest extends TestCase
 
     public function test_shelf_edit()
     {
-        $shelf = Bookshelf::first();
+        $shelf = $this->entities->shelf();
         $resp = $this->asEditor()->get($shelf->getUrl('/edit'));
         $resp->assertSeeText('Edit Shelf');
 
@@ -239,7 +239,7 @@ class BookShelfTest extends TestCase
 
     public function test_shelf_create_new_book()
     {
-        $shelf = Bookshelf::first();
+        $shelf = $this->entities->shelf();
         $resp = $this->asEditor()->get($shelf->getUrl('/create-book'));
 
         $resp->assertSee('Create New Book');
@@ -288,7 +288,7 @@ class BookShelfTest extends TestCase
 
     public function test_shelf_copy_permissions()
     {
-        $shelf = Bookshelf::first();
+        $shelf = $this->entities->shelf();
         $resp = $this->asAdmin()->get($shelf->getUrl('/permissions'));
         $resp->assertSeeText('Copy Permissions');
         $resp->assertSee("action=\"{$shelf->getUrl('/copy-permissions')}\"", false);
@@ -311,14 +311,14 @@ class BookShelfTest extends TestCase
 
     public function test_permission_page_has_a_warning_about_no_cascading()
     {
-        $shelf = Bookshelf::first();
+        $shelf = $this->entities->shelf();
         $resp = $this->asAdmin()->get($shelf->getUrl('/permissions'));
         $resp->assertSeeText('Permissions on shelves do not automatically cascade to contained books.');
     }
 
     public function test_bookshelves_show_in_breadcrumbs_if_in_context()
     {
-        $shelf = Bookshelf::first();
+        $shelf = $this->entities->shelf();
         $shelfBook = $shelf->books()->first();
         $shelfPage = $shelfBook->pages()->first();
         $this->asAdmin();

--- a/tests/Entity/BookShelfTest.php
+++ b/tests/Entity/BookShelfTest.php
@@ -62,7 +62,7 @@ class BookShelfTest extends TestCase
         config()->set([
             'setting-defaults.user.bookshelves_view_type' => 'list',
         ]);
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
         $book = $shelf->books()->first();
 
         $resp = $this->asEditor()->get('/shelves');
@@ -160,7 +160,7 @@ class BookShelfTest extends TestCase
 
     public function test_shelf_view_has_sort_control_that_defaults_to_default()
     {
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
         $resp = $this->asAdmin()->get($shelf->getUrl());
         $this->withHtml($resp)->assertElementExists('form[action$="change-sort/shelf_books"]');
         $this->withHtml($resp)->assertElementContains('form[action$="change-sort/shelf_books"] [aria-haspopup="true"]', 'Default');
@@ -373,8 +373,7 @@ class BookShelfTest extends TestCase
 
     public function test_cancel_on_child_book_creation_returns_to_original_shelf()
     {
-        /** @var Bookshelf $shelf */
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
         $resp = $this->asEditor()->get($shelf->getUrl('/create-book'));
         $this->withHtml($resp)->assertElementContains('form a[href="' . $shelf->getUrl() . '"]', 'Cancel');
     }

--- a/tests/Entity/BookShelfTest.php
+++ b/tests/Entity/BookShelfTest.php
@@ -45,7 +45,7 @@ class BookShelfTest extends TestCase
         $resp = $this->actingAs($user)->get('/');
         $this->withHtml($resp)->assertElementNotContains('header', 'Shelves');
 
-        $this->setEntityRestrictions($shelf, ['view'], [$userRole]);
+        $this->entities->setPermissions($shelf, ['view'], [$userRole]);
 
         $resp = $this->get('/');
         $this->withHtml($resp)->assertElementContains('header', 'Shelves');
@@ -69,7 +69,7 @@ class BookShelfTest extends TestCase
         $resp->assertSee($book->name);
         $resp->assertSee($book->getUrl());
 
-        $this->setEntityRestrictions($book, []);
+        $this->entities->setPermissions($book, []);
 
         $resp = $this->asEditor()->get('/shelves');
         $resp->assertDontSee($book->name);
@@ -298,7 +298,7 @@ class BookShelfTest extends TestCase
         $this->assertFalse(boolval($child->restricted), 'Child book should not be restricted by default');
         $this->assertTrue($child->permissions()->count() === 0, 'Child book should have no permissions by default');
 
-        $this->setEntityRestrictions($shelf, ['view', 'update'], [$editorRole]);
+        $this->entities->setPermissions($shelf, ['view', 'update'], [$editorRole]);
         $resp = $this->post($shelf->getUrl('/copy-permissions'));
         $child = $shelf->books()->first();
 

--- a/tests/Entity/BookTest.php
+++ b/tests/Entity/BookTest.php
@@ -246,13 +246,13 @@ class BookTest extends TestCase
 
     public function test_slug_multi_byte_url_safe()
     {
-        $book = $this->newBook([
+        $book = $this->entities->newBook([
             'name' => 'информация',
         ]);
 
         $this->assertEquals('informaciya', $book->slug);
 
-        $book = $this->newBook([
+        $book = $this->entities->newBook([
             'name' => '¿Qué?',
         ]);
 
@@ -261,7 +261,7 @@ class BookTest extends TestCase
 
     public function test_slug_format()
     {
-        $book = $this->newBook([
+        $book = $this->entities->newBook([
             'name' => 'PartA / PartB / PartC',
         ]);
 
@@ -311,7 +311,7 @@ class BookTest extends TestCase
         foreach ($book->getDirectChildren() as $child) {
             $child->restricted = true;
             $child->save();
-            $this->regenEntityPermissions($child);
+            $this->entities->regenPermissions($child);
         }
 
         $this->asEditor()->post($book->getUrl('/copy'), ['name' => 'My copy book']);
@@ -365,7 +365,7 @@ class BookTest extends TestCase
 
         $viewer = $this->getViewer();
         $this->giveUserPermissions($viewer, ['book-update-all', 'book-create-all', 'bookshelf-update-all']);
-        $this->setEntityRestrictions($shelfB);
+        $this->entities->setPermissions($shelfB);
 
 
         $this->asEditor()->post($book->getUrl('/copy'), ['name' => 'My copy book']);

--- a/tests/Entity/BookTest.php
+++ b/tests/Entity/BookTest.php
@@ -80,8 +80,7 @@ class BookTest extends TestCase
 
     public function test_update()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         // Cheeky initial update to refresh slug
         $this->asEditor()->put($book->getUrl(), ['name' => $book->name . '5', 'description' => $book->description]);
         $book->refresh();
@@ -104,8 +103,7 @@ class BookTest extends TestCase
 
     public function test_update_sets_tags()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
 
         $this->assertEquals(0, $book->tags()->count());
 
@@ -167,15 +165,14 @@ class BookTest extends TestCase
 
     public function test_cancel_on_edit_book_page_leads_back_to_book()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $resp = $this->asEditor()->get($book->getUrl('/edit'));
         $this->withHtml($resp)->assertElementContains('form a[href="' . $book->getUrl() . '"]', 'Cancel');
     }
 
     public function test_next_previous_navigation_controls_show_within_book_content()
     {
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $chapter = $book->chapters->first();
 
         $resp = $this->asEditor()->get($chapter->getUrl());
@@ -270,8 +267,7 @@ class BookTest extends TestCase
 
     public function test_show_view_has_copy_button()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $resp = $this->asEditor()->get($book->getUrl());
 
         $this->withHtml($resp)->assertElementContains("a[href=\"{$book->getUrl('/copy')}\"]", 'Copy');
@@ -279,8 +275,7 @@ class BookTest extends TestCase
 
     public function test_copy_view()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $resp = $this->asEditor()->get($book->getUrl('/copy'));
 
         $resp->assertOk();
@@ -338,8 +333,7 @@ class BookTest extends TestCase
 
     public function test_copy_clones_cover_image_if_existing()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $bookRepo = $this->app->make(BookRepo::class);
         $coverImageFile = $this->getTestImage('cover.png');
         $bookRepo->updateCoverImage($book, $coverImageFile);
@@ -357,8 +351,7 @@ class BookTest extends TestCase
         /** @var Bookshelf $shelfA */
         /** @var Bookshelf $shelfB */
         [$shelfA, $shelfB] = Bookshelf::query()->take(2)->get();
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
 
         $shelfA->appendBook($book);
         $shelfB->appendBook($book);

--- a/tests/Entity/ChapterTest.php
+++ b/tests/Entity/ChapterTest.php
@@ -96,8 +96,7 @@ class ChapterTest extends TestCase
 
     public function test_copy_does_not_copy_non_visible_pages()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->whereHas('pages')->first();
+        $chapter = $this->entities->chapterHasPages();
 
         // Hide pages to all non-admin roles
         /** @var Page $page */
@@ -118,8 +117,7 @@ class ChapterTest extends TestCase
 
     public function test_copy_does_not_copy_pages_if_user_cant_page_create()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->whereHas('pages')->first();
+        $chapter = $this->entities->chapterHasPages();
         $viewer = $this->getViewer();
         $this->giveUserPermissions($viewer, ['chapter-create-all']);
 

--- a/tests/Entity/ChapterTest.php
+++ b/tests/Entity/ChapterTest.php
@@ -11,8 +11,7 @@ class ChapterTest extends TestCase
 {
     public function test_create()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
 
         $chapter = Chapter::factory()->make([
             'name' => 'My First Chapter',
@@ -58,8 +57,7 @@ class ChapterTest extends TestCase
 
     public function test_show_view_has_copy_button()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
 
         $resp = $this->asEditor()->get($chapter->getUrl());
         $this->withHtml($resp)->assertElementContains("a[href$=\"{$chapter->getUrl('/copy')}\"]", 'Copy');
@@ -67,8 +65,7 @@ class ChapterTest extends TestCase
 
     public function test_copy_view()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
 
         $resp = $this->asEditor()->get($chapter->getUrl('/copy'));
         $resp->assertOk();
@@ -149,8 +146,7 @@ class ChapterTest extends TestCase
 
     public function test_sort_book_action_visible_if_permissions_allow()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
 
         $resp = $this->actingAs($this->getViewer())->get($chapter->getUrl());
         $this->withHtml($resp)->assertLinkNotExists($chapter->book->getUrl('sort'));

--- a/tests/Entity/ChapterTest.php
+++ b/tests/Entity/ChapterTest.php
@@ -107,7 +107,7 @@ class ChapterTest extends TestCase
         foreach ($chapter->pages as $page) {
             $page->restricted = true;
             $page->save();
-            $this->regenEntityPermissions($page);
+            $this->entities->regenPermissions($page);
         }
 
         $this->asEditor()->post($chapter->getUrl('/copy'), [

--- a/tests/Entity/CommentSettingTest.php
+++ b/tests/Entity/CommentSettingTest.php
@@ -2,34 +2,27 @@
 
 namespace Tests\Entity;
 
-use BookStack\Entities\Models\Page;
 use Tests\TestCase;
 
 class CommentSettingTest extends TestCase
 {
-    protected $page;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->page = Page::query()->first();
-    }
-
     public function test_comment_disable()
     {
+        $page = $this->entities->page();
         $this->setSettings(['app-disable-comments' => 'true']);
         $this->asAdmin();
 
-        $resp = $this->asAdmin()->get($this->page->getUrl());
+        $resp = $this->asAdmin()->get($page->getUrl());
         $this->withHtml($resp)->assertElementNotExists('.comments-list');
     }
 
     public function test_comment_enable()
     {
+        $page = $this->entities->page();
         $this->setSettings(['app-disable-comments' => 'false']);
         $this->asAdmin();
 
-        $resp = $this->asAdmin()->get($this->page->getUrl());
+        $resp = $this->asAdmin()->get($page->getUrl());
         $this->withHtml($resp)->assertElementExists('.comments-list');
     }
 }

--- a/tests/Entity/CommentTest.php
+++ b/tests/Entity/CommentTest.php
@@ -11,7 +11,7 @@ class CommentTest extends TestCase
     public function test_add_comment()
     {
         $this->asAdmin();
-        $page = Page::first();
+        $page = $this->entities->page();
 
         $comment = Comment::factory()->make(['parent_id' => 2]);
         $resp = $this->postJson("/comment/$page->id", $comment->getAttributes());
@@ -34,7 +34,7 @@ class CommentTest extends TestCase
     public function test_comment_edit()
     {
         $this->asAdmin();
-        $page = Page::first();
+        $page = $this->entities->page();
 
         $comment = Comment::factory()->make();
         $this->postJson("/comment/$page->id", $comment->getAttributes());
@@ -58,7 +58,7 @@ class CommentTest extends TestCase
     public function test_comment_delete()
     {
         $this->asAdmin();
-        $page = Page::first();
+        $page = $this->entities->page();
 
         $comment = Comment::factory()->make();
         $this->postJson("/comment/$page->id", $comment->getAttributes());
@@ -75,7 +75,7 @@ class CommentTest extends TestCase
 
     public function test_comments_converts_markdown_input_to_html()
     {
-        $page = Page::first();
+        $page = $this->entities->page();
         $this->asAdmin()->postJson("/comment/$page->id", [
             'text' => '# My Title',
         ]);
@@ -94,7 +94,7 @@ class CommentTest extends TestCase
     public function test_html_cannot_be_injected_via_comment_content()
     {
         $this->asAdmin();
-        $page = Page::first();
+        $page = $this->entities->page();
 
         $script = '<script>const a = "script";</script>\n\n# sometextinthecomment';
         $this->postJson("/comment/$page->id", [

--- a/tests/Entity/ConvertTest.php
+++ b/tests/Entity/ConvertTest.php
@@ -24,8 +24,7 @@ class ConvertTest extends TestCase
 
     public function test_convert_chapter_to_book()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->whereHas('pages')->first();
+        $chapter = $this->entities->chapterHasPages();
         $chapter->tags()->save(new Tag(['name' => 'Category', 'value' => 'Penguins']));
         /** @var Page $childPage */
         $childPage = $chapter->pages()->first();

--- a/tests/Entity/ConvertTest.php
+++ b/tests/Entity/ConvertTest.php
@@ -14,8 +14,7 @@ class ConvertTest extends TestCase
 {
     public function test_chapter_edit_view_shows_convert_option()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
 
         $resp = $this->asEditor()->get($chapter->getUrl('/edit'));
         $resp->assertSee('Convert to Book');
@@ -50,8 +49,7 @@ class ConvertTest extends TestCase
 
     public function test_convert_chapter_to_book_requires_permissions()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $user = $this->getViewer();
 
         $permissions = ['chapter-delete-all', 'book-create-all', 'chapter-update-all'];
@@ -71,7 +69,7 @@ class ConvertTest extends TestCase
 
     public function test_book_edit_view_shows_convert_option()
     {
-        $book = Book::query()->first();
+        $book = $this->entities->book();
 
         $resp = $this->asEditor()->get($book->getUrl('/edit'));
         $resp->assertSee('Convert to Shelf');
@@ -124,8 +122,7 @@ class ConvertTest extends TestCase
 
     public function test_book_convert_to_shelf_requires_permissions()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $user = $this->getViewer();
 
         $permissions = ['book-delete-all', 'bookshelf-create-all', 'book-update-all', 'book-create-all'];

--- a/tests/Entity/EntityAccessTest.php
+++ b/tests/Entity/EntityAccessTest.php
@@ -4,7 +4,6 @@ namespace Tests\Entity;
 
 use BookStack\Auth\UserRepo;
 use BookStack\Entities\Models\Entity;
-use BookStack\Entities\Repos\PageRepo;
 use Tests\TestCase;
 
 class EntityAccessTest extends TestCase
@@ -16,7 +15,7 @@ class EntityAccessTest extends TestCase
         $updater = $this->getViewer();
         $entities = $this->entities->createChainBelongingToUser($creator, $updater);
         app()->make(UserRepo::class)->destroy($creator);
-        app()->make(PageRepo::class)->update($entities['page'], ['html' => '<p>hello!</p>>']);
+        $this->entities->updatePage($entities['page'], ['html' => '<p>hello!</p>>']);
 
         $this->checkEntitiesViewable($entities);
     }
@@ -28,7 +27,7 @@ class EntityAccessTest extends TestCase
         $updater = $this->getEditor();
         $entities = $this->entities->createChainBelongingToUser($creator, $updater);
         app()->make(UserRepo::class)->destroy($updater);
-        app()->make(PageRepo::class)->update($entities['page'], ['html' => '<p>Hello there!</p>']);
+        $this->entities->updatePage($entities['page'], ['html' => '<p>Hello there!</p>']);
 
         $this->checkEntitiesViewable($entities);
     }

--- a/tests/Entity/EntityAccessTest.php
+++ b/tests/Entity/EntityAccessTest.php
@@ -14,7 +14,7 @@ class EntityAccessTest extends TestCase
         // Create required assets and revisions
         $creator = $this->getEditor();
         $updater = $this->getViewer();
-        $entities = $this->createEntityChainBelongingToUser($creator, $updater);
+        $entities = $this->entities->createChainBelongingToUser($creator, $updater);
         app()->make(UserRepo::class)->destroy($creator);
         app()->make(PageRepo::class)->update($entities['page'], ['html' => '<p>hello!</p>>']);
 
@@ -26,7 +26,7 @@ class EntityAccessTest extends TestCase
         // Create required assets and revisions
         $creator = $this->getViewer();
         $updater = $this->getEditor();
-        $entities = $this->createEntityChainBelongingToUser($creator, $updater);
+        $entities = $this->entities->createChainBelongingToUser($creator, $updater);
         app()->make(UserRepo::class)->destroy($updater);
         app()->make(PageRepo::class)->update($entities['page'], ['html' => '<p>Hello there!</p>']);
 

--- a/tests/Entity/EntitySearchTest.php
+++ b/tests/Entity/EntitySearchTest.php
@@ -47,7 +47,7 @@ class EntitySearchTest extends TestCase
 
     public function test_searching_accents_and_small_terms()
     {
-        $page = $this->newPage(['name' => 'My new test quaffleachits', 'html' => 'some áéííúü¿¡ test content a2 orange dog']);
+        $page = $this->entities->newPage(['name' => 'My new test quaffleachits', 'html' => 'some áéííúü¿¡ test content a2 orange dog']);
         $this->asEditor();
 
         $accentSearch = $this->get('/search?term=' . urlencode('áéíí'));
@@ -111,7 +111,7 @@ class EntitySearchTest extends TestCase
 
     public function test_exact_searches()
     {
-        $page = $this->newPage(['name' => 'My new test page', 'html' => 'this is a story about an orange donkey']);
+        $page = $this->entities->newPage(['name' => 'My new test page', 'html' => 'this is a story about an orange donkey']);
 
         $exactSearchA = $this->asEditor()->get('/search?term=' . urlencode('"story about an orange"'));
         $exactSearchA->assertStatus(200)->assertSee($page->name);
@@ -123,7 +123,7 @@ class EntitySearchTest extends TestCase
     public function test_search_terms_with_delimiters_are_converted_to_exact_matches()
     {
         $this->asEditor();
-        $page = $this->newPage(['name' => 'Delimiter test', 'html' => '<p>1.1 2,2 3?3 4:4 5;5 (8) &lt;9&gt; "10" \'11\' `12`</p>']);
+        $page = $this->entities->newPage(['name' => 'Delimiter test', 'html' => '<p>1.1 2,2 3?3 4:4 5;5 (8) &lt;9&gt; "10" \'11\' `12`</p>']);
         $terms = explode(' ', '1.1 2,2 3?3 4:4 5;5 (8) <9> "10" \'11\' `12`');
 
         foreach ($terms as $term) {
@@ -134,7 +134,7 @@ class EntitySearchTest extends TestCase
 
     public function test_search_filters()
     {
-        $page = $this->newPage(['name' => 'My new test quaffleachits', 'html' => 'this is about an orange donkey danzorbhsing']);
+        $page = $this->entities->newPage(['name' => 'My new test quaffleachits', 'html' => 'this is about an orange donkey danzorbhsing']);
         $this->asEditor();
         $editorId = $this->getEditor()->id;
         $editorSlug = $this->getEditor()->slug;
@@ -197,7 +197,7 @@ class EntitySearchTest extends TestCase
 
     public function test_ajax_entity_search()
     {
-        $page = $this->newPage(['name' => 'my ajax search test', 'html' => 'ajax test']);
+        $page = $this->entities->newPage(['name' => 'my ajax search test', 'html' => 'ajax test']);
         $notVisitedPage = Page::first();
 
         // Visit the page to make popular
@@ -334,15 +334,15 @@ class EntitySearchTest extends TestCase
 
     public function test_search_ranks_common_words_lower()
     {
-        $this->newPage(['name' => 'Test page A', 'html' => '<p>dog biscuit dog dog</p>']);
-        $this->newPage(['name' => 'Test page B', 'html' => '<p>cat biscuit</p>']);
+        $this->entities->newPage(['name' => 'Test page A', 'html' => '<p>dog biscuit dog dog</p>']);
+        $this->entities->newPage(['name' => 'Test page B', 'html' => '<p>cat biscuit</p>']);
 
         $search = $this->asEditor()->get('/search?term=cat+dog+biscuit');
         $this->withHtml($search)->assertElementContains('.entity-list > .page:nth-child(1)', 'Test page A');
         $this->withHtml($search)->assertElementContains('.entity-list > .page:nth-child(2)', 'Test page B');
 
         for ($i = 0; $i < 2; $i++) {
-            $this->newPage(['name' => 'Test page ' . $i, 'html' => '<p>dog</p>']);
+            $this->entities->newPage(['name' => 'Test page ' . $i, 'html' => '<p>dog</p>']);
         }
 
         $search = $this->asEditor()->get('/search?term=cat+dog+biscuit');
@@ -352,7 +352,7 @@ class EntitySearchTest extends TestCase
 
     public function test_terms_in_headers_have_an_adjusted_index_score()
     {
-        $page = $this->newPage(['name' => 'Test page A', 'html' => '
+        $page = $this->entities->newPage(['name' => 'Test page A', 'html' => '
             <p>TermA</p>
             <h1>TermB <strong>TermNested</strong></h1>
             <h2>TermC</h2>
@@ -377,7 +377,7 @@ class EntitySearchTest extends TestCase
 
     public function test_name_and_content_terms_are_merged_to_single_score()
     {
-        $page = $this->newPage(['name' => 'TermA', 'html' => '
+        $page = $this->entities->newPage(['name' => 'TermA', 'html' => '
             <p>TermA</p>
         ']);
 
@@ -389,7 +389,7 @@ class EntitySearchTest extends TestCase
 
     public function test_tag_names_and_values_are_indexed_for_search()
     {
-        $page = $this->newPage(['name' => 'PageA', 'html' => '<p>content</p>', 'tags' => [
+        $page = $this->entities->newPage(['name' => 'PageA', 'html' => '<p>content</p>', 'tags' => [
             ['name' => 'Animal', 'value' => 'MeowieCat'],
             ['name' => 'SuperImportant'],
         ]]);
@@ -402,7 +402,7 @@ class EntitySearchTest extends TestCase
 
     public function test_matching_terms_in_search_results_are_highlighted()
     {
-        $this->newPage(['name' => 'My Meowie Cat', 'html' => '<p>A superimportant page about meowieable animals</p>', 'tags' => [
+        $this->entities->newPage(['name' => 'My Meowie Cat', 'html' => '<p>A superimportant page about meowieable animals</p>', 'tags' => [
             ['name' => 'Animal', 'value' => 'MeowieCat'],
             ['name' => 'SuperImportant'],
         ]]);
@@ -420,7 +420,7 @@ class EntitySearchTest extends TestCase
 
     public function test_match_highlighting_works_with_multibyte_content()
     {
-        $this->newPage([
+        $this->entities->newPage([
             'name' => 'Test Page',
             'html' => '<p>На мен ми трябва нещо добро test</p>',
         ]);
@@ -431,7 +431,7 @@ class EntitySearchTest extends TestCase
 
     public function test_html_entities_in_item_details_remains_escaped_in_search_results()
     {
-        $this->newPage(['name' => 'My <cool> TestPageContent', 'html' => '<p>My supercool &lt;great&gt; TestPageContent page</p>']);
+        $this->entities->newPage(['name' => 'My <cool> TestPageContent', 'html' => '<p>My supercool &lt;great&gt; TestPageContent page</p>']);
 
         $search = $this->asEditor()->get('/search?term=TestPageContent');
         $search->assertSee('My &lt;cool&gt; <strong>TestPageContent</strong>', false);
@@ -440,7 +440,7 @@ class EntitySearchTest extends TestCase
 
     public function test_words_adjacent_to_lines_breaks_can_be_matched_with_normal_terms()
     {
-        $page = $this->newPage(['name' => 'TermA', 'html' => '
+        $page = $this->entities->newPage(['name' => 'TermA', 'html' => '
             <p>TermA<br>TermB<br>TermC</p>
         ']);
 

--- a/tests/Entity/EntitySearchTest.php
+++ b/tests/Entity/EntitySearchTest.php
@@ -5,15 +5,13 @@ namespace Tests\Entity;
 use BookStack\Actions\Tag;
 use BookStack\Entities\Models\Book;
 use BookStack\Entities\Models\Bookshelf;
-use BookStack\Entities\Models\Chapter;
-use BookStack\Entities\Models\Page;
 use Tests\TestCase;
 
 class EntitySearchTest extends TestCase
 {
     public function test_page_search()
     {
-        $book = Book::all()->first();
+        $book = $this->entities->book();
         $page = $book->pages->first();
 
         $search = $this->asEditor()->get('/search?term=' . urlencode($page->name));
@@ -71,7 +69,7 @@ class EntitySearchTest extends TestCase
 
     public function test_chapter_search()
     {
-        $chapter = Chapter::has('pages')->first();
+        $chapter = $this->entities->chapterHasPages();
         $page = $chapter->pages[0];
 
         $pageTestResp = $this->asEditor()->get('/search/chapter/' . $chapter->id . '?term=' . urlencode($page->name));
@@ -91,10 +89,10 @@ class EntitySearchTest extends TestCase
             ]),
         ];
 
-        $pageA = Page::first();
+        $pageA = $this->entities->page();
         $pageA->tags()->saveMany($newTags);
 
-        $pageB = Page::all()->last();
+        $pageB = $this->entities->page();
         $pageB->tags()->create(['name' => 'animal', 'value' => 'dog']);
 
         $this->asEditor();
@@ -197,7 +195,7 @@ class EntitySearchTest extends TestCase
     public function test_ajax_entity_search()
     {
         $page = $this->entities->newPage(['name' => 'my ajax search test', 'html' => 'ajax test']);
-        $notVisitedPage = Page::first();
+        $notVisitedPage = $this->entities->page();
 
         // Visit the page to make popular
         $this->asEditor()->get($page->getUrl());
@@ -215,7 +213,7 @@ class EntitySearchTest extends TestCase
 
     public function test_ajax_entity_search_shows_breadcrumbs()
     {
-        $chapter = Chapter::first();
+        $chapter = $this->entities->chapter();
         $page = $chapter->pages->first();
         $this->asEditor();
 
@@ -246,7 +244,7 @@ class EntitySearchTest extends TestCase
 
     public function test_sibling_search_for_pages()
     {
-        $chapter = Chapter::query()->with('pages')->first();
+        $chapter = $this->entities->chapterHasPages();
         $this->assertGreaterThan(2, count($chapter->pages), 'Ensure we\'re testing with at least 1 sibling');
         $page = $chapter->pages->first();
 
@@ -261,7 +259,7 @@ class EntitySearchTest extends TestCase
 
     public function test_sibling_search_for_pages_without_chapter()
     {
-        $page = Page::query()->where('chapter_id', '=', 0)->firstOrFail();
+        $page = $this->entities->pageNotWithinChapter();
         $bookChildren = $page->book->getDirectChildren();
         $this->assertGreaterThan(2, count($bookChildren), 'Ensure we\'re testing with at least 1 sibling');
 
@@ -276,7 +274,7 @@ class EntitySearchTest extends TestCase
 
     public function test_sibling_search_for_chapters()
     {
-        $chapter = Chapter::query()->firstOrFail();
+        $chapter = $this->entities->chapter();
         $bookChildren = $chapter->book->getDirectChildren();
         $this->assertGreaterThan(2, count($bookChildren), 'Ensure we\'re testing with at least 1 sibling');
 

--- a/tests/Entity/EntitySearchTest.php
+++ b/tests/Entity/EntitySearchTest.php
@@ -23,8 +23,7 @@ class EntitySearchTest extends TestCase
 
     public function test_bookshelf_search()
     {
-        /** @var Bookshelf $shelf */
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
 
         $search = $this->asEditor()->get('/search?term=' . urlencode($shelf->name) . '  {type:bookshelf}');
         $search->assertSee('Search Results');
@@ -232,7 +231,7 @@ class EntitySearchTest extends TestCase
 
     public function test_ajax_entity_search_reflects_items_without_permission()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $baseSelector = 'a[data-entity-type="page"][data-entity-id="' . $page->id . '"]';
         $searchUrl = '/ajax/search/entities?permission=update&term=' . urlencode($page->name);
 
@@ -318,7 +317,7 @@ class EntitySearchTest extends TestCase
 
     public function test_search_works_on_updated_page_content()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asEditor();
 
         $update = $this->put($page->getUrl(), [

--- a/tests/Entity/ExportTest.php
+++ b/tests/Entity/ExportTest.php
@@ -311,7 +311,7 @@ class ExportTest extends TestCase
 
     public function test_page_pdf_export_opens_details_blocks()
     {
-        $page = Page::query()->first()->forceFill([
+        $page = $this->entities->page()->forceFill([
             'html'     => '<details><summary>Hello</summary><p>Content!</p></details>',
         ]);
         $page->save();
@@ -339,7 +339,7 @@ class ExportTest extends TestCase
 
     public function test_page_markdown_export_uses_existing_markdown_if_apparent()
     {
-        $page = Page::query()->first()->forceFill([
+        $page = $this->entities->page()->forceFill([
             'markdown' => '# A header',
             'html'     => '<h1>Dogcat</h1>',
         ]);
@@ -352,7 +352,7 @@ class ExportTest extends TestCase
 
     public function test_page_markdown_export_converts_html_where_no_markdown()
     {
-        $page = Page::query()->first()->forceFill([
+        $page = $this->entities->page()->forceFill([
             'markdown' => '',
             'html'     => '<h1>Dogcat</h1><p>Some <strong>bold</strong> text</p>',
         ]);
@@ -446,9 +446,9 @@ class ExportTest extends TestCase
     public function test_html_exports_contain_csp_meta_tag()
     {
         $entities = [
-            Page::query()->first(),
-            Book::query()->first(),
-            Chapter::query()->first(),
+            $this->entities->page(),
+            $this->entities->book(),
+            $this->entities->chapter(),
         ];
 
         foreach ($entities as $entity) {

--- a/tests/Entity/ExportTest.php
+++ b/tests/Entity/ExportTest.php
@@ -15,7 +15,7 @@ class ExportTest extends TestCase
 {
     public function test_page_text_export()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asEditor();
 
         $resp = $this->get($page->getUrl('/export/plaintext'));
@@ -26,7 +26,7 @@ class ExportTest extends TestCase
 
     public function test_page_pdf_export()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asEditor();
 
         $resp = $this->get($page->getUrl('/export/pdf'));
@@ -36,7 +36,7 @@ class ExportTest extends TestCase
 
     public function test_page_html_export()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asEditor();
 
         $resp = $this->get($page->getUrl('/export/html'));
@@ -47,7 +47,7 @@ class ExportTest extends TestCase
 
     public function test_book_text_export()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $book = $page->book;
         $this->asEditor();
 
@@ -60,7 +60,7 @@ class ExportTest extends TestCase
 
     public function test_book_pdf_export()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $book = $page->book;
         $this->asEditor();
 
@@ -71,7 +71,7 @@ class ExportTest extends TestCase
 
     public function test_book_html_export()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $book = $page->book;
         $this->asEditor();
 
@@ -85,7 +85,7 @@ class ExportTest extends TestCase
     public function test_book_html_export_shows_chapter_descriptions()
     {
         $chapterDesc = 'My custom test chapter description ' . Str::random(12);
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $chapter->description = $chapterDesc;
         $chapter->save();
 
@@ -98,7 +98,7 @@ class ExportTest extends TestCase
 
     public function test_chapter_text_export()
     {
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $page = $chapter->pages[0];
         $this->asEditor();
 
@@ -111,7 +111,7 @@ class ExportTest extends TestCase
 
     public function test_chapter_pdf_export()
     {
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $this->asEditor();
 
         $resp = $this->get($chapter->getUrl('/export/pdf'));
@@ -121,7 +121,7 @@ class ExportTest extends TestCase
 
     public function test_chapter_html_export()
     {
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $page = $chapter->pages[0];
         $this->asEditor();
 
@@ -134,7 +134,7 @@ class ExportTest extends TestCase
 
     public function test_page_html_export_contains_custom_head_if_set()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $customHeadContent = '<style>p{color: red;}</style>';
         $this->setSettings(['app-custom-head' => $customHeadContent]);
@@ -145,7 +145,7 @@ class ExportTest extends TestCase
 
     public function test_page_html_export_does_not_break_with_only_comments_in_custom_head()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $customHeadContent = '<!-- A comment -->';
         $this->setSettings(['app-custom-head' => $customHeadContent]);
@@ -157,7 +157,7 @@ class ExportTest extends TestCase
 
     public function test_page_html_export_use_absolute_dates()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $resp = $this->asEditor()->get($page->getUrl('/export/html'));
         $resp->assertSee($page->created_at->formatLocalized('%e %B %Y %H:%M:%S'));
@@ -168,7 +168,7 @@ class ExportTest extends TestCase
 
     public function test_page_export_does_not_include_user_or_revision_links()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $resp = $this->asEditor()->get($page->getUrl('/export/html'));
         $resp->assertDontSee($page->getUrl('/revisions'));
@@ -178,7 +178,7 @@ class ExportTest extends TestCase
 
     public function test_page_export_sets_right_data_type_for_svg_embeds()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         Storage::disk('local')->makeDirectory('uploads/images/gallery');
         Storage::disk('local')->put('uploads/images/gallery/svg_test.svg', '<svg></svg>');
         $page->html = '<img src="http://localhost/uploads/images/gallery/svg_test.svg">';
@@ -194,7 +194,7 @@ class ExportTest extends TestCase
 
     public function test_page_image_containment_works_on_multiple_images_within_a_single_line()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         Storage::disk('local')->makeDirectory('uploads/images/gallery');
         Storage::disk('local')->put('uploads/images/gallery/svg_test.svg', '<svg></svg>');
         Storage::disk('local')->put('uploads/images/gallery/svg_test2.svg', '<svg></svg>');
@@ -210,7 +210,7 @@ class ExportTest extends TestCase
 
     public function test_page_export_contained_html_image_fetches_only_run_when_url_points_to_image_upload_folder()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->html = '<img src="http://localhost/uploads/images/gallery/svg_test.svg"/>'
             . '<img src="http://localhost/uploads/svg_test.svg"/>'
             . '<img src="/uploads/svg_test.svg"/>';
@@ -235,7 +235,7 @@ class ExportTest extends TestCase
         $contents = file_get_contents(public_path('.htaccess'));
         config()->set('filesystems.images', 'local');
 
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->html = '<img src="http://localhost/uploads/images/../../.htaccess"/>';
         $page->save();
 
@@ -249,7 +249,7 @@ class ExportTest extends TestCase
         config()->set('filesystems.images', 'local_secure');
         file_put_contents($testFilePath, 'I am a cat');
 
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->html = '<img src="http://localhost/uploads/images/../../logs/test.txt"/>';
         $page->save();
 
@@ -276,7 +276,7 @@ class ExportTest extends TestCase
     public function test_page_export_with_deleted_creator_and_updater()
     {
         $user = $this->getViewer(['name' => 'ExportWizardTheFifth']);
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->created_by = $user->id;
         $page->updated_by = $user->id;
         $page->save();
@@ -329,7 +329,7 @@ class ExportTest extends TestCase
 
     public function test_page_markdown_export()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $resp = $this->asEditor()->get($page->getUrl('/export/markdown'));
         $resp->assertStatus(200);
@@ -364,7 +364,7 @@ class ExportTest extends TestCase
 
     public function test_chapter_markdown_export()
     {
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $page = $chapter->pages()->first();
         $resp = $this->asEditor()->get($chapter->getUrl('/export/markdown'));
 
@@ -430,8 +430,7 @@ class ExportTest extends TestCase
 
     public function test_wkhtmltopdf_only_used_when_allow_untrusted_is_true()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         config()->set('snappy.pdf.binary', '/abc123');
         config()->set('app.allow_untrusted_server_fetching', false);
@@ -460,7 +459,7 @@ class ExportTest extends TestCase
 
     public function test_html_exports_contain_body_classes_for_export_identification()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $resp = $this->asEditor()->get($page->getUrl('/export/html'));
         $this->withHtml($resp)->assertElementExists('body.export.export-format-html.export-engine-none');

--- a/tests/Entity/PageContentTest.php
+++ b/tests/Entity/PageContentTest.php
@@ -16,7 +16,7 @@ class PageContentTest extends TestCase
     public function test_page_includes()
     {
         $page = $this->entities->page();
-        $secondPage = Page::query()->where('id', '!=', $page->id)->first();
+        $secondPage = $this->entities->page();
 
         $secondPage->html = "<p id='section1'>Hello, This is a test</p><p id='section2'>This is a second block of content</p>";
         $secondPage->save();
@@ -45,7 +45,7 @@ class PageContentTest extends TestCase
     public function test_saving_page_with_includes()
     {
         $page = $this->entities->page();
-        $secondPage = Page::query()->where('id', '!=', $page->id)->first();
+        $secondPage = $this->entities->page();
 
         $this->asEditor();
         $includeTag = '{{@' . $secondPage->id . '}}';

--- a/tests/Entity/PageContentTest.php
+++ b/tests/Entity/PageContentTest.php
@@ -15,7 +15,7 @@ class PageContentTest extends TestCase
 
     public function test_page_includes()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $secondPage = Page::query()->where('id', '!=', $page->id)->first();
 
         $secondPage->html = "<p id='section1'>Hello, This is a test</p><p id='section2'>This is a second block of content</p>";
@@ -44,7 +44,7 @@ class PageContentTest extends TestCase
 
     public function test_saving_page_with_includes()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $secondPage = Page::query()->where('id', '!=', $page->id)->first();
 
         $this->asEditor();
@@ -62,10 +62,8 @@ class PageContentTest extends TestCase
 
     public function test_page_includes_do_not_break_tables()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
-        /** @var Page $secondPage */
-        $secondPage = Page::query()->where('id', '!=', $page->id)->first();
+        $page = $this->entities->page();
+        $secondPage = $this->entities->page();
 
         $content = '<table id="table"><tbody><tr><td>test</td></tr></tbody></table>';
         $secondPage->html = $content;
@@ -80,10 +78,8 @@ class PageContentTest extends TestCase
 
     public function test_page_includes_do_not_break_code()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
-        /** @var Page $secondPage */
-        $secondPage = Page::query()->where('id', '!=', $page->id)->first();
+        $page = $this->entities->page();
+        $secondPage = $this->entities->page();
 
         $content = '<pre id="bkmrk-code"><code>var cat = null;</code></pre>';
         $secondPage->html = $content;
@@ -98,7 +94,7 @@ class PageContentTest extends TestCase
 
     public function test_page_includes_rendered_on_book_export()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $secondPage = Page::query()
             ->where('book_id', '!=', $page->book_id)
             ->first();
@@ -118,7 +114,7 @@ class PageContentTest extends TestCase
     public function test_page_content_scripts_removed_by_default()
     {
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $script = 'abc123<script>console.log("hello-test")</script>abc123';
         $page->html = "escape {$script}";
         $page->save();
@@ -141,7 +137,7 @@ class PageContentTest extends TestCase
         ];
 
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         foreach ($checks as $check) {
             $page->html = $check;
@@ -177,7 +173,7 @@ class PageContentTest extends TestCase
         ];
 
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         foreach ($checks as $check) {
             $page->html = $check;
@@ -206,7 +202,7 @@ class PageContentTest extends TestCase
         ];
 
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         foreach ($checks as $check) {
             $page->html = $check;
@@ -230,7 +226,7 @@ class PageContentTest extends TestCase
         ];
 
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         foreach ($checks as $check) {
             $page->html = $check;
@@ -255,7 +251,7 @@ class PageContentTest extends TestCase
         ];
 
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         foreach ($checks as $check) {
             $page->html = $check;
@@ -273,7 +269,7 @@ class PageContentTest extends TestCase
     public function test_page_inline_on_attributes_removed_by_default()
     {
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $script = '<p onmouseenter="console.log(\'test\')">Hello</p>';
         $page->html = "escape {$script}";
         $page->save();
@@ -298,7 +294,7 @@ class PageContentTest extends TestCase
         ];
 
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         foreach ($checks as $check) {
             $page->html = $check;
@@ -313,7 +309,7 @@ class PageContentTest extends TestCase
     public function test_page_content_scripts_show_when_configured()
     {
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         config()->push('app.allow_content_scripts', 'true');
 
         $script = 'abc123<script>console.log("hello-test")</script>abc123';
@@ -339,7 +335,7 @@ class PageContentTest extends TestCase
         ];
 
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         foreach ($checks as $check) {
             $page->html = $check;
@@ -358,7 +354,7 @@ class PageContentTest extends TestCase
     public function test_page_inline_on_attributes_show_if_configured()
     {
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         config()->push('app.allow_content_scripts', 'true');
 
         $script = '<p onmouseenter="console.log(\'test\')">Hello</p>';
@@ -390,7 +386,7 @@ class PageContentTest extends TestCase
     public function test_duplicate_ids_fixed_on_page_save()
     {
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $content = '<ul id="bkmrk-test"><li>test a</li><li><ul id="bkmrk-test"><li>test b</li></ul></li></ul>';
         $pageSave = $this->put($page->getUrl(), [
@@ -407,7 +403,7 @@ class PageContentTest extends TestCase
     public function test_anchors_referencing_non_bkmrk_ids_rewritten_after_save()
     {
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $content = '<h1 id="non-standard-id">test</h1><p><a href="#non-standard-id">link</a></p>';
         $this->put($page->getUrl(), [
@@ -485,7 +481,7 @@ class PageContentTest extends TestCase
 
     public function test_page_text_decodes_html_entities()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->actingAs($this->getAdmin())
             ->put($page->getUrl(''), [
@@ -500,7 +496,7 @@ class PageContentTest extends TestCase
     public function test_page_markdown_table_rendering()
     {
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $content = '| Syntax      | Description |
 | ----------- | ----------- |
@@ -521,7 +517,7 @@ class PageContentTest extends TestCase
     public function test_page_markdown_task_list_rendering()
     {
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $content = '- [ ] Item a
 - [x] Item b';
@@ -542,7 +538,7 @@ class PageContentTest extends TestCase
     public function test_page_markdown_strikethrough_rendering()
     {
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $content = '~~some crossed out text~~';
         $this->put($page->getUrl(), [
@@ -560,7 +556,7 @@ class PageContentTest extends TestCase
     public function test_page_markdown_single_html_comment_saving()
     {
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $content = '<!-- Test Comment -->';
         $this->put($page->getUrl(), [
@@ -579,7 +575,7 @@ class PageContentTest extends TestCase
     public function test_base64_images_get_extracted_from_page_content()
     {
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->put($page->getUrl(), [
             'name' => $page->name, 'summary' => '',
@@ -601,7 +597,7 @@ class PageContentTest extends TestCase
     public function test_base64_images_get_extracted_when_containing_whitespace()
     {
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $base64PngWithWhitespace = "iVBORw0KGg\noAAAANSUhE\tUgAAAAEAAAA BCA   YAAAAfFcSJAAA\n\t ACklEQVR4nGMAAQAABQAB";
         $base64PngWithoutWhitespace = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQAB';
@@ -632,7 +628,7 @@ class PageContentTest extends TestCase
 
         foreach ($extensions as $extension) {
             $this->asEditor();
-            $page = Page::query()->first();
+            $page = $this->entities->page();
 
             $this->put($page->getUrl(), [
                 'name' => $page->name, 'summary' => '',
@@ -647,7 +643,7 @@ class PageContentTest extends TestCase
     public function test_base64_images_get_extracted_from_markdown_page_content()
     {
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->put($page->getUrl(), [
             'name'     => $page->name, 'summary' => '',
@@ -672,7 +668,7 @@ class PageContentTest extends TestCase
         $pcreRecursionLimit = ini_get('pcre.recursion_limit');
 
         $this->asEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         ini_set('pcre.backtrack_limit', '500');
         ini_set('pcre.recursion_limit', '500');
@@ -701,7 +697,7 @@ class PageContentTest extends TestCase
 
     public function test_base64_images_within_markdown_blanked_if_not_supported_extension_for_extract()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->asEditor()->put($page->getUrl(), [
             'name'     => $page->name, 'summary' => '',
@@ -713,7 +709,7 @@ class PageContentTest extends TestCase
 
     public function test_nested_headers_gets_assigned_an_id()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $content = '<table><tbody><tr><td><h5>Simple Test</h5></td></tr></tbody></table>';
         $this->asEditor()->put($page->getUrl(), [
@@ -729,8 +725,7 @@ class PageContentTest extends TestCase
 
     public function test_non_breaking_spaces_are_preserved()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $content = '<p>&nbsp;</p>';
         $this->asEditor()->put($page->getUrl(), [

--- a/tests/Entity/PageDraftTest.php
+++ b/tests/Entity/PageDraftTest.php
@@ -85,8 +85,7 @@ class PageDraftTest extends TestCase
     {
         $admin = $this->getAdmin();
         $editor = $this->getEditor();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->actingAs($editor)->put('/ajax/page/' . $page->id . '/save-draft', [
             'name' => $page->name,
@@ -120,8 +119,7 @@ class PageDraftTest extends TestCase
     {
         $admin = $this->getAdmin();
         $editor = $this->getEditor();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->actingAs($admin)->put('/ajax/page/' . $page->id . '/save-draft', [
             'name' => $page->name,
@@ -140,8 +138,7 @@ class PageDraftTest extends TestCase
 
     public function test_draft_pages_show_on_homepage()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $resp = $this->asAdmin()->get('/');
         $this->withHtml($resp)->assertElementNotContains('#recent-drafts', 'New Page');
 
@@ -152,8 +149,7 @@ class PageDraftTest extends TestCase
 
     public function test_draft_pages_not_visible_by_others()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $chapter = $book->chapters->first();
         $newUser = $this->getEditor();
 
@@ -171,8 +167,7 @@ class PageDraftTest extends TestCase
     public function test_page_html_in_ajax_fetch_response()
     {
         $this->asAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->getJson('/ajax/page/' . $page->id)->assertJson([
             'html' => $page->html,
@@ -181,8 +176,7 @@ class PageDraftTest extends TestCase
 
     public function test_updating_page_draft_with_markdown_retains_markdown_content()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $this->asEditor()->get($book->getUrl('/create-page'));
         /** @var Page $draft */
         $draft = Page::query()->where('draft', '=', true)->where('book_id', '=', $book->id)->firstOrFail();
@@ -207,8 +201,7 @@ class PageDraftTest extends TestCase
 
     public function test_slug_generated_on_draft_publish_to_page_when_no_name_change()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $this->asEditor()->get($book->getUrl('/create-page'));
         /** @var Page $draft */
         $draft = Page::query()->where('draft', '=', true)->where('book_id', '=', $book->id)->firstOrFail();

--- a/tests/Entity/PageDraftTest.php
+++ b/tests/Entity/PageDraftTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Entity;
 
-use BookStack\Entities\Models\Book;
 use BookStack\Entities\Models\Page;
 use BookStack\Entities\Models\PageRevision;
 use BookStack\Entities\Repos\PageRepo;
@@ -10,20 +9,13 @@ use Tests\TestCase;
 
 class PageDraftTest extends TestCase
 {
-    /**
-     * @var Page
-     */
-    protected $page;
-
-    /**
-     * @var PageRepo
-     */
-    protected $pageRepo;
+    protected Page $page;
+    protected PageRepo $pageRepo;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->page = Page::query()->first();
+        $this->page = $this->entities->page();
         $this->pageRepo = app()->make(PageRepo::class);
     }
 

--- a/tests/Entity/PageEditorTest.php
+++ b/tests/Entity/PageEditorTest.php
@@ -2,20 +2,18 @@
 
 namespace Tests\Entity;
 
-use BookStack\Entities\Models\Book;
 use BookStack\Entities\Models\Chapter;
 use BookStack\Entities\Models\Page;
 use Tests\TestCase;
 
 class PageEditorTest extends TestCase
 {
-    /** @var Page */
-    protected $page;
+    protected Page $page;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->page = Page::query()->first();
+        $this->page = $this->entities->page();
     }
 
     public function test_default_editor_is_wysiwyg_for_new_pages()
@@ -80,8 +78,7 @@ class PageEditorTest extends TestCase
 
     public function test_back_link_in_editor_has_correct_url()
     {
-        /** @var Book $book */
-        $book = Book::query()->whereHas('pages')->whereHas('chapters')->firstOrFail();
+        $book = $this->entities->bookHasChaptersAndPages();
         $this->asEditor()->get($book->getUrl('/create-page'));
         /** @var Chapter $chapter */
         $chapter = $book->chapters()->firstOrFail();

--- a/tests/Entity/PageEditorTest.php
+++ b/tests/Entity/PageEditorTest.php
@@ -58,8 +58,7 @@ class PageEditorTest extends TestCase
     public function test_empty_markdown_still_saves_without_error()
     {
         $this->setSettings(['app-editor' => 'markdown']);
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
 
         $this->asEditor()->get($book->getUrl('/create-page'));
         $draft = Page::query()->where('book_id', '=', $book->id)
@@ -108,8 +107,7 @@ class PageEditorTest extends TestCase
 
     public function test_switching_from_html_to_clean_markdown_works()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->html = '<h2>A Header</h2><p>Some <strong>bold</strong> content.</p>';
         $page->save();
 
@@ -121,8 +119,7 @@ class PageEditorTest extends TestCase
 
     public function test_switching_from_html_to_stable_markdown_works()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->html = '<h2>A Header</h2><p>Some <strong>bold</strong> content.</p>';
         $page->save();
 
@@ -134,8 +131,7 @@ class PageEditorTest extends TestCase
 
     public function test_switching_from_markdown_to_wysiwyg_works()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->html = '';
         $page->markdown = "## A Header\n\nSome content with **bold** text!";
         $page->save();
@@ -180,8 +176,7 @@ class PageEditorTest extends TestCase
 
     public function test_page_editor_type_switch_does_not_work_without_change_editor_permissions()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->html = '<h2>A Header</h2><p>Some <strong>bold</strong> content.</p>';
         $page->save();
 
@@ -193,8 +188,7 @@ class PageEditorTest extends TestCase
 
     public function test_page_save_does_not_change_active_editor_without_change_editor_permissions()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->html = '<h2>A Header</h2><p>Some <strong>bold</strong> content.</p>';
         $page->editor = 'wysiwyg';
         $page->save();

--- a/tests/Entity/PageRevisionTest.php
+++ b/tests/Entity/PageRevisionTest.php
@@ -21,7 +21,7 @@ class PageRevisionTest extends TestCase
     public function test_page_revision_views_viewable()
     {
         $this->asEditor();
-        $page = Page::first();
+        $page = $this->entities->page();
         $this->createRevisions($page, 1, ['name' => 'updated page', 'html' => '<p>new content</p>']);
         $pageRevision = $page->revisions->last();
 
@@ -37,7 +37,7 @@ class PageRevisionTest extends TestCase
     public function test_page_revision_preview_shows_content_of_revision()
     {
         $this->asEditor();
-        $page = Page::first();
+        $page = $this->entities->page();
         $this->createRevisions($page, 1, ['name' => 'updated page', 'html' => '<p>new revision content</p>']);
         $pageRevision = $page->revisions->last();
         $this->createRevisions($page, 1, ['name' => 'updated page', 'html' => '<p>Updated content</p>']);
@@ -50,7 +50,7 @@ class PageRevisionTest extends TestCase
     public function test_page_revision_restore_updates_content()
     {
         $this->asEditor();
-        $page = Page::first();
+        $page = $this->entities->page();
         $this->createRevisions($page, 1, ['name' => 'updated page abc123', 'html' => '<p>new contente def456</p>']);
         $this->createRevisions($page, 1, ['name' => 'updated page again', 'html' => '<p>new content</p>']);
         $page = Page::find($page->id);
@@ -74,7 +74,7 @@ class PageRevisionTest extends TestCase
     public function test_page_revision_restore_with_markdown_retains_markdown_content()
     {
         $this->asEditor();
-        $page = Page::first();
+        $page = $this->entities->page();
         $this->createRevisions($page, 1, ['name' => 'updated page abc123', 'markdown' => '## New Content def456']);
         $this->createRevisions($page, 1, ['name' => 'updated page again', 'markdown' => '## New Content Updated']);
         $page = Page::find($page->id);
@@ -102,7 +102,7 @@ class PageRevisionTest extends TestCase
     public function test_page_revision_restore_sets_new_revision_with_summary()
     {
         $this->asEditor();
-        $page = Page::first();
+        $page = $this->entities->page();
         $this->createRevisions($page, 1, ['name' => 'updated page abc123', 'html' => '<p>new contente def456</p>', 'summary' => 'My first update']);
         $this->createRevisions($page, 1, ['html' => '<p>new content</p>']);
         $page->refresh();
@@ -124,7 +124,7 @@ class PageRevisionTest extends TestCase
 
     public function test_page_revision_count_increments_on_update()
     {
-        $page = Page::first();
+        $page = $this->entities->page();
         $startCount = $page->revision_count;
         $this->createRevisions($page, 1);
 
@@ -133,7 +133,7 @@ class PageRevisionTest extends TestCase
 
     public function test_revision_count_shown_in_page_meta()
     {
-        $page = Page::first();
+        $page = $this->entities->page();
         $this->createRevisions($page, 2);
 
         $pageView = $this->get($page->getUrl());
@@ -172,7 +172,7 @@ class PageRevisionTest extends TestCase
     public function test_revision_limit_enforced()
     {
         config()->set('app.revision_limit', 2);
-        $page = Page::first();
+        $page = $this->entities->page();
         $this->createRevisions($page, 12);
 
         $revisionCount = $page->revisions()->count();
@@ -182,7 +182,7 @@ class PageRevisionTest extends TestCase
     public function test_false_revision_limit_allows_many_revisions()
     {
         config()->set('app.revision_limit', false);
-        $page = Page::first();
+        $page = $this->entities->page();
         $this->createRevisions($page, 12);
 
         $revisionCount = $page->revisions()->count();
@@ -191,8 +191,7 @@ class PageRevisionTest extends TestCase
 
     public function test_revision_list_shows_editor_type()
     {
-        /** @var Page $page */
-        $page = Page::first();
+        $page = $this->entities->page();
         $this->createRevisions($page, 1, ['html' => 'new page html']);
 
         $resp = $this->asAdmin()->get($page->refresh()->getUrl('/revisions'));

--- a/tests/Entity/PageRevisionTest.php
+++ b/tests/Entity/PageRevisionTest.php
@@ -10,8 +10,7 @@ class PageRevisionTest extends TestCase
 {
     public function test_revision_links_visible_to_viewer()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $html = $this->withHtml($this->asViewer()->get($page->getUrl()));
         $html->assertLinkExists($page->getUrl('/revisions'));
@@ -143,8 +142,7 @@ class PageRevisionTest extends TestCase
 
     public function test_revision_deletion()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->createRevisions($page, 2);
         $beforeRevisionCount = $page->revisions->count();
 
@@ -208,8 +206,7 @@ class PageRevisionTest extends TestCase
 
     public function test_revision_restore_action_only_visible_with_permission()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->createRevisions($page, 2);
 
         $viewer = $this->getViewer();
@@ -227,8 +224,7 @@ class PageRevisionTest extends TestCase
 
     public function test_revision_delete_action_only_visible_with_permission()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->createRevisions($page, 2);
 
         $viewer = $this->getViewer();

--- a/tests/Entity/PageTemplateTest.php
+++ b/tests/Entity/PageTemplateTest.php
@@ -9,7 +9,7 @@ class PageTemplateTest extends TestCase
 {
     public function test_active_templates_visible_on_page_view()
     {
-        $page = Page::first();
+        $page = $this->entities->page();
 
         $this->asEditor();
         $templateView = $this->get($page->getUrl());
@@ -24,7 +24,7 @@ class PageTemplateTest extends TestCase
 
     public function test_manage_templates_permission_required_to_change_page_template_status()
     {
-        $page = Page::first();
+        $page = $this->entities->page();
         $editor = $this->getEditor();
         $this->actingAs($editor);
 
@@ -52,7 +52,7 @@ class PageTemplateTest extends TestCase
     public function test_templates_content_should_be_fetchable_only_if_page_marked_as_template()
     {
         $content = '<div>my_custom_template_content</div>';
-        $page = Page::first();
+        $page = $this->entities->page();
         $editor = $this->getEditor();
         $this->actingAs($editor);
 

--- a/tests/Entity/PageTest.php
+++ b/tests/Entity/PageTest.php
@@ -201,7 +201,7 @@ class PageTest extends TestCase
         $newBook->owned_by = $viewer->id;
         $newBook->save();
         $this->giveUserPermissions($viewer, ['page-create-own']);
-        $this->regenEntityPermissions($newBook);
+        $this->entities->regenPermissions($newBook);
 
         $resp = $this->actingAs($viewer)->get($page->getUrl());
         $resp->assertSee($page->getUrl('/copy'));
@@ -255,7 +255,7 @@ class PageTest extends TestCase
     public function test_recently_updated_pages_view()
     {
         $user = $this->getEditor();
-        $content = $this->createEntityChainBelongingToUser($user);
+        $content = $this->entities->createChainBelongingToUser($user);
 
         $resp = $this->asAdmin()->get('/pages/recently-updated');
         $this->withHtml($resp)->assertElementContains('.entity-list .page:nth-child(1)', $content['page']->name);
@@ -303,8 +303,8 @@ class PageTest extends TestCase
             'html' => '<p>Updated content</p>',
         ]);
 
-        $this->setEntityRestrictions($page->book);
-        $this->setEntityRestrictions($page, ['view'], [$user->roles->first()]);
+        $this->entities->setPermissions($page->book);
+        $this->entities->setPermissions($page, ['view'], [$user->roles->first()]);
 
         $resp = $this->get('/pages/recently-updated');
         $resp->assertDontSee($page->book->getShortName(42));

--- a/tests/Entity/PageTest.php
+++ b/tests/Entity/PageTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Entity;
 
 use BookStack\Entities\Models\Book;
-use BookStack\Entities\Models\Chapter;
 use BookStack\Entities\Models\Page;
 use Carbon\Carbon;
 use Tests\TestCase;
@@ -128,7 +127,7 @@ class PageTest extends TestCase
 
     public function test_page_copy()
     {
-        $page = Page::first();
+        $page = $this->entities->page();
         $page->html = '<p>This is some test content</p>';
         $page->save();
 
@@ -151,7 +150,7 @@ class PageTest extends TestCase
 
     public function test_page_copy_with_markdown_has_both_html_and_markdown()
     {
-        $page = Page::first();
+        $page = $this->entities->page();
         $page->html = '<h1>This is some test content</h1>';
         $page->markdown = '# This is some test content';
         $page->save();
@@ -169,7 +168,7 @@ class PageTest extends TestCase
 
     public function test_page_copy_with_no_destination()
     {
-        $page = Page::first();
+        $page = $this->entities->page();
         $currentBook = $page->book;
 
         $resp = $this->asEditor()->get($page->getUrl('/copy'));
@@ -188,7 +187,7 @@ class PageTest extends TestCase
 
     public function test_page_can_be_copied_without_edit_permission()
     {
-        $page = Page::first();
+        $page = $this->entities->page();
         $currentBook = $page->book;
         $newBook = Book::where('id', '!=', $currentBook->id)->first();
         $viewer = $this->getViewer();
@@ -274,8 +273,7 @@ class PageTest extends TestCase
     public function test_recently_updated_pages_view_shows_parent_chain()
     {
         $user = $this->getEditor();
-        /** @var Page $page */
-        $page = Page::query()->whereNotNull('chapter_id')->first();
+        $page = $this->entities->pageWithinChapter();
 
         $this->actingAs($user)->put($page->getUrl(), [
             'name' => 'Updated title',
@@ -290,8 +288,7 @@ class PageTest extends TestCase
     public function test_recently_updated_pages_view_does_not_show_parent_if_not_visible()
     {
         $user = $this->getEditor();
-        /** @var Page $page */
-        $page = Page::query()->whereNotNull('chapter_id')->first();
+        $page = $this->entities->pageWithinChapter();
 
         $this->actingAs($user)->put($page->getUrl(), [
             'name' => 'Updated title',

--- a/tests/Entity/PageTest.php
+++ b/tests/Entity/PageTest.php
@@ -12,8 +12,7 @@ class PageTest extends TestCase
 {
     public function test_create()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $page = Page::factory()->make([
             'name' => 'My First Page',
         ]);
@@ -39,7 +38,7 @@ class PageTest extends TestCase
 
     public function test_page_view_when_creator_is_deleted_but_owner_exists()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $user = $this->getViewer();
         $owner = $this->getEditor();
         $page->created_by = $user->id;
@@ -55,7 +54,7 @@ class PageTest extends TestCase
     public function test_page_creation_with_markdown_content()
     {
         $this->setSettings(['app-editor' => 'markdown']);
-        $book = Book::query()->first();
+        $book = $this->entities->book();
 
         $this->asEditor()->get($book->getUrl('/create-page'));
         $draft = Page::query()->where('book_id', '=', $book->id)
@@ -83,7 +82,7 @@ class PageTest extends TestCase
 
     public function test_page_delete()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->assertNull($page->deleted_at);
 
         $deleteViewReq = $this->asEditor()->get($page->getUrl('/delete'));
@@ -103,8 +102,7 @@ class PageTest extends TestCase
 
     public function test_page_full_delete_removes_all_revisions()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->revisions()->create([
             'html' => '<p>ducks</p>',
             'name' => 'my page revision',
@@ -221,8 +219,7 @@ class PageTest extends TestCase
 
     public function test_old_page_slugs_redirect_to_new_pages()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         // Need to save twice since revisions are not generated in seeder.
         $this->asAdmin()->put($page->getUrl(), [
@@ -244,8 +241,7 @@ class PageTest extends TestCase
 
     public function test_page_within_chapter_deletion_returns_to_chapter()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $page = $chapter->pages()->first();
 
         $this->asEditor()->delete($page->getUrl())
@@ -264,8 +260,7 @@ class PageTest extends TestCase
     public function test_recently_updated_pages_view_shows_updated_by_details()
     {
         $user = $this->getEditor();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->actingAs($user)->put($page->getUrl(), [
             'name' => 'Updated title',

--- a/tests/Entity/SortTest.php
+++ b/tests/Entity/SortTest.php
@@ -98,14 +98,14 @@ class SortTest extends TestCase
         $newBook = Book::query()->where('id', '!=', $currentBook->id)->first();
         $editor = $this->getEditor();
 
-        $this->setEntityRestrictions($newBook, ['view', 'update', 'delete'], $editor->roles->all());
+        $this->entities->setPermissions($newBook, ['view', 'update', 'delete'], $editor->roles->all());
 
         $movePageResp = $this->actingAs($editor)->put($page->getUrl('/move'), [
             'entity_selection' => 'book:' . $newBook->id,
         ]);
         $this->assertPermissionError($movePageResp);
 
-        $this->setEntityRestrictions($newBook, ['view', 'update', 'delete', 'create'], $editor->roles->all());
+        $this->entities->setPermissions($newBook, ['view', 'update', 'delete', 'create'], $editor->roles->all());
         $movePageResp = $this->put($page->getUrl('/move'), [
             'entity_selection' => 'book:' . $newBook->id,
         ]);
@@ -123,8 +123,8 @@ class SortTest extends TestCase
         $newBook = Book::query()->where('id', '!=', $currentBook->id)->first();
         $editor = $this->getEditor();
 
-        $this->setEntityRestrictions($newBook, ['view', 'update', 'create', 'delete'], $editor->roles->all());
-        $this->setEntityRestrictions($page, ['view', 'update', 'create'], $editor->roles->all());
+        $this->entities->setPermissions($newBook, ['view', 'update', 'create', 'delete'], $editor->roles->all());
+        $this->entities->setPermissions($page, ['view', 'update', 'create'], $editor->roles->all());
 
         $movePageResp = $this->actingAs($editor)->put($page->getUrl('/move'), [
             'entity_selection' => 'book:' . $newBook->id,
@@ -133,7 +133,7 @@ class SortTest extends TestCase
         $pageView = $this->get($page->getUrl());
         $pageView->assertDontSee($page->getUrl('/move'));
 
-        $this->setEntityRestrictions($page, ['view', 'update', 'create', 'delete'], $editor->roles->all());
+        $this->entities->setPermissions($page, ['view', 'update', 'create', 'delete'], $editor->roles->all());
         $movePageResp = $this->put($page->getUrl('/move'), [
             'entity_selection' => 'book:' . $newBook->id,
         ]);
@@ -178,8 +178,8 @@ class SortTest extends TestCase
         $newBook = Book::query()->where('id', '!=', $currentBook->id)->first();
         $editor = $this->getEditor();
 
-        $this->setEntityRestrictions($newBook, ['view', 'update', 'create', 'delete'], $editor->roles->all());
-        $this->setEntityRestrictions($chapter, ['view', 'update', 'create'], $editor->roles->all());
+        $this->entities->setPermissions($newBook, ['view', 'update', 'create', 'delete'], $editor->roles->all());
+        $this->entities->setPermissions($chapter, ['view', 'update', 'create'], $editor->roles->all());
 
         $moveChapterResp = $this->actingAs($editor)->put($chapter->getUrl('/move'), [
             'entity_selection' => 'book:' . $newBook->id,
@@ -188,7 +188,7 @@ class SortTest extends TestCase
         $pageView = $this->get($chapter->getUrl());
         $pageView->assertDontSee($chapter->getUrl('/move'));
 
-        $this->setEntityRestrictions($chapter, ['view', 'update', 'create', 'delete'], $editor->roles->all());
+        $this->entities->setPermissions($chapter, ['view', 'update', 'create', 'delete'], $editor->roles->all());
         $moveChapterResp = $this->put($chapter->getUrl('/move'), [
             'entity_selection' => 'book:' . $newBook->id,
         ]);
@@ -205,15 +205,15 @@ class SortTest extends TestCase
         $newBook = Book::query()->where('id', '!=', $currentBook->id)->first();
         $editor = $this->getEditor();
 
-        $this->setEntityRestrictions($newBook, ['view', 'update', 'delete'], [$editor->roles->first()]);
-        $this->setEntityRestrictions($chapter, ['view', 'update', 'create', 'delete'], [$editor->roles->first()]);
+        $this->entities->setPermissions($newBook, ['view', 'update', 'delete'], [$editor->roles->first()]);
+        $this->entities->setPermissions($chapter, ['view', 'update', 'create', 'delete'], [$editor->roles->first()]);
 
         $moveChapterResp = $this->actingAs($editor)->put($chapter->getUrl('/move'), [
             'entity_selection' => 'book:' . $newBook->id,
         ]);
         $this->assertPermissionError($moveChapterResp);
 
-        $this->setEntityRestrictions($newBook, ['view', 'update', 'create', 'delete'], [$editor->roles->first()]);
+        $this->entities->setPermissions($newBook, ['view', 'update', 'create', 'delete'], [$editor->roles->first()]);
         $moveChapterResp = $this->put($chapter->getUrl('/move'), [
             'entity_selection' => 'book:' . $newBook->id,
         ]);
@@ -257,8 +257,8 @@ class SortTest extends TestCase
     public function test_book_sort()
     {
         $oldBook = Book::query()->first();
-        $chapterToMove = $this->newChapter(['name' => 'chapter to move'], $oldBook);
-        $newBook = $this->newBook(['name' => 'New sort book']);
+        $chapterToMove = $this->entities->newChapter(['name' => 'chapter to move'], $oldBook);
+        $newBook = $this->entities->newBook(['name' => 'New sort book']);
         $pagesToMove = Page::query()->take(5)->get();
 
         // Create request data
@@ -323,7 +323,7 @@ class SortTest extends TestCase
         $page = Page::query()->where('chapter_id', '!=', 0)->first();
         /** @var Chapter $otherChapter */
         $otherChapter = Chapter::query()->where('book_id', '!=', $page->book_id)->first();
-        $this->setEntityRestrictions($otherChapter);
+        $this->entities->setPermissions($otherChapter);
 
         $sortData = [
             'id'            => $page->id,
@@ -346,7 +346,7 @@ class SortTest extends TestCase
         /** @var Chapter $otherChapter */
         $otherChapter = Chapter::query()->where('book_id', '!=', $page->book_id)->first();
         $editor = $this->getEditor();
-        $this->setEntityRestrictions($otherChapter->book, ['update', 'delete'], [$editor->roles()->first()]);
+        $this->entities->setPermissions($otherChapter->book, ['update', 'delete'], [$editor->roles()->first()]);
 
         $sortData = [
             'id'            => $page->id,
@@ -369,7 +369,7 @@ class SortTest extends TestCase
         /** @var Chapter $otherChapter */
         $otherChapter = Chapter::query()->where('book_id', '!=', $page->book_id)->first();
         $editor = $this->getEditor();
-        $this->setEntityRestrictions($otherChapter, ['view', 'delete'], [$editor->roles()->first()]);
+        $this->entities->setPermissions($otherChapter, ['view', 'delete'], [$editor->roles()->first()]);
 
         $sortData = [
             'id'            => $page->id,
@@ -392,7 +392,7 @@ class SortTest extends TestCase
         /** @var Chapter $otherChapter */
         $otherChapter = Chapter::query()->where('book_id', '!=', $page->book_id)->first();
         $editor = $this->getEditor();
-        $this->setEntityRestrictions($page, ['view', 'delete'], [$editor->roles()->first()]);
+        $this->entities->setPermissions($page, ['view', 'delete'], [$editor->roles()->first()]);
 
         $sortData = [
             'id'            => $page->id,
@@ -415,7 +415,7 @@ class SortTest extends TestCase
         /** @var Chapter $otherChapter */
         $otherChapter = Chapter::query()->where('book_id', '!=', $page->book_id)->first();
         $editor = $this->getEditor();
-        $this->setEntityRestrictions($page, ['view', 'update'], [$editor->roles()->first()]);
+        $this->entities->setPermissions($page, ['view', 'update'], [$editor->roles()->first()]);
 
         $sortData = [
             'id'            => $page->id,

--- a/tests/Entity/SortTest.php
+++ b/tests/Entity/SortTest.php
@@ -33,7 +33,7 @@ class SortTest extends TestCase
 
     public function test_page_move_into_book()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $currentBook = $page->book;
         $newBook = Book::query()->where('id', '!=', $currentBook->id)->first();
 
@@ -55,7 +55,7 @@ class SortTest extends TestCase
 
     public function test_page_move_into_chapter()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $currentBook = $page->book;
         $newBook = Book::query()->where('id', '!=', $currentBook->id)->first();
         $newChapter = $newBook->chapters()->first();
@@ -93,7 +93,7 @@ class SortTest extends TestCase
 
     public function test_page_move_requires_create_permissions_on_parent()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $currentBook = $page->book;
         $newBook = Book::query()->where('id', '!=', $currentBook->id)->first();
         $editor = $this->getEditor();
@@ -118,7 +118,7 @@ class SortTest extends TestCase
 
     public function test_page_move_requires_delete_permissions()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $currentBook = $page->book;
         $newBook = Book::query()->where('id', '!=', $currentBook->id)->first();
         $editor = $this->getEditor();
@@ -145,7 +145,7 @@ class SortTest extends TestCase
 
     public function test_chapter_move()
     {
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $currentBook = $chapter->book;
         $pageToCheck = $chapter->pages->first();
         $newBook = Book::query()->where('id', '!=', $currentBook->id)->first();
@@ -173,7 +173,7 @@ class SortTest extends TestCase
 
     public function test_chapter_move_requires_delete_permissions()
     {
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $currentBook = $chapter->book;
         $newBook = Book::query()->where('id', '!=', $currentBook->id)->first();
         $editor = $this->getEditor();
@@ -200,7 +200,7 @@ class SortTest extends TestCase
 
     public function test_chapter_move_requires_create_permissions_in_new_book()
     {
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $currentBook = $chapter->book;
         $newBook = Book::query()->where('id', '!=', $currentBook->id)->first();
         $editor = $this->getEditor();

--- a/tests/Entity/TagTest.php
+++ b/tests/Entity/TagTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Entity;
 
 use BookStack\Actions\Tag;
-use BookStack\Entities\Models\Book;
 use BookStack\Entities\Models\Entity;
 use BookStack\Entities\Models\Page;
 use Tests\TestCase;

--- a/tests/Entity/TagTest.php
+++ b/tests/Entity/TagTest.php
@@ -188,7 +188,7 @@ class TagTest extends TestCase
         $resp->assertSee('GreatTestContent');
 
         $page->restricted = true;
-        $this->regenEntityPermissions($page);
+        $this->entities->regenPermissions($page);
 
         $resp = $this->asEditor()->get('/tags');
         $resp->assertDontSee('SuperCategory');
@@ -207,7 +207,7 @@ class TagTest extends TestCase
     {
         $this->asEditor();
 
-        foreach ($this->getEachEntityType() as $entity) {
+        foreach ($this->entities->all() as $entity) {
             $entity->tags()->create(['name' => 'My Super Tag Name', 'value' => 'An-awesome-value']);
             $html = $this->withHtml($this->get($entity->getUrl()));
             $html->assertElementExists('body.tag-name-mysupertagname.tag-value-anawesomevalue.tag-pair-mysupertagname-anawesomevalue');

--- a/tests/Entity/TagTest.php
+++ b/tests/Entity/TagTest.php
@@ -102,8 +102,7 @@ class TagTest extends TestCase
 
     public function test_tags_index_shows_tag_name_as_expected_with_right_counts()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->tags()->create(['name' => 'Category', 'value' => 'GreatTestContent']);
         $page->tags()->create(['name' => 'Category', 'value' => 'OtherTestContent']);
 
@@ -120,8 +119,7 @@ class TagTest extends TestCase
         $html->assertElementContains('a[title="Assigned to Shelves"]', '0');
         $html->assertElementContains('a[href$="/tags?name=Category"]', '2 unique values');
 
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $book->tags()->create(['name' => 'Category', 'value' => 'GreatTestContent']);
         $resp = $this->asEditor()->get('/tags');
         $this->withHtml($resp)->assertElementContains('a[title="Total tag usages"]', '3');
@@ -131,8 +129,7 @@ class TagTest extends TestCase
 
     public function test_tag_index_can_be_searched()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->tags()->create(['name' => 'Category', 'value' => 'GreatTestContent']);
 
         $resp = $this->asEditor()->get('/tags?search=cat');
@@ -148,8 +145,7 @@ class TagTest extends TestCase
 
     public function test_tag_index_search_will_show_mulitple_values_of_a_single_tag_name()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->tags()->create(['name' => 'Animal', 'value' => 'Catfish']);
         $page->tags()->create(['name' => 'Animal', 'value' => 'Catdog']);
 
@@ -160,8 +156,7 @@ class TagTest extends TestCase
 
     public function test_tag_index_can_be_scoped_to_specific_tag_name()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->tags()->create(['name' => 'Category', 'value' => 'GreatTestContent']);
         $page->tags()->create(['name' => 'Category', 'value' => 'OtherTestContent']);
         $page->tags()->create(['name' => 'OtherTagName', 'value' => 'OtherValue']);
@@ -178,8 +173,7 @@ class TagTest extends TestCase
 
     public function test_tags_index_adheres_to_page_permissions()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->tags()->create(['name' => 'SuperCategory', 'value' => 'GreatTestContent']);
 
         $resp = $this->asEditor()->get('/tags');
@@ -216,7 +210,7 @@ class TagTest extends TestCase
 
     public function test_tag_classes_are_escaped()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->tags()->create(['name' => '<>']);
         $resp = $this->asEditor()->get($page->getUrl());
         $resp->assertDontSee('tag-name-<>', false);

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use BookStack\Entities\Models\Book;
 use Illuminate\Support\Facades\Log;
 
 class ErrorTest extends TestCase

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -27,7 +27,7 @@ class ErrorTest extends TestCase
     {
         $this->actingAs($this->getViewer());
         $handler = $this->withTestLogger();
-        $book = Book::query()->first();
+        $book = $this->entities->book();
 
         // Ensure we're seeing errors
         Log::error('cat');

--- a/tests/FavouriteTest.php
+++ b/tests/FavouriteTest.php
@@ -13,7 +13,7 @@ class FavouriteTest extends TestCase
 {
     public function test_page_add_favourite_flow()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $editor = $this->getEditor();
 
         $resp = $this->actingAs($editor)->get($page->getUrl());
@@ -36,7 +36,7 @@ class FavouriteTest extends TestCase
 
     public function test_page_remove_favourite_flow()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $editor = $this->getEditor();
         Favourite::query()->forceCreate([
             'user_id'           => $editor->id,
@@ -62,8 +62,7 @@ class FavouriteTest extends TestCase
 
     public function test_favourite_flow_with_own_permissions()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $user = User::factory()->create();
         $book->owned_by = $user->id;
         $book->save();
@@ -115,8 +114,7 @@ class FavouriteTest extends TestCase
         $resp = $this->actingAs($editor)->get('/');
         $this->withHtml($resp)->assertElementNotExists('#top-favourites');
 
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->favourites()->save((new Favourite())->forceFill(['user_id' => $editor->id]));
 
         $resp = $this->get('/');
@@ -126,8 +124,7 @@ class FavouriteTest extends TestCase
 
     public function test_favourites_list_page_shows_favourites_and_has_working_pagination()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $editor = $this->getEditor();
 
         $resp = $this->actingAs($editor)->get('/favourites');

--- a/tests/FavouriteTest.php
+++ b/tests/FavouriteTest.php
@@ -4,10 +4,6 @@ namespace Tests;
 
 use BookStack\Actions\Favourite;
 use BookStack\Auth\User;
-use BookStack\Entities\Models\Book;
-use BookStack\Entities\Models\Bookshelf;
-use BookStack\Entities\Models\Chapter;
-use BookStack\Entities\Models\Page;
 
 class FavouriteTest extends TestCase
 {
@@ -83,16 +79,11 @@ class FavouriteTest extends TestCase
         ]);
     }
 
-    public function test_book_chapter_shelf_pages_contain_favourite_button()
+    public function test_each_entity_type_shows_favourite_button()
     {
-        $entities = [
-            Bookshelf::query()->first(),
-            Book::query()->first(),
-            Chapter::query()->first(),
-        ];
         $this->actingAs($this->getEditor());
 
-        foreach ($entities as $entity) {
+        foreach ($this->entities->all() as $entity) {
             $resp = $this->get($entity->getUrl());
             $this->withHtml($resp)->assertElementExists('form[method="POST"][action$="/favourites/add"]');
         }

--- a/tests/Helpers/EntityProvider.php
+++ b/tests/Helpers/EntityProvider.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Helpers;
+
+use BookStack\Auth\Role;
+use BookStack\Auth\User;
+use BookStack\Entities\Models\Book;
+use BookStack\Entities\Models\Bookshelf;
+use BookStack\Entities\Models\Chapter;
+use BookStack\Entities\Models\Entity;
+use BookStack\Entities\Models\Page;
+use BookStack\Entities\Repos\BookRepo;
+use BookStack\Entities\Repos\BookshelfRepo;
+use BookStack\Entities\Repos\ChapterRepo;
+use BookStack\Entities\Repos\PageRepo;
+
+class EntityProvider
+{
+    /**
+     * @var array<string, int[]>
+     */
+    protected array $fetchCache = [
+        'book' => [],
+        'page' => [],
+        'bookshelf' => [],
+        'chapter' => [],
+    ];
+
+    /**
+     * Get an un-fetched page from the system.
+     */
+    public function page(): Page
+    {
+        /** @var Page $page */
+        $page = Page::query()->whereNotIn('id', $this->fetchCache['page'])->first();
+        $this->addToCache($page);
+        return $page;
+    }
+
+    /**
+     * Get an un-fetched chapter from the system.
+     */
+    public function chapter(): Chapter
+    {
+        /** @var Chapter $chapter */
+        $chapter = Chapter::query()->whereNotIn('id', $this->fetchCache['chapter'])->first();
+        $this->addToCache($chapter);
+        return $chapter;
+    }
+
+    /**
+     * Get an un-fetched book from the system.
+     */
+    public function book(): Book
+    {
+        /** @var Book $book */
+        $book = Book::query()->whereNotIn('id', $this->fetchCache['book'])->first();
+        $this->addToCache($book);
+        return $book;
+    }
+
+    /**
+     * Get an un-fetched shelf from the system.
+     */
+    public function shelf(): Bookshelf
+    {
+        /** @var Bookshelf $shelf */
+        $shelf = Bookshelf::query()->whereNotIn('id', $this->fetchCache['bookshelf'])->first();
+        $this->addToCache($shelf);
+        return $shelf;
+    }
+
+    /**
+     * Get all entity types from the system.
+     * @return array{page: Page, chapter: Chapter, book: Book, bookshelf: Bookshelf}
+     */
+    public function all(): array
+    {
+        return [
+            'page'      => $this->page(),
+            'chapter'   => $this->chapter(),
+            'book'      => $this->book(),
+            'bookshelf' => $this->shelf(),
+        ];
+    }
+
+    /**
+     * Create a book to page chain of entities that belong to a specific user.
+     * @return array{book: Book, chapter: Chapter, page: Page}
+     */
+    public function createChainBelongingToUser(User $creatorUser, ?User $updaterUser = null): array
+    {
+        if (empty($updaterUser)) {
+            $updaterUser = $creatorUser;
+        }
+
+        $userAttrs = ['created_by' => $creatorUser->id, 'owned_by' => $creatorUser->id, 'updated_by' => $updaterUser->id];
+        /** @var Book $book */
+        $book = Book::factory()->create($userAttrs);
+        $chapter = Chapter::factory()->create(array_merge(['book_id' => $book->id], $userAttrs));
+        $page = Page::factory()->create(array_merge(['book_id' => $book->id, 'chapter_id' => $chapter->id], $userAttrs));
+
+        $book->rebuildPermissions();
+        $this->addToCache([$page, $chapter, $book]);
+
+        return compact('book', 'chapter', 'page');
+    }
+
+    /**
+     * Create and return a new bookshelf.
+     */
+    public function newShelf(array $input = ['name' => 'test shelf', 'description' => 'My new test shelf']): Bookshelf
+    {
+        $shelf = app(BookshelfRepo::class)->create($input, []);
+        $this->addToCache($shelf);
+        return $shelf;
+    }
+
+    /**
+     * Create and return a new book.
+     */
+    public function newBook(array $input = ['name' => 'test book', 'description' => 'My new test book']): Book
+    {
+        $book = app(BookRepo::class)->create($input);
+        $this->addToCache($book);
+        return $book;
+    }
+
+    /**
+     * Create and return a new test chapter.
+     */
+    public function newChapter(array $input, Book $book): Chapter
+    {
+        $chapter = app(ChapterRepo::class)->create($input, $book);
+        $this->addToCache($chapter);
+        return $chapter;
+    }
+
+    /**
+     * Create and return a new test page.
+     */
+    public function newPage(array $input = ['name' => 'test page', 'html' => 'My new test page']): Page
+    {
+        $book = Book::query()->first();
+        $pageRepo = app(PageRepo::class);
+        $draftPage = $pageRepo->getNewDraftPage($book);
+        $this->addToCache($draftPage);
+        return $pageRepo->publishDraft($draftPage, $input);
+    }
+
+    /**
+     * Regenerate the permission for an entity.
+     * Centralised to manage clearing of cached elements between requests.
+     */
+    public function regenPermissions(Entity $entity): void
+    {
+        $entity->rebuildPermissions();
+        $entity->load('jointPermissions');
+    }
+
+    /**
+     * Set the given entity as having restricted permissions, and apply the given
+     * permissions for the given roles.
+     * @param string[] $actions
+     * @param Role[] $roles
+     */
+    public function setPermissions(Entity $entity, array $actions = [], array $roles = []): void
+    {
+        $entity->restricted = true;
+        $entity->permissions()->delete();
+
+        $permissions = [];
+        foreach ($actions as $action) {
+            foreach ($roles as $role) {
+                $permissions[] = [
+                    'role_id' => $role->id,
+                    'action'  => strtolower($action),
+                ];
+            }
+        }
+
+        $entity->permissions()->createMany($permissions);
+        $entity->save();
+        $entity->load('permissions');
+        $this->regenPermissions($entity);
+    }
+
+    /**
+     * @param Entity|Entity[] $entities
+     */
+    protected function addToCache($entities): void
+    {
+        if (!is_array($entities)) {
+            $entities = [$entities];
+        }
+
+        foreach ($entities as $entity) {
+            $this->fetchCache[$entity->getType()][] = $entity->id;
+        }
+    }
+}

--- a/tests/Helpers/EntityProvider.php
+++ b/tests/Helpers/EntityProvider.php
@@ -141,7 +141,7 @@ class EntityProvider
      */
     public function newPage(array $input = ['name' => 'test page', 'html' => 'My new test page']): Page
     {
-        $book = Book::query()->first();
+        $book = $this->book();
         $pageRepo = app(PageRepo::class);
         $draftPage = $pageRepo->getNewDraftPage($book);
         $this->addToCache($draftPage);

--- a/tests/Helpers/TestServiceProvider.php
+++ b/tests/Helpers/TestServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Tests\Helpers;
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\ParallelTesting;

--- a/tests/HomepageTest.php
+++ b/tests/HomepageTest.php
@@ -4,8 +4,6 @@ namespace Tests;
 
 use BookStack\Auth\Role;
 use BookStack\Auth\User;
-use BookStack\Entities\Models\Bookshelf;
-use BookStack\Entities\Models\Page;
 
 class HomepageTest extends TestCase
 {
@@ -99,8 +97,7 @@ class HomepageTest extends TestCase
     public function test_custom_homepage_renders_includes()
     {
         $this->asEditor();
-        /** @var Page $included */
-        $included = Page::query()->first();
+        $included = $this->entities->page();
         $content = str_repeat('This is the body content of my custom homepage.', 20);
         $included->html = $content;
         $included->save();
@@ -138,7 +135,7 @@ class HomepageTest extends TestCase
     {
         $editor = $this->getEditor();
         setting()->putUser($editor, 'bookshelves_view_type', 'grid');
-        $shelf = Bookshelf::query()->firstOrFail();
+        $shelf = $this->entities->shelf();
 
         $this->setSettings(['app-homepage-type' => 'bookshelves']);
 

--- a/tests/HomepageTest.php
+++ b/tests/HomepageTest.php
@@ -24,7 +24,7 @@ class HomepageTest extends TestCase
         $this->asEditor();
         $name = 'My custom homepage';
         $content = str_repeat('This is the body content of my custom homepage.', 20);
-        $customPage = $this->newPage(['name' => $name, 'html' => $content]);
+        $customPage = $this->entities->newPage(['name' => $name, 'html' => $content]);
         $this->setSettings(['app-homepage' => $customPage->id]);
         $this->setSettings(['app-homepage-type' => 'page']);
 
@@ -41,7 +41,7 @@ class HomepageTest extends TestCase
         $this->asEditor();
         $name = 'My custom homepage';
         $content = str_repeat('This is the body content of my custom homepage.', 20);
-        $customPage = $this->newPage(['name' => $name, 'html' => $content]);
+        $customPage = $this->entities->newPage(['name' => $name, 'html' => $content]);
         $this->setSettings([
             'app-homepage'      => $customPage->id,
             'app-homepage-type' => 'page',
@@ -67,7 +67,7 @@ class HomepageTest extends TestCase
         $this->asEditor();
         $name = 'My custom homepage';
         $content = str_repeat('This is the body content of my custom homepage.', 20);
-        $customPage = $this->newPage(['name' => $name, 'html' => $content]);
+        $customPage = $this->entities->newPage(['name' => $name, 'html' => $content]);
         $this->setSettings([
             'app-homepage'      => $customPage->id,
             'app-homepage-type' => 'default',
@@ -107,7 +107,7 @@ class HomepageTest extends TestCase
         $included->save();
 
         $name = 'My custom homepage';
-        $customPage = $this->newPage(['name' => $name, 'html' => '{{@' . $included->id . '}}']);
+        $customPage = $this->entities->newPage(['name' => $name, 'html' => '{{@' . $included->id . '}}']);
         $this->setSettings(['app-homepage' => $customPage->id]);
         $this->setSettings(['app-homepage-type' => 'page']);
 
@@ -177,7 +177,7 @@ class HomepageTest extends TestCase
         $this->withHtml($homeVisit)->assertElementNotContains('.content-wrap', $book->name);
 
         // Ensure is visible again with entity-level view permission
-        $this->setEntityRestrictions($book, ['view'], [$editor->roles()->first()]);
+        $this->entities->setPermissions($book, ['view'], [$editor->roles()->first()]);
         $homeVisit = $this->get('/');
         $this->withHtml($homeVisit)->assertElementContains('.content-wrap', $shelf->name);
         $this->withHtml($homeVisit)->assertElementContains('.content-wrap', $book->name);

--- a/tests/HomepageTest.php
+++ b/tests/HomepageTest.php
@@ -81,8 +81,7 @@ class HomepageTest extends TestCase
 
     public function test_custom_homepage_cannot_be_deleted_from_parent_deletion()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->setSettings([
             'app-homepage'      => $page->id,
             'app-homepage-type' => 'page',
@@ -161,7 +160,7 @@ class HomepageTest extends TestCase
         $this->setSettings(['app-homepage-type' => 'bookshelves']);
         $this->asEditor();
 
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
         $book = $shelf->books()->first();
 
         // Ensure initially visible

--- a/tests/OpenGraphTest.php
+++ b/tests/OpenGraphTest.php
@@ -2,10 +2,6 @@
 
 namespace Tests;
 
-use BookStack\Entities\Models\Book;
-use BookStack\Entities\Models\Bookshelf;
-use BookStack\Entities\Models\Chapter;
-use BookStack\Entities\Models\Page;
 use BookStack\Entities\Repos\BaseRepo;
 use BookStack\Entities\Repos\BookRepo;
 use Illuminate\Support\Str;

--- a/tests/OpenGraphTest.php
+++ b/tests/OpenGraphTest.php
@@ -18,7 +18,7 @@ class OpenGraphTest extends TestCase
 
     public function test_page_tags()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $resp = $this->asEditor()->get($page->getUrl());
         $tags = $this->getOpenGraphTags($resp);
 
@@ -29,7 +29,7 @@ class OpenGraphTest extends TestCase
 
     public function test_chapter_tags()
     {
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $resp = $this->asEditor()->get($chapter->getUrl());
         $tags = $this->getOpenGraphTags($resp);
 
@@ -40,7 +40,7 @@ class OpenGraphTest extends TestCase
 
     public function test_book_tags()
     {
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $resp = $this->asEditor()->get($book->getUrl());
         $tags = $this->getOpenGraphTags($resp);
 
@@ -60,7 +60,7 @@ class OpenGraphTest extends TestCase
 
     public function test_shelf_tags()
     {
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
         $resp = $this->asEditor()->get($shelf->getUrl());
         $tags = $this->getOpenGraphTags($resp);
 

--- a/tests/Permissions/EntityOwnerChangeTest.php
+++ b/tests/Permissions/EntityOwnerChangeTest.php
@@ -13,7 +13,7 @@ class EntityOwnerChangeTest extends TestCase
 {
     public function test_changing_page_owner()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $user = User::query()->where('id', '!=', $page->owned_by)->first();
 
         $this->asAdmin()->put($page->getUrl('permissions'), ['owned_by' => $user->id]);
@@ -22,7 +22,7 @@ class EntityOwnerChangeTest extends TestCase
 
     public function test_changing_chapter_owner()
     {
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $user = User::query()->where('id', '!=', $chapter->owned_by)->first();
 
         $this->asAdmin()->put($chapter->getUrl('permissions'), ['owned_by' => $user->id]);
@@ -31,7 +31,7 @@ class EntityOwnerChangeTest extends TestCase
 
     public function test_changing_book_owner()
     {
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $user = User::query()->where('id', '!=', $book->owned_by)->first();
 
         $this->asAdmin()->put($book->getUrl('permissions'), ['owned_by' => $user->id]);
@@ -40,7 +40,7 @@ class EntityOwnerChangeTest extends TestCase
 
     public function test_changing_shelf_owner()
     {
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
         $user = User::query()->where('id', '!=', $shelf->owned_by)->first();
 
         $this->asAdmin()->put($shelf->getUrl('permissions'), ['owned_by' => $user->id]);

--- a/tests/Permissions/EntityOwnerChangeTest.php
+++ b/tests/Permissions/EntityOwnerChangeTest.php
@@ -3,10 +3,6 @@
 namespace Tests\Permissions;
 
 use BookStack\Auth\User;
-use BookStack\Entities\Models\Book;
-use BookStack\Entities\Models\Bookshelf;
-use BookStack\Entities\Models\Chapter;
-use BookStack\Entities\Models\Page;
 use Tests\TestCase;
 
 class EntityOwnerChangeTest extends TestCase

--- a/tests/Permissions/EntityPermissionsTest.php
+++ b/tests/Permissions/EntityPermissionsTest.php
@@ -13,15 +13,8 @@ use Tests\TestCase;
 
 class EntityPermissionsTest extends TestCase
 {
-    /**
-     * @var User
-     */
-    protected $user;
-
-    /**
-     * @var User
-     */
-    protected $viewer;
+    protected User $user;
+    protected User $viewer;
 
     protected function setUp(): void
     {

--- a/tests/Permissions/EntityPermissionsTest.php
+++ b/tests/Permissions/EntityPermissionsTest.php
@@ -41,8 +41,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_bookshelf_view_restriction()
     {
-        /** @var Bookshelf $shelf */
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
 
         $this->actingAs($this->user)
             ->get($shelf->getUrl())
@@ -61,8 +60,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_bookshelf_update_restriction()
     {
-        /** @var Bookshelf $shelf */
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
 
         $this->actingAs($this->user)
             ->get($shelf->getUrl('/edit'))
@@ -82,8 +80,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_bookshelf_delete_restriction()
     {
-        /** @var Bookshelf $shelf */
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
 
         $this->actingAs($this->user)
             ->get($shelf->getUrl('/delete'))
@@ -103,8 +100,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_book_view_restriction()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $bookPage = $book->pages->first();
         $bookChapter = $book->chapters->first();
 
@@ -134,8 +130,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_book_create_restriction()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
 
         $bookUrl = $book->getUrl();
         $resp = $this->actingAs($this->viewer)->get($bookUrl);
@@ -181,8 +176,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_book_update_restriction()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $bookPage = $book->pages->first();
         $bookChapter = $book->chapters->first();
 
@@ -209,8 +203,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_book_delete_restriction()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $bookPage = $book->pages->first();
         $bookChapter = $book->chapters->first();
 
@@ -236,8 +229,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_chapter_view_restriction()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $chapterPage = $chapter->pages->first();
 
         $chapterUrl = $chapter->getUrl();
@@ -256,8 +248,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_chapter_create_restriction()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
 
         $chapterUrl = $chapter->getUrl();
         $resp = $this->actingAs($this->user)->get($chapterUrl);
@@ -285,8 +276,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_chapter_update_restriction()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $chapterPage = $chapter->pages->first();
 
         $chapterUrl = $chapter->getUrl();
@@ -308,8 +298,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_chapter_delete_restriction()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $chapterPage = $chapter->pages->first();
 
         $chapterUrl = $chapter->getUrl();
@@ -332,8 +321,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_page_view_restriction()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $pageUrl = $page->getUrl();
         $this->actingAs($this->user)->get($pageUrl)->assertOk();
@@ -349,8 +337,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_page_update_restriction()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $pageUrl = $page->getUrl();
         $resp = $this->actingAs($this->user)
@@ -371,8 +358,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_page_delete_restriction()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $pageUrl = $page->getUrl();
         $this->actingAs($this->user)
@@ -436,8 +422,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_restricted_pages_not_visible_in_book_navigation_on_pages()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $page = $chapter->pages->first();
         $page2 = $chapter->pages[2];
 
@@ -449,8 +434,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_restricted_pages_not_visible_in_book_navigation_on_chapters()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $page = $chapter->pages->first();
 
         $this->setRestrictionsForTestRoles($page, []);
@@ -461,8 +445,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_restricted_pages_not_visible_on_chapter_pages()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $page = $chapter->pages->first();
 
         $this->setRestrictionsForTestRoles($page, []);
@@ -474,8 +457,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_restricted_chapter_pages_not_visible_on_book_page()
     {
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $this->actingAs($this->user)
             ->get($chapter->book->getUrl())
             ->assertSee($chapter->pages->first()->name);
@@ -491,8 +473,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_bookshelf_update_restriction_override()
     {
-        /** @var Bookshelf $shelf */
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
 
         $this->actingAs($this->viewer)
             ->get($shelf->getUrl('/edit'))
@@ -510,8 +491,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_bookshelf_delete_restriction_override()
     {
-        /** @var Bookshelf $shelf */
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
 
         $this->actingAs($this->viewer)
             ->get($shelf->getUrl('/delete'))
@@ -529,8 +509,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_book_create_restriction_override()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
 
         $bookUrl = $book->getUrl();
         $resp = $this->actingAs($this->viewer)->get($bookUrl);
@@ -571,8 +550,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_book_update_restriction_override()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $bookPage = $book->pages->first();
         $bookChapter = $book->chapters->first();
 
@@ -598,8 +576,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_book_delete_restriction_override()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $bookPage = $book->pages->first();
         $bookChapter = $book->chapters->first();
 
@@ -626,8 +603,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_page_visible_if_has_permissions_when_book_not_visible()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $bookChapter = $book->chapters->first();
         $bookPage = $bookChapter->pages->first();
 
@@ -667,8 +643,7 @@ class EntityPermissionsTest extends TestCase
 
     public function test_can_create_page_if_chapter_has_permissions_when_book_not_visible()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $this->setRestrictionsForTestRoles($book, []);
         $bookChapter = $book->chapters->first();
         $this->setRestrictionsForTestRoles($bookChapter, ['view']);

--- a/tests/Permissions/EntityPermissionsTest.php
+++ b/tests/Permissions/EntityPermissionsTest.php
@@ -36,7 +36,7 @@ class EntityPermissionsTest extends TestCase
             $this->user->roles->first(),
             $this->viewer->roles->first(),
         ];
-        $this->setEntityRestrictions($entity, $actions, $roles);
+        $this->entities->setPermissions($entity, $actions, $roles);
     }
 
     public function test_bookshelf_view_restriction()

--- a/tests/Permissions/ExportPermissionsTest.php
+++ b/tests/Permissions/ExportPermissionsTest.php
@@ -11,7 +11,7 @@ class ExportPermissionsTest extends TestCase
 {
     public function test_page_content_without_view_access_hidden_on_chapter_export()
     {
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $page = $chapter->pages()->firstOrFail();
         $pageContent = Str::random(48);
         $page->html = '<p>' . $pageContent . '</p>';
@@ -39,7 +39,7 @@ class ExportPermissionsTest extends TestCase
 
     public function test_page_content_without_view_access_hidden_on_book_export()
     {
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $page = $book->pages()->firstOrFail();
         $pageContent = Str::random(48);
         $page->html = '<p>' . $pageContent . '</p>';

--- a/tests/Permissions/ExportPermissionsTest.php
+++ b/tests/Permissions/ExportPermissionsTest.php
@@ -27,7 +27,7 @@ class ExportPermissionsTest extends TestCase
             $resp->assertSee($pageContent);
         }
 
-        $this->setEntityRestrictions($page, []);
+        $this->entities->setPermissions($page, []);
 
         foreach ($formats as $format) {
             $resp = $this->get($chapter->getUrl("export/{$format}"));
@@ -55,7 +55,7 @@ class ExportPermissionsTest extends TestCase
             $resp->assertSee($pageContent);
         }
 
-        $this->setEntityRestrictions($page, []);
+        $this->entities->setPermissions($page, []);
 
         foreach ($formats as $format) {
             $resp = $this->get($book->getUrl("export/{$format}"));

--- a/tests/Permissions/ExportPermissionsTest.php
+++ b/tests/Permissions/ExportPermissionsTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\Permissions;
 
-use BookStack\Entities\Models\Book;
-use BookStack\Entities\Models\Chapter;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 

--- a/tests/Permissions/RolesTest.php
+++ b/tests/Permissions/RolesTest.php
@@ -520,8 +520,7 @@ class RolesTest extends TestCase
 
     public function test_chapter_create_all_permissions()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $this->checkAccessPermission('chapter-create-all', [
             $book->getUrl('/create-chapter'),
         ], [
@@ -603,10 +602,8 @@ class RolesTest extends TestCase
 
     public function test_page_create_own_permissions()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $book = $this->entities->book();
+        $chapter = $this->entities->chapter();
 
         $entities = $this->entities->createChainBelongingToUser($this->user);
         $ownBook = $entities['book'];
@@ -652,10 +649,8 @@ class RolesTest extends TestCase
 
     public function test_page_create_all_permissions()
     {
-        /** @var Book $book */
-        $book = Book::query()->first();
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $book = $this->entities->book();
+        $chapter = $this->entities->chapter();
         $createUrl = $book->getUrl('/create-page');
 
         $createUrlChapter = $chapter->getUrl('/create-page');
@@ -806,8 +801,7 @@ class RolesTest extends TestCase
     public function test_image_delete_own_permission()
     {
         $this->giveUserPermissions($this->user, ['image-update-all']);
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $image = Image::factory()->create([
             'uploaded_to' => $page->id,
             'created_by'  => $this->user->id,
@@ -826,8 +820,7 @@ class RolesTest extends TestCase
     {
         $this->giveUserPermissions($this->user, ['image-update-all']);
         $admin = $this->getAdmin();
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $image = Image::factory()->create(['uploaded_to' => $page->id, 'created_by' => $admin->id, 'updated_by' => $admin->id]);
 
         $this->actingAs($this->user)->json('delete', '/images/' . $image->id)->assertStatus(403);
@@ -845,8 +838,7 @@ class RolesTest extends TestCase
     public function test_role_permission_removal()
     {
         // To cover issue fixed in f99c8ff99aee9beb8c692f36d4b84dc6e651e50a.
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $viewerRole = Role::getRole('viewer');
         $viewer = $this->getViewer();
         $this->actingAs($viewer)->get($page->getUrl())->assertOk();

--- a/tests/Permissions/RolesTest.php
+++ b/tests/Permissions/RolesTest.php
@@ -285,7 +285,7 @@ class RolesTest extends TestCase
     {
         /** @var Page $otherUsersPage */
         $otherUsersPage = Page::query()->first();
-        $content = $this->createEntityChainBelongingToUser($this->user);
+        $content = $this->entities->createChainBelongingToUser($this->user);
 
         // Set a different creator on the page we're checking to ensure
         // that the owner fields are checked
@@ -355,9 +355,9 @@ class RolesTest extends TestCase
     {
         /** @var Bookshelf $otherShelf */
         $otherShelf = Bookshelf::query()->first();
-        $ownShelf = $this->newShelf(['name' => 'test-shelf', 'slug' => 'test-shelf']);
+        $ownShelf = $this->entities->newShelf(['name' => 'test-shelf', 'slug' => 'test-shelf']);
         $ownShelf->forceFill(['owned_by' => $this->user->id, 'updated_by' => $this->user->id])->save();
-        $this->regenEntityPermissions($ownShelf);
+        $this->entities->regenPermissions($ownShelf);
 
         $this->checkAccessPermission('bookshelf-update-own', [
             $ownShelf->getUrl('/edit'),
@@ -386,9 +386,9 @@ class RolesTest extends TestCase
         $this->giveUserPermissions($this->user, ['bookshelf-update-all']);
         /** @var Bookshelf $otherShelf */
         $otherShelf = Bookshelf::query()->first();
-        $ownShelf = $this->newShelf(['name' => 'test-shelf', 'slug' => 'test-shelf']);
+        $ownShelf = $this->entities->newShelf(['name' => 'test-shelf', 'slug' => 'test-shelf']);
         $ownShelf->forceFill(['owned_by' => $this->user->id, 'updated_by' => $this->user->id])->save();
-        $this->regenEntityPermissions($ownShelf);
+        $this->entities->regenPermissions($ownShelf);
 
         $this->checkAccessPermission('bookshelf-delete-own', [
             $ownShelf->getUrl('/delete'),
@@ -438,7 +438,7 @@ class RolesTest extends TestCase
     {
         /** @var Book $otherBook */
         $otherBook = Book::query()->take(1)->get()->first();
-        $ownBook = $this->createEntityChainBelongingToUser($this->user)['book'];
+        $ownBook = $this->entities->createChainBelongingToUser($this->user)['book'];
         $this->checkAccessPermission('book-update-own', [
             $ownBook->getUrl() . '/edit',
         ], [
@@ -466,7 +466,7 @@ class RolesTest extends TestCase
         $this->giveUserPermissions($this->user, ['book-update-all']);
         /** @var Book $otherBook */
         $otherBook = Book::query()->take(1)->get()->first();
-        $ownBook = $this->createEntityChainBelongingToUser($this->user)['book'];
+        $ownBook = $this->entities->createChainBelongingToUser($this->user)['book'];
         $this->checkAccessPermission('book-delete-own', [
             $ownBook->getUrl() . '/delete',
         ], [
@@ -501,7 +501,7 @@ class RolesTest extends TestCase
     {
         /** @var Book $book */
         $book = Book::query()->take(1)->get()->first();
-        $ownBook = $this->createEntityChainBelongingToUser($this->user)['book'];
+        $ownBook = $this->entities->createChainBelongingToUser($this->user)['book'];
         $this->checkAccessPermission('chapter-create-own', [
             $ownBook->getUrl('/create-chapter'),
         ], [
@@ -538,7 +538,7 @@ class RolesTest extends TestCase
     {
         /** @var Chapter $otherChapter */
         $otherChapter = Chapter::query()->first();
-        $ownChapter = $this->createEntityChainBelongingToUser($this->user)['chapter'];
+        $ownChapter = $this->entities->createChainBelongingToUser($this->user)['chapter'];
         $this->checkAccessPermission('chapter-update-own', [
             $ownChapter->getUrl() . '/edit',
         ], [
@@ -566,7 +566,7 @@ class RolesTest extends TestCase
         $this->giveUserPermissions($this->user, ['chapter-update-all']);
         /** @var Chapter $otherChapter */
         $otherChapter = Chapter::query()->first();
-        $ownChapter = $this->createEntityChainBelongingToUser($this->user)['chapter'];
+        $ownChapter = $this->entities->createChainBelongingToUser($this->user)['chapter'];
         $this->checkAccessPermission('chapter-delete-own', [
             $ownChapter->getUrl() . '/delete',
         ], [
@@ -608,7 +608,7 @@ class RolesTest extends TestCase
         /** @var Chapter $chapter */
         $chapter = Chapter::query()->first();
 
-        $entities = $this->createEntityChainBelongingToUser($this->user);
+        $entities = $this->entities->createChainBelongingToUser($this->user);
         $ownBook = $entities['book'];
         $ownChapter = $entities['chapter'];
 
@@ -699,7 +699,7 @@ class RolesTest extends TestCase
     {
         /** @var Page $otherPage */
         $otherPage = Page::query()->first();
-        $ownPage = $this->createEntityChainBelongingToUser($this->user)['page'];
+        $ownPage = $this->entities->createChainBelongingToUser($this->user)['page'];
         $this->checkAccessPermission('page-update-own', [
             $ownPage->getUrl() . '/edit',
         ], [
@@ -727,7 +727,7 @@ class RolesTest extends TestCase
         $this->giveUserPermissions($this->user, ['page-update-all']);
         /** @var Page $otherPage */
         $otherPage = Page::query()->first();
-        $ownPage = $this->createEntityChainBelongingToUser($this->user)['page'];
+        $ownPage = $this->entities->createChainBelongingToUser($this->user)['page'];
         $this->checkAccessPermission('page-delete-own', [
             $ownPage->getUrl() . '/delete',
         ], [
@@ -865,14 +865,14 @@ class RolesTest extends TestCase
         $admin = $this->getAdmin();
         // Book links
         $book = Book::factory()->create(['created_by' => $admin->id, 'updated_by' => $admin->id]);
-        $this->regenEntityPermissions($book);
+        $this->entities->regenPermissions($book);
         $this->actingAs($this->getViewer())->get($book->getUrl())
             ->assertDontSee('Create a new page')
             ->assertDontSee('Add a chapter');
 
         // Chapter links
         $chapter = Chapter::factory()->create(['created_by' => $admin->id, 'updated_by' => $admin->id, 'book_id' => $book->id]);
-        $this->regenEntityPermissions($chapter);
+        $this->entities->regenPermissions($chapter);
         $this->actingAs($this->getViewer())->get($chapter->getUrl())
             ->assertDontSee('Create a new page')
             ->assertDontSee('Sort the current book');
@@ -880,7 +880,7 @@ class RolesTest extends TestCase
 
     public function test_comment_create_permission()
     {
-        $ownPage = $this->createEntityChainBelongingToUser($this->user)['page'];
+        $ownPage = $this->entities->createChainBelongingToUser($this->user)['page'];
 
         $this->actingAs($this->user)
             ->addComment($ownPage)
@@ -895,7 +895,7 @@ class RolesTest extends TestCase
 
     public function test_comment_update_own_permission()
     {
-        $ownPage = $this->createEntityChainBelongingToUser($this->user)['page'];
+        $ownPage = $this->entities->createChainBelongingToUser($this->user)['page'];
         $this->giveUserPermissions($this->user, ['comment-create-all']);
         $this->actingAs($this->user)->addComment($ownPage);
         /** @var Comment $comment */
@@ -913,7 +913,7 @@ class RolesTest extends TestCase
     public function test_comment_update_all_permission()
     {
         /** @var Page $ownPage */
-        $ownPage = $this->createEntityChainBelongingToUser($this->user)['page'];
+        $ownPage = $this->entities->createChainBelongingToUser($this->user)['page'];
         $this->asAdmin()->addComment($ownPage);
         /** @var Comment $comment */
         $comment = $ownPage->comments()->latest()->first();
@@ -930,7 +930,7 @@ class RolesTest extends TestCase
     public function test_comment_delete_own_permission()
     {
         /** @var Page $ownPage */
-        $ownPage = $this->createEntityChainBelongingToUser($this->user)['page'];
+        $ownPage = $this->entities->createChainBelongingToUser($this->user)['page'];
         $this->giveUserPermissions($this->user, ['comment-create-all']);
         $this->actingAs($this->user)->addComment($ownPage);
 
@@ -949,7 +949,7 @@ class RolesTest extends TestCase
     public function test_comment_delete_all_permission()
     {
         /** @var Page $ownPage */
-        $ownPage = $this->createEntityChainBelongingToUser($this->user)['page'];
+        $ownPage = $this->entities->createChainBelongingToUser($this->user)['page'];
         $this->asAdmin()->addComment($ownPage);
         /** @var Comment $comment */
         $comment = $ownPage->comments()->latest()->first();

--- a/tests/Permissions/RolesTest.php
+++ b/tests/Permissions/RolesTest.php
@@ -17,7 +17,7 @@ use Tests\TestCase;
 
 class RolesTest extends TestCase
 {
-    protected $user;
+    protected User $user;
 
     protected function setUp(): void
     {

--- a/tests/PublicActionTest.php
+++ b/tests/PublicActionTest.php
@@ -17,11 +17,11 @@ class PublicActionTest extends TestCase
     public function test_app_not_public()
     {
         $this->setSettings(['app-public' => 'false']);
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $this->get('/books')->assertRedirect('/login');
         $this->get($book->getUrl())->assertRedirect('/login');
 
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->get($page->getUrl())->assertRedirect('/login');
     }
 
@@ -93,8 +93,7 @@ class PublicActionTest extends TestCase
         $this->app->make(JointPermissionBuilder::class)->rebuildForRole($publicRole);
         user()->clearPermissionCache();
 
-        /** @var Chapter $chapter */
-        $chapter = Chapter::query()->first();
+        $chapter = $this->entities->chapter();
         $resp = $this->get($chapter->getUrl());
         $resp->assertSee('New Page');
         $this->withHtml($resp)->assertElementExists('a[href="' . $chapter->getUrl('/create-page') . '"]');
@@ -118,7 +117,7 @@ class PublicActionTest extends TestCase
 
     public function test_content_not_listed_on_404_for_public_users()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $page->fill(['name' => 'my testing random unique page name'])->save();
         $this->asAdmin()->get($page->getUrl()); // Fake visit to show on recents
         $resp = $this->get('/cats/dogs/hippos');
@@ -162,8 +161,7 @@ class PublicActionTest extends TestCase
     public function test_public_view_then_login_redirects_to_previous_content()
     {
         $this->setSettings(['app-public' => 'true']);
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $resp = $this->get($book->getUrl());
         $resp->assertSee($book->name);
 
@@ -175,8 +173,7 @@ class PublicActionTest extends TestCase
     public function test_access_hidden_content_then_login_redirects_to_intended_content()
     {
         $this->setSettings(['app-public' => 'true']);
-        /** @var Book $book */
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $this->entities->setPermissions($book);
 
         $resp = $this->get($book->getUrl());

--- a/tests/PublicActionTest.php
+++ b/tests/PublicActionTest.php
@@ -177,7 +177,7 @@ class PublicActionTest extends TestCase
         $this->setSettings(['app-public' => 'true']);
         /** @var Book $book */
         $book = Book::query()->first();
-        $this->setEntityRestrictions($book);
+        $this->entities->setPermissions($book);
 
         $resp = $this->get($book->getUrl());
         $resp->assertSee('Book not found');

--- a/tests/PublicActionTest.php
+++ b/tests/PublicActionTest.php
@@ -8,7 +8,6 @@ use BookStack\Auth\Role;
 use BookStack\Auth\User;
 use BookStack\Entities\Models\Book;
 use BookStack\Entities\Models\Chapter;
-use BookStack\Entities\Models\Page;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\View;
 

--- a/tests/References/CrossLinkParserTest.php
+++ b/tests/References/CrossLinkParserTest.php
@@ -10,7 +10,7 @@ class CrossLinkParserTest extends TestCase
 {
     public function test_instance_with_entity_resolvers_matches_entity_links()
     {
-        $entities = $this->getEachEntityType();
+        $entities = $this->entities->all();
         $otherPage = Page::query()->where('id', '!=', $entities['page']->id)->first();
 
         $html = '

--- a/tests/References/CrossLinkParserTest.php
+++ b/tests/References/CrossLinkParserTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\References;
 
-use BookStack\Entities\Models\Page;
 use BookStack\References\CrossLinkParser;
 use Tests\TestCase;
 
@@ -11,7 +10,7 @@ class CrossLinkParserTest extends TestCase
     public function test_instance_with_entity_resolvers_matches_entity_links()
     {
         $entities = $this->entities->all();
-        $otherPage = Page::query()->where('id', '!=', $entities['page']->id)->first();
+        $otherPage = $this->entities->page();
 
         $html = '
 <a href="' . url('/link/' . $otherPage->id) . '#cat">Page Permalink</a>

--- a/tests/References/CrossLinkParserTest.php
+++ b/tests/References/CrossLinkParserTest.php
@@ -40,7 +40,7 @@ class CrossLinkParserTest extends TestCase
 
     public function test_similar_page_and_book_reference_links_dont_conflict()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $book = $page->book;
 
         $html = '

--- a/tests/References/ReferencesTest.php
+++ b/tests/References/ReferencesTest.php
@@ -57,7 +57,7 @@ class ReferencesTest extends TestCase
 
     public function test_references_to_count_visible_on_entity_show_view()
     {
-        $entities = $this->getEachEntityType();
+        $entities = $this->entities->all();
         /** @var Page $otherPage */
         $otherPage = Page::query()->where('id', '!=', $entities['page']->id)->first();
 
@@ -79,7 +79,7 @@ class ReferencesTest extends TestCase
 
     public function test_references_to_visible_on_references_page()
     {
-        $entities = $this->getEachEntityType();
+        $entities = $this->entities->all();
         $this->asEditor();
         foreach ($entities as $entity) {
             $this->createReference($entities['page'], $entity);
@@ -101,7 +101,7 @@ class ReferencesTest extends TestCase
         $pageB = Page::query()->where('id', '!=', $page->id)->first();
         $this->createReference($pageB, $page);
 
-        $this->setEntityRestrictions($pageB);
+        $this->entities->setPermissions($pageB);
 
         $this->asEditor()->get($page->getUrl('/references'))->assertDontSee($pageB->name);
         $this->asAdmin()->get($page->getUrl('/references'))->assertSee($pageB->name);

--- a/tests/References/ReferencesTest.php
+++ b/tests/References/ReferencesTest.php
@@ -97,7 +97,7 @@ class ReferencesTest extends TestCase
     {
         /** @var Page $page */
         /** @var Page $pageB */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $pageB = Page::query()->where('id', '!=', $page->id)->first();
         $this->createReference($pageB, $page);
 
@@ -109,8 +109,7 @@ class ReferencesTest extends TestCase
 
     public function test_reference_page_shows_empty_state_with_no_references()
     {
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->asEditor()
             ->get($page->getUrl('/references'))
@@ -124,7 +123,7 @@ class ReferencesTest extends TestCase
         /** @var Book $book */
         $pageA = Page::query()->first();
         $pageB = Page::query()->where('id', '!=', $pageA->id)->first();
-        $book = Book::query()->first();
+        $book = $this->entities->book();
 
         foreach ([$pageA, $pageB] as $page) {
             $page->html = '<a href="' . $book->getUrl() . '">Link</a>';
@@ -200,8 +199,8 @@ class ReferencesTest extends TestCase
     {
         /** @var Page $page */
         /** @var Book $book */
-        $page = Page::query()->first();
-        $book = Book::query()->first();
+        $page = $this->entities->page();
+        $book = $this->entities->book();
 
         $bookUrl = $book->getUrl();
         $markdown = '

--- a/tests/References/ReferencesTest.php
+++ b/tests/References/ReferencesTest.php
@@ -2,9 +2,6 @@
 
 namespace Tests\References;
 
-use BookStack\Entities\Models\Book;
-use BookStack\Entities\Models\Chapter;
-use BookStack\Entities\Models\Page;
 use BookStack\Entities\Repos\PageRepo;
 use BookStack\Entities\Tools\TrashCan;
 use BookStack\Model;
@@ -15,10 +12,8 @@ class ReferencesTest extends TestCase
 {
     public function test_references_created_on_page_update()
     {
-        /** @var Page $pageA */
-        /** @var Page $pageB */
-        $pageA = Page::query()->first();
-        $pageB = Page::query()->where('id', '!=', $pageA->id)->first();
+        $pageA = $this->entities->page();
+        $pageB = $this->entities->page();
 
         $this->assertDatabaseMissing('references', ['from_id' => $pageA->id, 'from_type' => $pageA->getMorphClass()]);
 
@@ -37,10 +32,8 @@ class ReferencesTest extends TestCase
 
     public function test_references_deleted_on_entity_delete()
     {
-        /** @var Page $pageA */
-        /** @var Page $pageB */
-        $pageA = Page::query()->first();
-        $pageB = Page::query()->where('id', '!=', $pageA->id)->first();
+        $pageA = $this->entities->page();
+        $pageB = $this->entities->page();
 
         $this->createReference($pageA, $pageB);
         $this->createReference($pageB, $pageA);
@@ -58,8 +51,7 @@ class ReferencesTest extends TestCase
     public function test_references_to_count_visible_on_entity_show_view()
     {
         $entities = $this->entities->all();
-        /** @var Page $otherPage */
-        $otherPage = Page::query()->where('id', '!=', $entities['page']->id)->first();
+        $otherPage = $this->entities->page();
 
         $this->asEditor();
         foreach ($entities as $entity) {
@@ -95,10 +87,8 @@ class ReferencesTest extends TestCase
 
     public function test_reference_not_visible_if_view_permission_does_not_permit()
     {
-        /** @var Page $page */
-        /** @var Page $pageB */
         $page = $this->entities->page();
-        $pageB = Page::query()->where('id', '!=', $page->id)->first();
+        $pageB = $this->entities->page();
         $this->createReference($pageB, $page);
 
         $this->entities->setPermissions($pageB);
@@ -118,11 +108,8 @@ class ReferencesTest extends TestCase
 
     public function test_pages_leading_to_entity_updated_on_url_change()
     {
-        /** @var Page $pageA */
-        /** @var Page $pageB */
-        /** @var Book $book */
-        $pageA = Page::query()->first();
-        $pageB = Page::query()->where('id', '!=', $pageA->id)->first();
+        $pageA = $this->entities->page();
+        $pageB = $this->entities->page();
         $book = $this->entities->book();
 
         foreach ([$pageA, $pageB] as $page) {
@@ -147,11 +134,8 @@ class ReferencesTest extends TestCase
 
     public function test_pages_linking_to_other_page_updated_on_parent_book_url_change()
     {
-        /** @var Page $bookPage */
-        /** @var Page $otherPage */
-        /** @var Book $book */
-        $bookPage = Page::query()->first();
-        $otherPage = Page::query()->where('id', '!=', $bookPage->id)->first();
+        $bookPage = $this->entities->page();
+        $otherPage = $this->entities->page();
         $book = $bookPage->book;
 
         $otherPage->html = '<a href="' . $bookPage->getUrl() . '">Link</a>';
@@ -172,11 +156,8 @@ class ReferencesTest extends TestCase
 
     public function test_pages_linking_to_chapter_updated_on_parent_book_url_change()
     {
-        /** @var Chapter $bookChapter */
-        /** @var Page $otherPage */
-        /** @var Book $book */
-        $bookChapter = Chapter::query()->first();
-        $otherPage = Page::query()->first();
+        $bookChapter = $this->entities->chapter();
+        $otherPage = $this->entities->page();
         $book = $bookChapter->book;
 
         $otherPage->html = '<a href="' . $bookChapter->getUrl() . '">Link</a>';
@@ -197,8 +178,6 @@ class ReferencesTest extends TestCase
 
     public function test_markdown_links_leading_to_entity_updated_on_url_change()
     {
-        /** @var Page $page */
-        /** @var Book $book */
         $page = $this->entities->page();
         $book = $this->entities->book();
 

--- a/tests/Settings/RecycleBinTest.php
+++ b/tests/Settings/RecycleBinTest.php
@@ -16,7 +16,7 @@ class RecycleBinTest extends TestCase
 {
     public function test_recycle_bin_routes_permissions()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $editor = $this->getEditor();
         $this->actingAs($editor)->delete($page->getUrl());
         $deletion = Deletion::query()->firstOrFail();
@@ -57,7 +57,7 @@ class RecycleBinTest extends TestCase
 
     public function test_recycle_bin_view()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $book = Book::query()->whereHas('pages')->whereHas('chapters')->withCount(['pages', 'chapters'])->first();
         $editor = $this->getEditor();
         $this->actingAs($editor)->delete($page->getUrl());
@@ -74,7 +74,7 @@ class RecycleBinTest extends TestCase
 
     public function test_recycle_bin_empty()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $book = Book::query()->where('id', '!=', $page->book_id)->whereHas('pages')->whereHas('chapters')->with(['pages', 'chapters'])->firstOrFail();
         $editor = $this->getEditor();
         $this->actingAs($editor)->delete($page->getUrl());

--- a/tests/Settings/RecycleBinTest.php
+++ b/tests/Settings/RecycleBinTest.php
@@ -3,10 +3,7 @@
 namespace Tests\Settings;
 
 use BookStack\Entities\Models\Book;
-use BookStack\Entities\Models\Bookshelf;
-use BookStack\Entities\Models\Chapter;
 use BookStack\Entities\Models\Deletion;
-use BookStack\Entities\Models\Entity;
 use BookStack\Entities\Models\Page;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -97,7 +94,7 @@ class RecycleBinTest extends TestCase
 
     public function test_entity_restore()
     {
-        $book = Book::query()->whereHas('pages')->whereHas('chapters')->with(['pages', 'chapters'])->firstOrFail();
+        $book = $this->entities->bookHasChaptersAndPages();
         $this->asEditor()->delete($book->getUrl());
         $deletion = Deletion::query()->firstOrFail();
 
@@ -118,7 +115,7 @@ class RecycleBinTest extends TestCase
 
     public function test_permanent_delete()
     {
-        $book = Book::query()->whereHas('pages')->whereHas('chapters')->with(['pages', 'chapters'])->firstOrFail();
+        $book = $this->entities->bookHasChaptersAndPages();
         $this->asEditor()->delete($book->getUrl());
         $deletion = Deletion::query()->firstOrFail();
 
@@ -137,9 +134,7 @@ class RecycleBinTest extends TestCase
 
     public function test_permanent_delete_for_each_type()
     {
-        /** @var Entity $entity */
-        foreach ([new Bookshelf(), new Book(), new Chapter(), new Page()] as $entity) {
-            $entity = $entity->newQuery()->first();
+        foreach ($this->entities->all() as $type => $entity) {
             $this->asEditor()->delete($entity->getUrl());
             $deletion = Deletion::query()->orderBy('id', 'desc')->firstOrFail();
 
@@ -152,7 +147,7 @@ class RecycleBinTest extends TestCase
 
     public function test_permanent_entity_delete_updates_existing_activity_with_entity_name()
     {
-        $page = Page::query()->firstOrFail();
+        $page = $this->entities->page();
         $this->asEditor()->delete($page->getUrl());
         $deletion = $page->deletions()->firstOrFail();
 
@@ -181,8 +176,8 @@ class RecycleBinTest extends TestCase
     public function test_auto_clear_functionality_works()
     {
         config()->set('app.recycle_bin_lifetime', 5);
-        $page = Page::query()->firstOrFail();
-        $otherPage = Page::query()->where('id', '!=', $page->id)->firstOrFail();
+        $page = $this->entities->page();
+        $otherPage = $this->entities->page();
 
         $this->asEditor()->delete($page->getUrl());
         $this->assertDatabaseHas('pages', ['id' => $page->id]);
@@ -198,8 +193,8 @@ class RecycleBinTest extends TestCase
     public function test_auto_clear_functionality_with_negative_time_keeps_forever()
     {
         config()->set('app.recycle_bin_lifetime', -1);
-        $page = Page::query()->firstOrFail();
-        $otherPage = Page::query()->where('id', '!=', $page->id)->firstOrFail();
+        $page = $this->entities->page();
+        $otherPage = $this->entities->page();
 
         $this->asEditor()->delete($page->getUrl());
         $this->assertEquals(1, Deletion::query()->count());
@@ -214,7 +209,7 @@ class RecycleBinTest extends TestCase
     public function test_auto_clear_functionality_with_zero_time_deletes_instantly()
     {
         config()->set('app.recycle_bin_lifetime', 0);
-        $page = Page::query()->firstOrFail();
+        $page = $this->entities->page();
 
         $this->asEditor()->delete($page->getUrl());
         $this->assertDatabaseMissing('pages', ['id' => $page->id]);
@@ -253,8 +248,7 @@ class RecycleBinTest extends TestCase
 
     public function test_restore_page_shows_link_to_parent_restore_if_parent_also_deleted()
     {
-        /** @var Book $book */
-        $book = Book::query()->whereHas('pages')->whereHas('chapters')->with(['pages', 'chapters'])->firstOrFail();
+        $book = $this->entities->bookHasChaptersAndPages();
         $chapter = $book->chapters->first();
         /** @var Page $page */
         $page = $chapter->pages->first();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,15 +7,7 @@ use BookStack\Auth\Permissions\PermissionsRepo;
 use BookStack\Auth\Permissions\RolePermission;
 use BookStack\Auth\Role;
 use BookStack\Auth\User;
-use BookStack\Entities\Models\Book;
-use BookStack\Entities\Models\Bookshelf;
-use BookStack\Entities\Models\Chapter;
 use BookStack\Entities\Models\Entity;
-use BookStack\Entities\Models\Page;
-use BookStack\Entities\Repos\BookRepo;
-use BookStack\Entities\Repos\BookshelfRepo;
-use BookStack\Entities\Repos\ChapterRepo;
-use BookStack\Entities\Repos\PageRepo;
 use BookStack\Settings\SettingService;
 use BookStack\Uploads\HttpFetcher;
 use GuzzleHttp\Client;
@@ -34,6 +26,7 @@ use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use Psr\Http\Client\ClientInterface;
 use Ssddanbrown\AssertHtml\TestsHtml;
+use Tests\Helpers\EntityProvider;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -43,6 +36,13 @@ abstract class TestCase extends BaseTestCase
 
     protected ?User $admin = null;
     protected ?User $editor = null;
+    protected EntityProvider $entities;
+
+    protected function setUp(): void
+    {
+        $this->entities = new EntityProvider();
+        parent::setUp();
+    }
 
     /**
      * The base URL to use while testing the application.
@@ -136,51 +136,6 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
-     * Regenerate the permission for an entity.
-     */
-    protected function regenEntityPermissions(Entity $entity): void
-    {
-        $entity->rebuildPermissions();
-        $entity->load('jointPermissions');
-    }
-
-    /**
-     * Create and return a new bookshelf.
-     */
-    public function newShelf(array $input = ['name' => 'test shelf', 'description' => 'My new test shelf']): Bookshelf
-    {
-        return app(BookshelfRepo::class)->create($input, []);
-    }
-
-    /**
-     * Create and return a new book.
-     */
-    public function newBook(array $input = ['name' => 'test book', 'description' => 'My new test book']): Book
-    {
-        return app(BookRepo::class)->create($input);
-    }
-
-    /**
-     * Create and return a new test chapter.
-     */
-    public function newChapter(array $input, Book $book): Chapter
-    {
-        return app(ChapterRepo::class)->create($input, $book);
-    }
-
-    /**
-     * Create and return a new test page.
-     */
-    public function newPage(array $input = ['name' => 'test page', 'html' => 'My new test page']): Page
-    {
-        $book = Book::query()->first();
-        $pageRepo = app(PageRepo::class);
-        $draftPage = $pageRepo->getNewDraftPage($book);
-
-        return $pageRepo->publishDraft($draftPage, $input);
-    }
-
-    /**
      * Quickly sets an array of settings.
      */
     protected function setSettings(array $settingsArray): void
@@ -189,31 +144,6 @@ abstract class TestCase extends BaseTestCase
         foreach ($settingsArray as $key => $value) {
             $settings->put($key, $value);
         }
-    }
-
-    /**
-     * Manually set some permissions on an entity.
-     */
-    protected function setEntityRestrictions(Entity $entity, array $actions = [], array $roles = []): void
-    {
-        $entity->restricted = true;
-        $entity->permissions()->delete();
-
-        $permissions = [];
-        foreach ($actions as $action) {
-            foreach ($roles as $role) {
-                $permissions[] = [
-                    'role_id' => $role->id,
-                    'action'  => strtolower($action),
-                ];
-            }
-        }
-        $entity->permissions()->createMany($permissions);
-
-        $entity->save();
-        $entity->load('permissions');
-        $this->app->make(JointPermissionBuilder::class)->rebuildForEntity($entity);
-        $entity->load('jointPermissions');
     }
 
     /**
@@ -260,27 +190,6 @@ abstract class TestCase extends BaseTestCase
         $roleData['permissions'] = array_flip($permissions);
 
         return $permissionRepo->saveNewRole($roleData);
-    }
-
-    /**
-     * Create a group of entities that belong to a specific user.
-     *
-     * @return array{book: Book, chapter: Chapter, page: Page}
-     */
-    protected function createEntityChainBelongingToUser(User $creatorUser, ?User $updaterUser = null): array
-    {
-        if (empty($updaterUser)) {
-            $updaterUser = $creatorUser;
-        }
-
-        $userAttrs = ['created_by' => $creatorUser->id, 'owned_by' => $creatorUser->id, 'updated_by' => $updaterUser->id];
-        $book = Book::factory()->create($userAttrs);
-        $chapter = Chapter::factory()->create(array_merge(['book_id' => $book->id], $userAttrs));
-        $page = Page::factory()->create(array_merge(['book_id' => $book->id, 'chapter_id' => $chapter->id], $userAttrs));
-
-        $this->app->make(JointPermissionBuilder::class)->rebuildForEntity($book);
-
-        return compact('book', 'chapter', 'page');
     }
 
     /**
@@ -459,18 +368,5 @@ abstract class TestCase extends BaseTestCase
         }
 
         $this->assertDatabaseHas('activities', $detailsToCheck);
-    }
-
-    /**
-     * @return array{page: Page, chapter: Chapter, book: Book, bookshelf: Bookshelf}
-     */
-    protected function getEachEntityType(): array
-    {
-        return [
-            'page'      => Page::query()->first(),
-            'chapter'   => Chapter::query()->first(),
-            'book'      => Book::query()->first(),
-            'bookshelf' => Bookshelf::query()->first(),
-        ];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,6 +27,7 @@ use Monolog\Logger;
 use Psr\Http\Client\ClientInterface;
 use Ssddanbrown\AssertHtml\TestsHtml;
 use Tests\Helpers\EntityProvider;
+use Tests\Helpers\TestServiceProvider;
 
 abstract class TestCase extends BaseTestCase
 {

--- a/tests/ThemeTest.php
+++ b/tests/ThemeTest.php
@@ -64,7 +64,7 @@ class ThemeTest extends TestCase
         };
         Theme::listen(ThemeEvents::COMMONMARK_ENVIRONMENT_CONFIGURE, $callback);
 
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $content = new PageContent($page);
         $content->setNewMarkdown('# test');
 
@@ -199,7 +199,7 @@ class ThemeTest extends TestCase
 
     public function test_event_activity_logged()
     {
-        $book = Book::query()->first();
+        $book = $this->entities->book();
         $args = [];
         $callback = function (...$eventArgs) use (&$args) {
             $args = $eventArgs;
@@ -218,7 +218,7 @@ class ThemeTest extends TestCase
     {
         /** @var Page $page */
         /** @var Page $otherPage */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $otherPage = Page::query()->where('id', '!=', $page->id)->first();
         $otherPage->html = '<p id="bkmrk-cool">This is a really cool section</p>';
         $page->html = "<p>{{@{$otherPage->id}#bkmrk-cool}}</p>";
@@ -324,8 +324,7 @@ class ThemeTest extends TestCase
     {
         $bodyStartStr = 'garry-fought-against-the-panther';
         $bodyEndStr = 'garry-lost-his-fight-with-grace';
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $this->usingThemeFolder(function (string $folder) use ($bodyStartStr, $bodyEndStr, $page) {
             $viewDir = theme_path('layouts/parts');

--- a/tests/Uploads/AttachmentTest.php
+++ b/tests/Uploads/AttachmentTest.php
@@ -73,7 +73,7 @@ class AttachmentTest extends TestCase
 
     public function test_file_upload()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asAdmin();
         $admin = $this->getAdmin();
         $fileName = 'upload_test_file.txt';
@@ -101,7 +101,7 @@ class AttachmentTest extends TestCase
 
     public function test_file_upload_does_not_use_filename()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $fileName = 'upload_test_file.txt';
 
         $upload = $this->asAdmin()->uploadFile($fileName, $page->id);
@@ -115,7 +115,7 @@ class AttachmentTest extends TestCase
 
     public function test_file_display_and_access()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asAdmin();
         $fileName = 'upload_test_file.txt';
 
@@ -136,7 +136,7 @@ class AttachmentTest extends TestCase
 
     public function test_attaching_link_to_page()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $admin = $this->getAdmin();
         $this->asAdmin();
 
@@ -173,7 +173,7 @@ class AttachmentTest extends TestCase
 
     public function test_attachment_updating()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asAdmin();
 
         $attachment = $this->createAttachment($page);
@@ -197,7 +197,7 @@ class AttachmentTest extends TestCase
 
     public function test_file_deletion()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asAdmin();
         $fileName = 'deletion_test.txt';
         $this->uploadFile($fileName, $page->id);
@@ -219,7 +219,7 @@ class AttachmentTest extends TestCase
 
     public function test_attachment_deletion_on_page_deletion()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asAdmin();
         $fileName = 'deletion_test.txt';
         $this->uploadFile($fileName, $page->id);
@@ -247,7 +247,7 @@ class AttachmentTest extends TestCase
     {
         $admin = $this->getAdmin();
         $viewer = $this->getViewer();
-        $page = Page::query()->first(); /** @var Page $page */
+        $page = $this->entities->page(); /** @var Page $page */
         $this->actingAs($admin);
         $fileName = 'permission_test.txt';
         $this->uploadFile($fileName, $page->id);
@@ -269,7 +269,7 @@ class AttachmentTest extends TestCase
 
     public function test_data_and_js_links_cannot_be_attached_to_a_page()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asAdmin();
 
         $badLinks = [
@@ -310,7 +310,7 @@ class AttachmentTest extends TestCase
 
     public function test_file_access_with_open_query_param_provides_inline_response_with_correct_content_type()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asAdmin();
         $fileName = 'upload_test_file.txt';
 
@@ -329,7 +329,7 @@ class AttachmentTest extends TestCase
 
     public function test_html_file_access_with_open_forces_plain_content_type()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asAdmin();
 
         $attachment = $this->createUploadAttachment($page, 'test_file.html', '<html></html><p>testing</p>', 'text/html');
@@ -346,7 +346,7 @@ class AttachmentTest extends TestCase
     {
         config()->set('filesystems.attachments', 'local_secure_restricted');
 
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $fileName = 'upload_test_file.txt';
 
         $upload = $this->asAdmin()->uploadFile($fileName, $page->id);

--- a/tests/Uploads/ImageTest.php
+++ b/tests/Uploads/ImageTest.php
@@ -342,7 +342,7 @@ class ImageTest extends TestCase
 
         $this->get($expectedUrl)->assertOk();
 
-        $this->setEntityRestrictions($page, [], []);
+        $this->entities->setPermissions($page, [], []);
 
         $resp = $this->get($expectedUrl);
         $resp->assertNotFound();
@@ -367,7 +367,7 @@ class ImageTest extends TestCase
 
         $this->get($expectedUrl)->assertOk();
 
-        $this->setEntityRestrictions($page, [], []);
+        $this->entities->setPermissions($page, [], []);
 
         $resp = $this->get($expectedUrl);
         $resp->assertNotFound();
@@ -400,7 +400,7 @@ class ImageTest extends TestCase
         $export = $this->get($pageB->getUrl('/export/html'));
         $this->assertStringContainsString($encodedImageContent, $export->getContent());
 
-        $this->setEntityRestrictions($pageA, [], []);
+        $this->entities->setPermissions($pageA, [], []);
 
         $export = $this->get($pageB->getUrl('/export/html'));
         $this->assertStringNotContainsString($encodedImageContent, $export->getContent());

--- a/tests/Uploads/ImageTest.php
+++ b/tests/Uploads/ImageTest.php
@@ -15,7 +15,7 @@ class ImageTest extends TestCase
 
     public function test_image_upload()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $admin = $this->getAdmin();
         $this->actingAs($admin);
 
@@ -39,7 +39,7 @@ class ImageTest extends TestCase
 
     public function test_image_display_thumbnail_generation_does_not_increase_image_size()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $admin = $this->getAdmin();
         $this->actingAs($admin);
 
@@ -63,7 +63,7 @@ class ImageTest extends TestCase
 
     public function test_image_display_thumbnail_generation_for_apng_images_uses_original_file()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $admin = $this->getAdmin();
         $this->actingAs($admin);
 
@@ -125,7 +125,7 @@ class ImageTest extends TestCase
 
     public function test_image_usage()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $editor = $this->getEditor();
         $this->actingAs($editor);
 
@@ -145,7 +145,7 @@ class ImageTest extends TestCase
 
     public function test_php_files_cannot_be_uploaded()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $admin = $this->getAdmin();
         $this->actingAs($admin);
 
@@ -167,7 +167,7 @@ class ImageTest extends TestCase
 
     public function test_php_like_files_cannot_be_uploaded()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $admin = $this->getAdmin();
         $this->actingAs($admin);
 
@@ -184,7 +184,7 @@ class ImageTest extends TestCase
 
     public function test_files_with_double_extensions_will_get_sanitized()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $admin = $this->getAdmin();
         $this->actingAs($admin);
 
@@ -219,7 +219,7 @@ class ImageTest extends TestCase
         ];
         foreach ($badNames as $name) {
             $galleryFile = $this->getTestImage($name);
-            $page = Page::query()->first();
+            $page = $this->entities->page();
             $badPath = $this->getTestImagePath('gallery', $name);
             $this->deleteImage($badPath);
 
@@ -244,7 +244,7 @@ class ImageTest extends TestCase
         config()->set('filesystems.images', 'local_secure');
         $this->asEditor();
         $galleryFile = $this->getTestImage('my-secure-test-upload.png');
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $expectedPath = storage_path('uploads/images/gallery/' . date('Y-m') . '/my-secure-test-upload.png');
 
         $upload = $this->call('POST', '/images/gallery', ['uploaded_to' => $page->id], [], ['file' => $galleryFile], []);
@@ -292,7 +292,7 @@ class ImageTest extends TestCase
         config()->set('filesystems.images', 'local_secure');
         $this->asEditor();
         $galleryFile = $this->getTestImage('my-secure-test-upload.png');
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $expectedPath = storage_path('uploads/images/gallery/' . date('Y-m') . '/my-secure-test-upload.png');
 
         $upload = $this->call('POST', '/images/gallery', ['uploaded_to' => $page->id], [], ['file' => $galleryFile], []);
@@ -332,8 +332,7 @@ class ImageTest extends TestCase
         config()->set('filesystems.images', 'local_secure_restricted');
         $this->asEditor();
         $galleryFile = $this->getTestImage('my-secure-restricted-test-upload.png');
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $upload = $this->call('POST', '/images/gallery', ['uploaded_to' => $page->id], [], ['file' => $galleryFile], []);
         $upload->assertStatus(200);
@@ -357,8 +356,7 @@ class ImageTest extends TestCase
         config()->set('filesystems.images', 'local_secure_restricted');
         $this->asEditor();
         $galleryFile = $this->getTestImage('my-secure-restricted-thumb-test-test.png');
-        /** @var Page $page */
-        $page = Page::query()->first();
+        $page = $this->entities->page();
 
         $upload = $this->call('POST', '/images/gallery', ['uploaded_to' => $page->id], [], ['file' => $galleryFile], []);
         $upload->assertStatus(200);
@@ -412,7 +410,7 @@ class ImageTest extends TestCase
 
     public function test_image_delete()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asAdmin();
         $imageName = 'first-image.png';
         $relPath = $this->getTestImagePath('gallery', $imageName);
@@ -434,7 +432,7 @@ class ImageTest extends TestCase
 
     public function test_image_delete_does_not_delete_similar_images()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asAdmin();
         $imageName = 'first-image.png';
 
@@ -459,7 +457,7 @@ class ImageTest extends TestCase
 
     public function test_image_manager_delete_button_only_shows_with_permission()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->asAdmin();
         $imageName = 'first-image.png';
         $relPath = $this->getTestImagePath('gallery', $imageName);
@@ -539,7 +537,7 @@ class ImageTest extends TestCase
 
     public function test_deleted_unused_images()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $admin = $this->getAdmin();
         $this->actingAs($admin);
 

--- a/tests/Uploads/UsesImages.php
+++ b/tests/Uploads/UsesImages.php
@@ -91,7 +91,7 @@ trait UsesImages
     protected function uploadGalleryImage(Page $page = null, ?string $testDataFileName = null)
     {
         if ($page === null) {
-            $page = Page::query()->first();
+            $page = $this->entities->page();
         }
 
         $imageName = $testDataFileName ?? 'first-image.png';

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -4,9 +4,6 @@ namespace Tests;
 
 use BookStack\Http\Request;
 
-use function request;
-use function url;
-
 class UrlTest extends TestCase
 {
     public function test_url_helper_takes_custom_url_into_account()

--- a/tests/User/UserManagementTest.php
+++ b/tests/User/UserManagementTest.php
@@ -150,7 +150,7 @@ class UserManagementTest extends TestCase
 
     public function test_delete_with_new_owner_id_changes_ownership()
     {
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $owner = $page->ownedBy;
         $newOwner = User::query()->where('id', '!=', $owner->id)->first();
 

--- a/tests/User/UserManagementTest.php
+++ b/tests/User/UserManagementTest.php
@@ -6,7 +6,6 @@ use BookStack\Actions\ActivityType;
 use BookStack\Auth\Access\UserInviteService;
 use BookStack\Auth\Role;
 use BookStack\Auth\User;
-use BookStack\Entities\Models\Page;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Mockery\MockInterface;

--- a/tests/User/UserPreferencesTest.php
+++ b/tests/User/UserPreferencesTest.php
@@ -132,8 +132,7 @@ class UserPreferencesTest extends TestCase
     public function test_shelf_view_type_change()
     {
         $editor = $this->getEditor();
-        /** @var Bookshelf $shelf */
-        $shelf = Bookshelf::query()->first();
+        $shelf = $this->entities->shelf();
         setting()->putUser($editor, 'bookshelf_view_type', 'list');
 
         $resp = $this->actingAs($editor)->get($shelf->getUrl())->assertSee('Grid View');
@@ -155,7 +154,7 @@ class UserPreferencesTest extends TestCase
     public function test_update_code_language_favourite()
     {
         $editor = $this->getEditor();
-        $page = Page::query()->first();
+        $page = $this->entities->page();
         $this->actingAs($editor);
 
         $this->patch('/settings/users/update-code-language-favourite', ['language' => 'php', 'active' => true]);

--- a/tests/User/UserPreferencesTest.php
+++ b/tests/User/UserPreferencesTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\User;
 
-use BookStack\Entities\Models\Bookshelf;
-use BookStack\Entities\Models\Page;
 use Tests\TestCase;
 
 class UserPreferencesTest extends TestCase

--- a/tests/User/UserProfileTest.php
+++ b/tests/User/UserProfileTest.php
@@ -29,7 +29,7 @@ class UserProfileTest extends TestCase
 
     public function test_profile_page_shows_recent_entities()
     {
-        $content = $this->createEntityChainBelongingToUser($this->user, $this->user);
+        $content = $this->entities->createChainBelongingToUser($this->user, $this->user);
 
         $resp = $this->asAdmin()->get('/user/' . $this->user->slug);
         // Check the recently created page is shown
@@ -50,7 +50,7 @@ class UserProfileTest extends TestCase
             ->assertElementContains('#content-counts', '0 Chapters')
             ->assertElementContains('#content-counts', '0 Pages');
 
-        $this->createEntityChainBelongingToUser($newUser, $newUser);
+        $this->entities->createChainBelongingToUser($newUser, $newUser);
 
         $resp = $this->asAdmin()->get('/user/' . $newUser->slug)
             ->assertSee($newUser->name);
@@ -63,7 +63,7 @@ class UserProfileTest extends TestCase
     {
         $newUser = User::factory()->create();
         $this->actingAs($newUser);
-        $entities = $this->createEntityChainBelongingToUser($newUser, $newUser);
+        $entities = $this->entities->createChainBelongingToUser($newUser, $newUser);
         Activity::add(ActivityType::BOOK_UPDATE, $entities['book']);
         Activity::add(ActivityType::PAGE_CREATE, $entities['page']);
 
@@ -77,7 +77,7 @@ class UserProfileTest extends TestCase
     {
         $newUser = User::factory()->create();
         $this->actingAs($newUser);
-        $entities = $this->createEntityChainBelongingToUser($newUser, $newUser);
+        $entities = $this->entities->createChainBelongingToUser($newUser, $newUser);
         Activity::add(ActivityType::BOOK_UPDATE, $entities['book']);
         Activity::add(ActivityType::PAGE_CREATE, $entities['page']);
 


### PR DESCRIPTION
Clean-up of entity-specific handling within testcases to cut down on very common boilerplate work and
organise some of the TestCase messiness and manual phpdoc types.