### PR TITLE
Install spatie/laravel-backup for automated & easy backups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,13 @@ MAIL_PORT=1025
 MAIL_USERNAME=null
 MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null
+
+# Backup settings
+# Specifies all the disks to which the backup should be persisted.
+# May be a comma-separated list
+BACKUP_DISKS=backup
+
+# In case of using the "backup" disk, this is the base directory
+# where backup will be stored. Should be outside of the
+# application directory
+BACKUP_ROOT=/var/backups/BookStack

--- a/.env.example.complete
+++ b/.env.example.complete
@@ -139,6 +139,9 @@ STORAGE_S3_ENDPOINT=https://my-custom-s3-compatible.service.com:8001
 # An s3-format URL will be generated if not set.
 STORAGE_URL=false
 
+# The base directory to store backups in
+BACKUP_ROOT=/var/backups/BookStack
+
 # Authentication method to use
 # Can be 'standard', 'ldap', 'saml2' or 'oidc'
 AUTH_METHOD=standard

--- a/app/Config/backup.php
+++ b/app/Config/backup.php
@@ -1,0 +1,268 @@
+<?php
+
+use Illuminate\Support\Str;
+
+return [
+
+    'backup' => [
+
+        /*
+         * The name of this application. You can use this name to monitor
+         * the backups.
+         */
+        'name' => env('APP_NAME', 'laravel-backup'),
+
+        'source' => [
+
+            'files' => [
+
+                /*
+                 * The list of directories and files that will be included in the backup.
+                 */
+                'include' => [
+                    base_path('.env'),
+                    base_path('public/uploads'),
+                    base_path('storage/uploads'),
+                ],
+
+                /*
+                 * These directories and files will be excluded from the backup.
+                 *
+                 * Directories used by the backup process will automatically be excluded.
+                 */
+                'exclude' => [
+                    base_path('vendor'),
+                    base_path('node_modules'),
+                ],
+
+                /*
+                 * Determines if symlinks should be followed.
+                 */
+                'follow_links' => true,
+
+                /*
+                 * Determines if it should avoid unreadable folders.
+                 */
+                'ignore_unreadable_directories' => false,
+
+                /*
+                 * This path is used to make directories in resulting zip-file relative
+                 * Set to `null` to include complete absolute path
+                 * Example: base_path()
+                 */
+                'relative_path' => null,
+            ],
+
+            /*
+             * The names of the connections to the databases that should be backed up
+             * MySQL, PostgreSQL, SQLite and Mongo databases are supported.
+             *
+             * The content of the database dump may be customized for each connection
+             * by adding a 'dump' key to the connection settings in config/database.php.
+             * E.g.
+             * 'mysql' => [
+             *       ...
+             *      'dump' => [
+             *           'excludeTables' => [
+             *                'table_to_exclude_from_backup',
+             *                'another_table_to_exclude'
+             *            ]
+             *       ],
+             * ],
+             *
+             * If you are using only InnoDB tables on a MySQL server, you can
+             * also supply the useSingleTransaction option to avoid table locking.
+             *
+             * E.g.
+             * 'mysql' => [
+             *       ...
+             *      'dump' => [
+             *           'useSingleTransaction' => true,
+             *       ],
+             * ],
+             *
+             * For a complete list of available customization options, see https://github.com/spatie/db-dumper
+             */
+            'databases' => [
+                'mysql',
+            ],
+        ],
+
+        /*
+         * The database dump can be compressed to decrease diskspace usage.
+         *
+         * Out of the box Laravel-backup supplies
+         * Spatie\DbDumper\Compressors\GzipCompressor::class.
+         *
+         * You can also create custom compressor. More info on that here:
+         * https://github.com/spatie/db-dumper#using-compression
+         *
+         * If you do not want any compressor at all, set it to null.
+         */
+        'database_dump_compressor' => null,
+
+        /*
+         * The file extension used for the database dump files.
+         *
+         * If not specified, the file extension will be .archive for MongoDB and .sql for all other databases
+         * The file extension should be specified without a leading .
+         */
+        'database_dump_file_extension' => '',
+
+        'destination' => [
+
+            /*
+             * The filename prefix used for the backup zip file.
+             */
+            'filename_prefix' => '',
+
+            /*
+             * The disk names on which the backups will be stored.
+             */
+            'disks' => Str::of(env('BACKUP_DISKS', 'backup'))->split(',')->all(),
+        ],
+
+        /*
+         * The directory where the temporary files will be stored.
+         */
+        'temporary_directory' => storage_path('app/backup-temp'),
+
+        /*
+         * The password to be used for archive encryption.
+         * Set to `null` to disable encryption.
+         */
+        'password' => env('BACKUP_ARCHIVE_PASSWORD'),
+
+        /*
+         * The encryption algorithm to be used for archive encryption.
+         * You can set it to `null` or `false` to disable encryption.
+         *
+         * When set to 'default', we'll use ZipArchive::EM_AES_256 if it is
+         * available on your system.
+         */
+        'encryption' => 'default',
+    ],
+
+    /*
+     * You can get notified when specific events occur. Out of the box you can use 'mail' and 'slack'.
+     * For Slack you need to install laravel/slack-notification-channel.
+     *
+     * You can also use your own notification classes, just make sure the class is named after one of
+     * the `Spatie\Backup\Events` classes.
+     */
+    'notifications' => [
+
+        'notifications' => [
+            \Spatie\Backup\Notifications\Notifications\BackupHasFailed::class => ['mail'],
+            \Spatie\Backup\Notifications\Notifications\UnhealthyBackupWasFound::class => ['mail'],
+            \Spatie\Backup\Notifications\Notifications\CleanupHasFailed::class => ['mail'],
+            \Spatie\Backup\Notifications\Notifications\BackupWasSuccessful::class => ['mail'],
+            \Spatie\Backup\Notifications\Notifications\HealthyBackupWasFound::class => ['mail'],
+            \Spatie\Backup\Notifications\Notifications\CleanupWasSuccessful::class => ['mail'],
+        ],
+
+        /*
+         * Here you can specify the notifiable to which the notifications should be sent. The default
+         * notifiable will use the variables specified in this config file.
+         */
+        'notifiable' => \Spatie\Backup\Notifications\Notifiable::class,
+
+        'mail' => [
+            'to' => 'your@example.com',
+
+            'from' => [
+                'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
+                'name' => env('MAIL_FROM_NAME', 'Example'),
+            ],
+        ],
+
+        'slack' => [
+            'webhook_url' => '',
+
+            /*
+             * If this is set to null the default channel of the webhook will be used.
+             */
+            'channel' => null,
+
+            'username' => null,
+
+            'icon' => null,
+
+        ],
+    ],
+
+    /*
+     * Here you can specify which backups should be monitored.
+     * If a backup does not meet the specified requirements the
+     * UnHealthyBackupWasFound event will be fired.
+     */
+    'monitor_backups' => [
+        [
+            'name' => env('APP_NAME', 'laravel-backup'),
+            'disks' => ['local'],
+            'health_checks' => [
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 1,
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes::class => 5000,
+            ],
+        ],
+
+        /*
+        [
+            'name' => 'name of the second app',
+            'disks' => ['local', 's3'],
+            'health_checks' => [
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 1,
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes::class => 5000,
+            ],
+        ],
+        */
+    ],
+
+    'cleanup' => [
+        /*
+         * The strategy that will be used to cleanup old backups. The default strategy
+         * will keep all backups for a certain amount of days. After that period only
+         * a daily backup will be kept. After that period only weekly backups will
+         * be kept and so on.
+         *
+         * No matter how you configure it the default strategy will never
+         * delete the newest backup.
+         */
+        'strategy' => \Spatie\Backup\Tasks\Cleanup\Strategies\DefaultStrategy::class,
+
+        'default_strategy' => [
+
+            /*
+             * The number of days for which backups must be kept.
+             */
+            'keep_all_backups_for_days' => 7,
+
+            /*
+             * The number of days for which daily backups must be kept.
+             */
+            'keep_daily_backups_for_days' => 16,
+
+            /*
+             * The number of weeks for which one weekly backup must be kept.
+             */
+            'keep_weekly_backups_for_weeks' => 8,
+
+            /*
+             * The number of months for which one monthly backup must be kept.
+             */
+            'keep_monthly_backups_for_months' => 4,
+
+            /*
+             * The number of years for which one yearly backup must be kept.
+             */
+            'keep_yearly_backups_for_years' => 2,
+
+            /*
+             * After cleaning up the backups remove the oldest backup until
+             * this amount of megabytes has been reached.
+             */
+            'delete_oldest_backups_when_using_more_megabytes_than' => 5000,
+        ],
+    ],
+
+];

--- a/app/Config/backup.php
+++ b/app/Config/backup.php
@@ -21,6 +21,7 @@ return [
                  */
                 'include' => [
                     base_path('.env'),
+                    base_path('version'),
                     base_path('public/uploads'),
                     base_path('storage/uploads'),
                 ],

--- a/app/Config/filesystems.php
+++ b/app/Config/filesystems.php
@@ -56,6 +56,12 @@ return [
             'use_path_style_endpoint' => env('STORAGE_S3_ENDPOINT', null) !== null,
         ],
 
+        'backup' => [
+            'driver' => 'local',
+            'root' => env('BACKUP_ROOT', storage_path('backup')),
+            'throw' => false,
+        ],
+
     ],
 
     // Symbolic Links

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "socialiteproviders/okta": "^4.1",
         "socialiteproviders/slack": "^4.1",
         "socialiteproviders/twitch": "^5.3",
+        "spatie/laravel-backup": "^6.16",
         "ssddanbrown/htmldiff": "^1.0.2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1fed6278d440ef18af1ffa6ca7b29166",
+    "content-hash": "1fb92b1846a50b8918bc430691c524ca",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4856,6 +4856,207 @@
                 "source": "https://github.com/SocialiteProviders/Twitch/tree/5.3.1"
             },
             "time": "2020-12-01T23:10:59+00:00"
+        },
+        {
+            "name": "spatie/db-dumper",
+            "version": "2.21.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/db-dumper.git",
+                "reference": "05e5955fb882008a8947c5a45146d86cfafa10d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/05e5955fb882008a8947c5a45146d86cfafa10d1",
+                "reference": "05e5955fb882008a8947c5a45146d86cfafa10d1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "symfony/process": "^4.2|^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0|^8.0|^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\DbDumper\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Dump databases",
+            "homepage": "https://github.com/spatie/db-dumper",
+            "keywords": [
+                "database",
+                "db-dumper",
+                "dump",
+                "mysqldump",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/db-dumper/issues",
+                "source": "https://github.com/spatie/db-dumper/tree/2.21.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-02-24T14:56:42+00:00"
+        },
+        {
+            "name": "spatie/laravel-backup",
+            "version": "6.16.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-backup.git",
+                "reference": "332fae80b12cacb9e4161824ba195d984b28c8fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/332fae80b12cacb9e4161824ba195d984b28c8fb",
+                "reference": "332fae80b12cacb9e4161824ba195d984b28c8fb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zip": "^1.14.0",
+                "illuminate/console": "^6.0|^7.0|^8.0",
+                "illuminate/contracts": "^6.0|^7.0|^8.0",
+                "illuminate/events": "^6.0|^7.0|^8.0",
+                "illuminate/filesystem": "^6.0|^7.0|^8.0",
+                "illuminate/notifications": "^6.0|^7.0|^8.0",
+                "illuminate/support": "^6.0|^7.0|^8.0",
+                "league/flysystem": "^1.0.49",
+                "php": "^7.3|^8.0",
+                "spatie/db-dumper": "^2.12",
+                "spatie/temporary-directory": "^1.1",
+                "symfony/finder": "^4.2|^5.0"
+            },
+            "require-dev": {
+                "laravel/slack-notification-channel": "^2.3",
+                "league/flysystem-aws-s3-v3": "^1.0",
+                "mockery/mockery": "^1.4.2",
+                "orchestra/testbench": "4.*|5.*|6.*",
+                "phpunit/phpunit": "^8.4|^9.0"
+            },
+            "suggest": {
+                "laravel/slack-notification-channel": "Required for sending notifications via Slack"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Backup\\BackupServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Helpers/functions.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Backup\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A Laravel package to backup your application",
+            "homepage": "https://github.com/spatie/laravel-backup",
+            "keywords": [
+                "backup",
+                "database",
+                "laravel-backup",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-backup/issues",
+                "source": "https://github.com/spatie/laravel-backup/tree/6.16.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/spatie",
+                    "type": "github"
+                },
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "other"
+                }
+            ],
+            "time": "2021-09-12T10:04:18+00:00"
+        },
+        {
+            "name": "spatie/temporary-directory",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/temporary-directory.git",
+                "reference": "f517729b3793bca58f847c5fd383ec16f03ffec6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/f517729b3793bca58f847c5fd383ec16f03ffec6",
+                "reference": "f517729b3793bca58f847c5fd383ec16f03ffec6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0|^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TemporaryDirectory\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily create, use and destroy temporary directories",
+            "homepage": "https://github.com/spatie/temporary-directory",
+            "keywords": [
+                "php",
+                "spatie",
+                "temporary-directory"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/temporary-directory/issues",
+                "source": "https://github.com/spatie/temporary-directory/tree/1.3.0"
+            },
+            "time": "2020-11-09T15:54:21+00:00"
         },
         {
             "name": "ssddanbrown/htmldiff",

--- a/resources/lang/vendor/backup/ar/notifications.php
+++ b/resources/lang/vendor/backup/ar/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'رسالة استثناء: :message',
+    'exception_trace' => 'تتبع الإستثناء: :trace',
+    'exception_message_title' => 'رسالة استثناء',
+    'exception_trace_title' => 'تتبع الإستثناء',
+
+    'backup_failed_subject' => 'أخفق النسخ الاحتياطي لل :application_name',
+    'backup_failed_body' => 'مهم: حدث خطأ أثناء النسخ الاحتياطي :application_name',
+
+    'backup_successful_subject' => 'نسخ احتياطي جديد ناجح ل :application_name',
+    'backup_successful_subject_title' => 'نجاح النسخ الاحتياطي الجديد!',
+    'backup_successful_body' => 'أخبار عظيمة، نسخة احتياطية جديدة ل :application_name تم إنشاؤها بنجاح على القرص المسمى :disk_name.',
+
+    'cleanup_failed_subject' => 'فشل تنظيف النسخ الاحتياطي للتطبيق :application_name .',
+    'cleanup_failed_body' => 'حدث خطأ أثناء تنظيف النسخ الاحتياطية ل :application_name',
+
+    'cleanup_successful_subject' => 'تنظيف النسخ الاحتياطية ل :application_name تمت بنجاح',
+    'cleanup_successful_subject_title' => 'تنظيف النسخ الاحتياطية تم بنجاح!',
+    'cleanup_successful_body' => 'تنظيف النسخ الاحتياطية ل :application_name على القرص المسمى :disk_name تم بنجاح.',
+
+    'healthy_backup_found_subject' => 'النسخ الاحتياطية ل :application_name على القرص :disk_name صحية',
+    'healthy_backup_found_subject_title' => 'النسخ الاحتياطية ل :application_name صحية',
+    'healthy_backup_found_body' => 'تعتبر النسخ الاحتياطية ل :application_name صحية. عمل جيد!',
+
+    'unhealthy_backup_found_subject' => 'مهم: النسخ الاحتياطية ل :application_name غير صحية',
+    'unhealthy_backup_found_subject_title' => 'مهم: النسخ الاحتياطية ل :application_name غير صحية. :problem',
+    'unhealthy_backup_found_body' => 'النسخ الاحتياطية ل :application_name على القرص :disk_name غير صحية.',
+    'unhealthy_backup_found_not_reachable' => 'لا يمكن الوصول إلى وجهة النسخ الاحتياطي. :error',
+    'unhealthy_backup_found_empty' => 'لا توجد نسخ احتياطية لهذا التطبيق على الإطلاق.',
+    'unhealthy_backup_found_old' => 'تم إنشاء أحدث النسخ الاحتياطية في :date وتعتبر قديمة جدا.',
+    'unhealthy_backup_found_unknown' => 'عذرا، لا يمكن تحديد سبب دقيق.',
+    'unhealthy_backup_found_full' => 'النسخ الاحتياطية تستخدم الكثير من التخزين. الاستخدام الحالي هو :disk_usage وهو أعلى من الحد المسموح به من :disk_limit.',
+];

--- a/resources/lang/vendor/backup/cs/notifications.php
+++ b/resources/lang/vendor/backup/cs/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Zpráva výjimky: :message',
+    'exception_trace' => 'Stopa výjimky: :trace',
+    'exception_message_title' => 'Zpráva výjimky',
+    'exception_trace_title' => 'Stopa výjimky',
+
+    'backup_failed_subject' => 'Záloha :application_name neuspěla',
+    'backup_failed_body' => 'Důležité: Při záloze :application_name se vyskytla chyba',
+
+    'backup_successful_subject' => 'Úspěšná nová záloha :application_name',
+    'backup_successful_subject_title' => 'Úspěšná nová záloha!',
+    'backup_successful_body' => 'Dobrá zpráva, na disku jménem :disk_name byla úspěšně vytvořena nová záloha :application_name.',
+
+    'cleanup_failed_subject' => 'Vyčištění záloh :application_name neuspělo.',
+    'cleanup_failed_body' => 'Při vyčištění záloh :application_name se vyskytla chyba',
+
+    'cleanup_successful_subject' => 'Vyčištění záloh :application_name úspěšné',
+    'cleanup_successful_subject_title' => 'Vyčištění záloh bylo úspěšné!',
+    'cleanup_successful_body' => 'Vyčištění záloh :application_name na disku jménem :disk_name bylo úspěšné.',
+
+    'healthy_backup_found_subject' => 'Zálohy pro :application_name na disku :disk_name jsou zdravé',
+    'healthy_backup_found_subject_title' => 'Zálohy pro :application_name jsou zdravé',
+    'healthy_backup_found_body' => 'Zálohy pro :application_name jsou považovány za zdravé. Dobrá práce!',
+
+    'unhealthy_backup_found_subject' => 'Důležité: Zálohy pro :application_name jsou nezdravé',
+    'unhealthy_backup_found_subject_title' => 'Důležité: Zálohy pro :application_name jsou nezdravé. :problem',
+    'unhealthy_backup_found_body' => 'Zálohy pro :application_name na disku :disk_name Jsou nezdravé.',
+    'unhealthy_backup_found_not_reachable' => 'Nelze se dostat k cíli zálohy. :error',
+    'unhealthy_backup_found_empty' => 'Tato aplikace nemá vůbec žádné zálohy.',
+    'unhealthy_backup_found_old' => 'Poslední záloha vytvořená dne :date je považována za příliš starou.',
+    'unhealthy_backup_found_unknown' => 'Omlouváme se, nemůžeme určit přesný důvod.',
+    'unhealthy_backup_found_full' => 'Zálohy zabírají příliš mnoho místa na disku. Aktuální využití disku je :disk_usage, což je vyšší než povolený limit :disk_limit.',
+];

--- a/resources/lang/vendor/backup/da/notifications.php
+++ b/resources/lang/vendor/backup/da/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Fejlbesked: :message',
+    'exception_trace' => 'Fejl trace: :trace',
+    'exception_message_title' => 'Fejlbesked',
+    'exception_trace_title' => 'Fejl trace',
+
+    'backup_failed_subject' => 'Backup af :application_name fejlede',
+    'backup_failed_body' => 'Vigtigt: Der skete en fejl under backup af :application_name',
+
+    'backup_successful_subject' => 'Ny backup af :application_name oprettet',
+    'backup_successful_subject_title' => 'Ny backup!',
+    'backup_successful_body' => 'Gode nyheder - der blev oprettet en ny backup af :application_name på disken :disk_name.',
+
+    'cleanup_failed_subject' => 'Oprydning af backups for :application_name fejlede.',
+    'cleanup_failed_body' => 'Der skete en fejl under oprydning af backups for :application_name',
+
+    'cleanup_successful_subject' => 'Oprydning af backups for :application_name gennemført',
+    'cleanup_successful_subject_title' => 'Backup oprydning gennemført!',
+    'cleanup_successful_body' => 'Oprydningen af backups for :application_name på disken :disk_name er gennemført.',
+
+    'healthy_backup_found_subject' => 'Alle backups for :application_name på disken :disk_name er OK',
+    'healthy_backup_found_subject_title' => 'Alle backups for :application_name er OK',
+    'healthy_backup_found_body' => 'Alle backups for :application_name er ok. Godt gået!',
+
+    'unhealthy_backup_found_subject' => 'Vigtigt: Backups for :application_name fejlbehæftede',
+    'unhealthy_backup_found_subject_title' => 'Vigtigt: Backups for :application_name er fejlbehæftede. :problem',
+    'unhealthy_backup_found_body' => 'Backups for :application_name på disken :disk_name er fejlbehæftede.',
+    'unhealthy_backup_found_not_reachable' => 'Backup destinationen kunne ikke findes. :error',
+    'unhealthy_backup_found_empty' => 'Denne applikation har ingen backups overhovedet.',
+    'unhealthy_backup_found_old' => 'Den seneste backup fra :date er for gammel.',
+    'unhealthy_backup_found_unknown' => 'Beklager, en præcis årsag kunne ikke findes.',
+    'unhealthy_backup_found_full' => 'Backups bruger for meget plads. Nuværende disk forbrug er :disk_usage, hvilket er mere end den tilladte grænse på :disk_limit.',
+];

--- a/resources/lang/vendor/backup/de/notifications.php
+++ b/resources/lang/vendor/backup/de/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Fehlermeldung: :message',
+    'exception_trace' => 'Fehlerverfolgung: :trace',
+    'exception_message_title' => 'Fehlermeldung',
+    'exception_trace_title' => 'Fehlerverfolgung',
+
+    'backup_failed_subject' => 'Backup von :application_name konnte nicht erstellt werden',
+    'backup_failed_body' => 'Wichtig: Beim Backup von :application_name ist ein Fehler aufgetreten',
+
+    'backup_successful_subject' => 'Erfolgreiches neues Backup von :application_name',
+    'backup_successful_subject_title' => 'Erfolgreiches neues Backup!',
+    'backup_successful_body' => 'Gute Nachrichten, ein neues Backup von :application_name wurde erfolgreich erstellt und in :disk_name gepeichert.',
+
+    'cleanup_failed_subject' => 'Aufräumen der Backups von :application_name schlug fehl.',
+    'cleanup_failed_body' => 'Beim aufräumen der Backups von :application_name ist ein Fehler aufgetreten',
+
+    'cleanup_successful_subject' => 'Aufräumen der Backups von :application_name backups erfolgreich',
+    'cleanup_successful_subject_title' => 'Aufräumen der Backups erfolgreich!',
+    'cleanup_successful_body' => 'Aufräumen der Backups von :application_name in :disk_name war erfolgreich.',
+
+    'healthy_backup_found_subject' => 'Die Backups von :application_name in :disk_name sind gesund',
+    'healthy_backup_found_subject_title' => 'Die Backups von :application_name sind Gesund',
+    'healthy_backup_found_body' => 'Die Backups von :application_name wurden als gesund eingestuft. Gute Arbeit!',
+
+    'unhealthy_backup_found_subject' => 'Wichtig: Die Backups für :application_name sind nicht gesund',
+    'unhealthy_backup_found_subject_title' => 'Wichtig: Die Backups für :application_name sind ungesund. :problem',
+    'unhealthy_backup_found_body' => 'Die Backups für :application_name in :disk_name sind ungesund.',
+    'unhealthy_backup_found_not_reachable' => 'Das Backup Ziel konnte nicht erreicht werden. :error',
+    'unhealthy_backup_found_empty' => 'Es gibt für die Anwendung noch gar keine Backups.',
+    'unhealthy_backup_found_old' => 'Das letzte Backup am :date ist zu lange her.',
+    'unhealthy_backup_found_unknown' => 'Sorry, ein genauer Grund konnte nicht gefunden werden.',
+    'unhealthy_backup_found_full' => 'Die Backups verbrauchen zu viel Platz. Aktuell wird :disk_usage belegt, dass ist höher als das erlaubte Limit von :disk_limit.',
+];

--- a/resources/lang/vendor/backup/en/notifications.php
+++ b/resources/lang/vendor/backup/en/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Exception message: :message',
+    'exception_trace' => 'Exception trace: :trace',
+    'exception_message_title' => 'Exception message',
+    'exception_trace_title' => 'Exception trace',
+
+    'backup_failed_subject' => 'Failed backup of :application_name',
+    'backup_failed_body' => 'Important: An error occurred while backing up :application_name',
+
+    'backup_successful_subject' => 'Successful new backup of :application_name',
+    'backup_successful_subject_title' => 'Successful new backup!',
+    'backup_successful_body' => 'Great news, a new backup of :application_name was successfully created on the disk named :disk_name.',
+
+    'cleanup_failed_subject' => 'Cleaning up the backups of :application_name failed.',
+    'cleanup_failed_body' => 'An error occurred while cleaning up the backups of :application_name',
+
+    'cleanup_successful_subject' => 'Clean up of :application_name backups successful',
+    'cleanup_successful_subject_title' => 'Clean up of backups successful!',
+    'cleanup_successful_body' => 'The clean up of the :application_name backups on the disk named :disk_name was successful.',
+
+    'healthy_backup_found_subject' => 'The backups for :application_name on disk :disk_name are healthy',
+    'healthy_backup_found_subject_title' => 'The backups for :application_name are healthy',
+    'healthy_backup_found_body' => 'The backups for :application_name are considered healthy. Good job!',
+
+    'unhealthy_backup_found_subject' => 'Important: The backups for :application_name are unhealthy',
+    'unhealthy_backup_found_subject_title' => 'Important: The backups for :application_name are unhealthy. :problem',
+    'unhealthy_backup_found_body' => 'The backups for :application_name on disk :disk_name are unhealthy.',
+    'unhealthy_backup_found_not_reachable' => 'The backup destination cannot be reached. :error',
+    'unhealthy_backup_found_empty' => 'There are no backups of this application at all.',
+    'unhealthy_backup_found_old' => 'The latest backup made on :date is considered too old.',
+    'unhealthy_backup_found_unknown' => 'Sorry, an exact reason cannot be determined.',
+    'unhealthy_backup_found_full' => 'The backups are using too much storage. Current usage is :disk_usage which is higher than the allowed limit of :disk_limit.',
+];

--- a/resources/lang/vendor/backup/es/notifications.php
+++ b/resources/lang/vendor/backup/es/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Mensaje de la excepción: :message',
+    'exception_trace' => 'Traza de la excepción: :trace',
+    'exception_message_title' => 'Mensaje de la excepción',
+    'exception_trace_title' => 'Traza de la excepción',
+
+    'backup_failed_subject' => 'Copia de seguridad de :application_name fallida',
+    'backup_failed_body' => 'Importante: Ocurrió un error al realizar la copia de seguridad de :application_name',
+
+    'backup_successful_subject' => 'Se completó con éxito la copia de seguridad de :application_name',
+    'backup_successful_subject_title' => '¡Nueva copia de seguridad creada con éxito!',
+    'backup_successful_body' => 'Buenas noticias, una nueva copia de seguridad de :application_name fue creada con éxito en el disco llamado :disk_name.',
+
+    'cleanup_failed_subject' => 'La limpieza de copias de seguridad de :application_name falló.',
+    'cleanup_failed_body' => 'Ocurrió un error mientras se realizaba la limpieza de copias de seguridad de :application_name',
+
+    'cleanup_successful_subject' => 'La limpieza de copias de seguridad de :application_name se completó con éxito',
+    'cleanup_successful_subject_title' => '!Limpieza de copias de seguridad completada con éxito!',
+    'cleanup_successful_body' => 'La limpieza de copias de seguridad de :application_name en el disco llamado :disk_name se completo con éxito.',
+
+    'healthy_backup_found_subject' => 'Las copias de seguridad de :application_name en el disco :disk_name están en buen estado',
+    'healthy_backup_found_subject_title' => 'Las copias de seguridad de :application_name están en buen estado',
+    'healthy_backup_found_body' => 'Las copias de seguridad de :application_name se consideran en buen estado. ¡Buen trabajo!',
+
+    'unhealthy_backup_found_subject' => 'Importante: Las copias de seguridad de :application_name están en mal estado',
+    'unhealthy_backup_found_subject_title' => 'Importante: Las copias de seguridad de :application_name están en mal estado. :problem',
+    'unhealthy_backup_found_body' => 'Las copias de seguridad de :application_name en el disco :disk_name están en mal estado.',
+    'unhealthy_backup_found_not_reachable' => 'No se puede acceder al destino de la copia de seguridad. :error',
+    'unhealthy_backup_found_empty' => 'No existe ninguna copia de seguridad de esta aplicación.',
+    'unhealthy_backup_found_old' => 'La última copia de seguriad hecha en :date es demasiado antigua.',
+    'unhealthy_backup_found_unknown' => 'Lo siento, no es posible determinar la razón exacta.',
+    'unhealthy_backup_found_full' => 'Las copias de seguridad  están ocupando demasiado espacio. El espacio utilizado actualmente es :disk_usage el cual es mayor que el límite permitido de :disk_limit.',
+];

--- a/resources/lang/vendor/backup/fa/notifications.php
+++ b/resources/lang/vendor/backup/fa/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'پیغام خطا: :message',
+    'exception_trace' => 'جزییات خطا: :trace',
+    'exception_message_title' => 'پیغام خطا',
+    'exception_trace_title' => 'جزییات خطا',
+
+    'backup_failed_subject' => 'پشتیبان‌گیری :application_name با خطا مواجه شد.',
+    'backup_failed_body' => 'پیغام مهم: هنگام پشتیبان‌گیری از :application_name خطایی رخ داده است. ',
+
+    'backup_successful_subject' => 'نسخه پشتیبان جدید :application_name با موفقیت ساخته شد.',
+    'backup_successful_subject_title' => 'پشتیبان‌گیری موفق!',
+    'backup_successful_body' => 'خبر خوب, به تازگی نسخه پشتیبان :application_name بر روی دیسک :disk_name با موفقیت ساخته شد. ',
+
+    'cleanup_failed_subject' => 'پاک‌‌سازی نسخه پشتیبان :application_name انجام نشد.',
+    'cleanup_failed_body' => 'هنگام پاک‌سازی نسخه پشتیبان :application_name خطایی رخ داده است.',
+
+    'cleanup_successful_subject' => 'پاک‌سازی نسخه پشتیبان :application_name با موفقیت انجام شد.',
+    'cleanup_successful_subject_title' => 'پاک‌سازی نسخه پشتیبان!',
+    'cleanup_successful_body' => 'پاک‌سازی نسخه پشتیبان :application_name بر روی دیسک :disk_name با موفقیت انجام شد.',
+
+    'healthy_backup_found_subject' => 'نسخه پشتیبان :application_name بر روی دیسک :disk_name سالم بود.',
+    'healthy_backup_found_subject_title' => 'نسخه پشتیبان :application_name سالم بود.',
+    'healthy_backup_found_body' => 'نسخه پشتیبان :application_name به نظر سالم میاد. دمت گرم!',
+
+    'unhealthy_backup_found_subject' => 'خبر مهم: نسخه پشتیبان :application_name سالم نبود.',
+    'unhealthy_backup_found_subject_title' => 'خبر مهم: نسخه پشتیبان :application_name سالم نبود. :problem',
+    'unhealthy_backup_found_body' => 'نسخه پشتیبان :application_name بر روی دیسک :disk_name سالم نبود.',
+    'unhealthy_backup_found_not_reachable' => 'مقصد پشتیبان‌گیری در دسترس نبود. :error',
+    'unhealthy_backup_found_empty' => 'برای این برنامه هیچ نسخه پشتیبانی وجود ندارد.',
+    'unhealthy_backup_found_old' => 'آخرین نسخه پشتیبان برای تاریخ :date است. که به نظر خیلی قدیمی میاد. ',
+    'unhealthy_backup_found_unknown' => 'متاسفانه دلیل دقیق مشخص نشده است.',
+    'unhealthy_backup_found_full' => 'نسخه‌های پشتیبانی که تهیه کرده اید حجم زیادی اشغال کرده اند. میزان دیسک استفاده شده :disk_usage است که از میزان مجاز :disk_limit فراتر رفته است. ',
+];

--- a/resources/lang/vendor/backup/fi/notifications.php
+++ b/resources/lang/vendor/backup/fi/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Virheilmoitus: :message',
+    'exception_trace' => 'Virhe, jäljitys: :trace',
+    'exception_message_title' => 'Virheilmoitus',
+    'exception_trace_title' => 'Virheen jäljitys',
+
+    'backup_failed_subject' => ':application_name varmuuskopiointi epäonnistui',
+    'backup_failed_body' => 'HUOM!: :application_name varmuuskoipionnissa tapahtui virhe',
+
+    'backup_successful_subject' => ':application_name varmuuskopioitu onnistuneesti',
+    'backup_successful_subject_title' => 'Uusi varmuuskopio!',
+    'backup_successful_body' => 'Hyviä uutisia! :application_name on varmuuskopioitu levylle :disk_name.',
+
+    'cleanup_failed_subject' => ':application_name varmuuskopioiden poistaminen epäonnistui.',
+    'cleanup_failed_body' => ':application_name varmuuskopioiden poistamisessa tapahtui virhe.',
+
+    'cleanup_successful_subject' => ':application_name varmuuskopiot poistettu onnistuneesti',
+    'cleanup_successful_subject_title' => 'Varmuuskopiot poistettu onnistuneesti!',
+    'cleanup_successful_body' => ':application_name varmuuskopiot poistettu onnistuneesti levyltä :disk_name.',
+
+    'healthy_backup_found_subject' => ':application_name varmuuskopiot levyllä :disk_name ovat kunnossa',
+    'healthy_backup_found_subject_title' => ':application_name varmuuskopiot ovat kunnossa',
+    'healthy_backup_found_body' => ':application_name varmuuskopiot ovat kunnossa. Hieno homma!',
+
+    'unhealthy_backup_found_subject' => 'HUOM!: :application_name varmuuskopiot ovat vialliset',
+    'unhealthy_backup_found_subject_title' => 'HUOM!: :application_name varmuuskopiot ovat vialliset. :problem',
+    'unhealthy_backup_found_body' => ':application_name varmuuskopiot levyllä :disk_name ovat vialliset.',
+    'unhealthy_backup_found_not_reachable' => 'Varmuuskopioiden kohdekansio ei ole saatavilla. :error',
+    'unhealthy_backup_found_empty' => 'Tästä sovelluksesta ei ole varmuuskopioita.',
+    'unhealthy_backup_found_old' => 'Viimeisin varmuuskopio, luotu :date, on liian vanha.',
+    'unhealthy_backup_found_unknown' => 'Virhe, tarkempaa tietoa syystä ei valitettavasti ole saatavilla.',
+    'unhealthy_backup_found_full' => 'Varmuuskopiot vievät liikaa levytilaa. Tällä hetkellä käytössä :disk_usage, mikä on suurempi kuin sallittu tilavuus (:disk_limit).',
+];

--- a/resources/lang/vendor/backup/fr/notifications.php
+++ b/resources/lang/vendor/backup/fr/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Message de l\'exception : :message',
+    'exception_trace' => 'Trace de l\'exception : :trace',
+    'exception_message_title' => 'Message de l\'exception',
+    'exception_trace_title' => 'Trace de l\'exception',
+
+    'backup_failed_subject' => 'Échec de la sauvegarde de :application_name',
+    'backup_failed_body' => 'Important : Une erreur est survenue lors de la sauvegarde de :application_name',
+
+    'backup_successful_subject' => 'Succès de la sauvegarde de :application_name',
+    'backup_successful_subject_title' => 'Sauvegarde créée avec succès !',
+    'backup_successful_body' => 'Bonne nouvelle, une nouvelle sauvegarde de :application_name a été créée avec succès sur le disque nommé :disk_name.',
+
+    'cleanup_failed_subject' => 'Le nettoyage des sauvegardes de :application_name a echoué.',
+    'cleanup_failed_body' => 'Une erreur est survenue lors du nettoyage des sauvegardes de :application_name',
+
+    'cleanup_successful_subject' => 'Succès du nettoyage des sauvegardes de :application_name',
+    'cleanup_successful_subject_title' => 'Sauvegardes nettoyées avec succès !',
+    'cleanup_successful_body' => 'Le nettoyage des sauvegardes de :application_name sur le disque nommé :disk_name a été effectué avec succès.',
+
+    'healthy_backup_found_subject' => 'Les sauvegardes pour :application_name sur le disque :disk_name sont saines',
+    'healthy_backup_found_subject_title' => 'Les sauvegardes pour :application_name sont saines',
+    'healthy_backup_found_body' => 'Les sauvegardes pour :application_name sont considérées saines. Bon travail !',
+
+    'unhealthy_backup_found_subject' => 'Important : Les sauvegardes pour :application_name sont corrompues',
+    'unhealthy_backup_found_subject_title' => 'Important : Les sauvegardes pour :application_name sont corrompues. :problem',
+    'unhealthy_backup_found_body' => 'Les sauvegardes pour :application_name sur le disque :disk_name sont corrompues.',
+    'unhealthy_backup_found_not_reachable' => 'La destination de la sauvegarde n\'est pas accessible. :error',
+    'unhealthy_backup_found_empty' => 'Il n\'y a aucune sauvegarde pour cette application.',
+    'unhealthy_backup_found_old' => 'La dernière sauvegarde du :date est considérée trop vieille.',
+    'unhealthy_backup_found_unknown' => 'Désolé, une raison exacte ne peut être déterminée.',
+    'unhealthy_backup_found_full' => 'Les sauvegardes utilisent trop d\'espace disque. L\'utilisation actuelle est de :disk_usage alors que la limite autorisée est de :disk_limit.',
+];

--- a/resources/lang/vendor/backup/hi/notifications.php
+++ b/resources/lang/vendor/backup/hi/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'गलती संदेश: :message',
+    'exception_trace' => 'गलती निशान: :trace',
+    'exception_message_title' => 'गलती संदेश',
+    'exception_trace_title' => 'गलती निशान',
+
+    'backup_failed_subject' => ':application_name का बैकअप असफल रहा',
+    'backup_failed_body' => 'जरूरी सुचना: :application_name का बैकअप लेते समय असफल रहे',
+
+    'backup_successful_subject' => ':application_name का बैकअप सफल रहा',
+    'backup_successful_subject_title' => 'बैकअप सफल रहा!',
+    'backup_successful_body' => 'खुशखबरी, :application_name का बैकअप :disk_name पर संग्रहित करने मे सफल रहे.',
+
+    'cleanup_failed_subject' => ':application_name के बैकअप की सफाई असफल रही.',
+    'cleanup_failed_body' => ':application_name के बैकअप की सफाई करते समय कुछ बाधा आयी है.',
+
+    'cleanup_successful_subject' => ':application_name के बैकअप की सफाई सफल रही',
+    'cleanup_successful_subject_title' => 'बैकअप की सफाई सफल रही!',
+    'cleanup_successful_body' => ':application_name का बैकअप जो :disk_name नाम की डिस्क पर संग्रहित है, उसकी सफाई सफल रही.',
+
+    'healthy_backup_found_subject' => ':disk_name नाम की डिस्क पर संग्रहित :application_name के बैकअप स्वस्थ है',
+    'healthy_backup_found_subject_title' => ':application_name के सभी बैकअप स्वस्थ है',
+    'healthy_backup_found_body' => 'बहुत बढ़िया! :application_name के सभी बैकअप स्वस्थ है.',
+
+    'unhealthy_backup_found_subject' => 'जरूरी सुचना :  :application_name के बैकअप अस्वस्थ है',
+    'unhealthy_backup_found_subject_title' => 'जरूरी सुचना : :application_name के बैकअप :problem के बजेसे अस्वस्थ है',
+    'unhealthy_backup_found_body' => ':disk_name नाम की डिस्क पर संग्रहित :application_name के बैकअप अस्वस्थ है',
+    'unhealthy_backup_found_not_reachable' => ':error के बजेसे बैकअप की मंजिल तक पोहोच नहीं सकते.',
+    'unhealthy_backup_found_empty' => 'इस एप्लीकेशन का कोई भी बैकअप नहीं है.',
+    'unhealthy_backup_found_old' => 'हालहीमें :date को लिया हुआ बैकअप बहुत पुराना है.',
+    'unhealthy_backup_found_unknown' => 'माफ़ कीजिये, सही कारण निर्धारित नहीं कर सकते.',
+    'unhealthy_backup_found_full' => 'सभी बैकअप बहुत ज्यादा जगह का उपयोग कर रहे है. फ़िलहाल सभी बैकअप :disk_usage जगह का उपयोग कर रहे है, जो की :disk_limit अनुमति सीमा से अधिक का है.',
+];

--- a/resources/lang/vendor/backup/id/notifications.php
+++ b/resources/lang/vendor/backup/id/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Pesan pengecualian: :message',
+    'exception_trace' => 'Jejak pengecualian: :trace',
+    'exception_message_title' => 'Pesan pengecualian',
+    'exception_trace_title' => 'Jejak pengecualian',
+
+    'backup_failed_subject' => 'Gagal backup :application_name',
+    'backup_failed_body' => 'Penting: Sebuah error terjadi ketika membackup :application_name',
+
+    'backup_successful_subject' => 'Backup baru sukses dari :application_name',
+    'backup_successful_subject_title' => 'Backup baru sukses!',
+    'backup_successful_body' => 'Kabar baik, sebuah backup baru dari :application_name sukses dibuat pada disk bernama :disk_name.',
+
+    'cleanup_failed_subject' => 'Membersihkan backup dari :application_name yang gagal.',
+    'cleanup_failed_body' => 'Sebuah error teradi ketika membersihkan backup dari :application_name',
+
+    'cleanup_successful_subject' => 'Sukses membersihkan backup :application_name',
+    'cleanup_successful_subject_title' => 'Sukses membersihkan backup!',
+    'cleanup_successful_body' => 'Pembersihan backup :application_name pada disk bernama :disk_name telah sukses.',
+
+    'healthy_backup_found_subject' => 'Backup untuk :application_name pada disk :disk_name sehat',
+    'healthy_backup_found_subject_title' => 'Backup untuk :application_name sehat',
+    'healthy_backup_found_body' => 'Backup untuk :application_name dipertimbangkan sehat. Kerja bagus!',
+
+    'unhealthy_backup_found_subject' => 'Penting: Backup untuk :application_name tidak sehat',
+    'unhealthy_backup_found_subject_title' => 'Penting: Backup untuk :application_name tidak sehat. :problem',
+    'unhealthy_backup_found_body' => 'Backup untuk :application_name pada disk :disk_name tidak sehat.',
+    'unhealthy_backup_found_not_reachable' => 'Tujuan backup tidak dapat terjangkau. :error',
+    'unhealthy_backup_found_empty' => 'Tidak ada backup pada aplikasi ini sama sekali.',
+    'unhealthy_backup_found_old' => 'Backup terakhir dibuat pada :date dimana dipertimbahkan sudah sangat lama.',
+    'unhealthy_backup_found_unknown' => 'Maaf, sebuah alasan persisnya tidak dapat ditentukan.',
+    'unhealthy_backup_found_full' => 'Backup menggunakan terlalu banyak kapasitas penyimpanan. Penggunaan terkini adalah :disk_usage dimana lebih besar dari batas yang diperbolehkan yaitu :disk_limit.',
+];

--- a/resources/lang/vendor/backup/it/notifications.php
+++ b/resources/lang/vendor/backup/it/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Messaggio dell\'eccezione: :message',
+    'exception_trace' => 'Traccia dell\'eccezione: :trace',
+    'exception_message_title' => 'Messaggio dell\'eccezione',
+    'exception_trace_title' => 'Traccia dell\'eccezione',
+
+    'backup_failed_subject' => 'Fallito il backup di :application_name',
+    'backup_failed_body' => 'Importante: Si è verificato un errore durante il backup di :application_name',
+
+    'backup_successful_subject' => 'Creato nuovo backup di :application_name',
+    'backup_successful_subject_title' => 'Nuovo backup creato!',
+    'backup_successful_body' => 'Grande notizia, un nuovo backup di :application_name è stato creato con successo sul disco :disk_name.',
+
+    'cleanup_failed_subject' => 'Pulizia dei backup di :application_name fallita.',
+    'cleanup_failed_body' => 'Si è verificato un errore durante la pulizia dei backup di :application_name',
+
+    'cleanup_successful_subject' => 'Pulizia dei backup di :application_name avvenuta con successo',
+    'cleanup_successful_subject_title' => 'Pulizia dei backup avvenuta con successo!',
+    'cleanup_successful_body' => 'La pulizia dei backup di :application_name sul disco :disk_name è avvenuta con successo.',
+
+    'healthy_backup_found_subject' => 'I backup per :application_name sul disco :disk_name sono sani',
+    'healthy_backup_found_subject_title' => 'I backup per :application_name sono sani',
+    'healthy_backup_found_body' => 'I backup per :application_name sono considerati sani. Bel Lavoro!',
+
+    'unhealthy_backup_found_subject' => 'Importante: i backup per :application_name sono corrotti',
+    'unhealthy_backup_found_subject_title' => 'Importante: i backup per :application_name sono corrotti. :problem',
+    'unhealthy_backup_found_body' => 'I backup per :application_name sul disco :disk_name sono corrotti.',
+    'unhealthy_backup_found_not_reachable' => 'Impossibile raggiungere la destinazione di backup. :error',
+    'unhealthy_backup_found_empty' => 'Non esiste alcun backup di questa applicazione.',
+    'unhealthy_backup_found_old' => 'L\'ultimo backup fatto il :date è considerato troppo vecchio.',
+    'unhealthy_backup_found_unknown' => 'Spiacenti, non è possibile determinare una ragione esatta.',
+    'unhealthy_backup_found_full' => 'I backup utilizzano troppa memoria. L\'utilizzo corrente è :disk_usage che è superiore al limite consentito di :disk_limit.',
+];

--- a/resources/lang/vendor/backup/ja/notifications.php
+++ b/resources/lang/vendor/backup/ja/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => '例外のメッセージ: :message',
+    'exception_trace' => '例外の追跡: :trace',
+    'exception_message_title' => '例外のメッセージ',
+    'exception_trace_title' => '例外の追跡',
+
+    'backup_failed_subject' => ':application_name のバックアップに失敗しました。',
+    'backup_failed_body' => '重要: :application_name のバックアップ中にエラーが発生しました。',
+
+    'backup_successful_subject' => ':application_name のバックアップに成功しました。',
+    'backup_successful_subject_title' => 'バックアップに成功しました！',
+    'backup_successful_body' => '朗報です。ディスク :disk_name へ :application_name のバックアップが成功しました。',
+
+    'cleanup_failed_subject' => ':application_name のバックアップ削除に失敗しました。',
+    'cleanup_failed_body' => ':application_name のバックアップ削除中にエラーが発生しました。',
+
+    'cleanup_successful_subject' => ':application_name のバックアップ削除に成功しました。',
+    'cleanup_successful_subject_title' => 'バックアップ削除に成功しました！',
+    'cleanup_successful_body' => 'ディスク :disk_name に保存された :application_name のバックアップ削除に成功しました。',
+
+    'healthy_backup_found_subject' => 'ディスク :disk_name への :application_name のバックアップは正常です。',
+    'healthy_backup_found_subject_title' => ':application_name のバックアップは正常です。',
+    'healthy_backup_found_body' => ':application_name へのバックアップは正常です。いい仕事してますね！',
+
+    'unhealthy_backup_found_subject' => '重要: :application_name のバックアップに異常があります。',
+    'unhealthy_backup_found_subject_title' => '重要: :application_name のバックアップに異常があります。 :problem',
+    'unhealthy_backup_found_body' => ':disk_name への :application_name のバックアップに異常があります。',
+    'unhealthy_backup_found_not_reachable' => 'バックアップ先にアクセスできませんでした。 :error',
+    'unhealthy_backup_found_empty' => 'このアプリケーションのバックアップは見つかりませんでした。',
+    'unhealthy_backup_found_old' => ':date に保存された直近のバックアップが古すぎます。',
+    'unhealthy_backup_found_unknown' => '申し訳ございません。予期せぬエラーです。',
+    'unhealthy_backup_found_full' => 'バックアップがディスク容量を圧迫しています。現在の使用量 :disk_usage　は、許可された限界値 :disk_limit を超えています。',
+];

--- a/resources/lang/vendor/backup/nl/notifications.php
+++ b/resources/lang/vendor/backup/nl/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Fout bericht: :message',
+    'exception_trace' => 'Fout trace: :trace',
+    'exception_message_title' => 'Fout bericht',
+    'exception_trace_title' => 'Fout trace',
+
+    'backup_failed_subject' => 'Back-up van :application_name mislukt',
+    'backup_failed_body' => 'Belangrijk: Er ging iets fout tijdens het maken van een back-up van :application_name',
+
+    'backup_successful_subject' => 'Succesvolle nieuwe back-up van :application_name',
+    'backup_successful_subject_title' => 'Succesvolle nieuwe back-up!',
+    'backup_successful_body' => 'Goed nieuws, een nieuwe back-up van :application_name was succesvol aangemaakt op de schijf genaamd :disk_name.',
+
+    'cleanup_failed_subject' => 'Het opschonen van de back-ups van :application_name is mislukt.',
+    'cleanup_failed_body' => 'Er ging iets fout tijdens het opschonen van de back-ups van :application_name',
+
+    'cleanup_successful_subject' => 'Opschonen van :application_name back-ups was succesvol.',
+    'cleanup_successful_subject_title' => 'Opschonen van back-ups was succesvol!',
+    'cleanup_successful_body' => 'Het opschonen van de :application_name back-ups op de schijf genaamd :disk_name was succesvol.',
+
+    'healthy_backup_found_subject' => 'De back-ups voor :application_name op schijf :disk_name zijn gezond',
+    'healthy_backup_found_subject_title' => 'De back-ups voor :application_name zijn gezond',
+    'healthy_backup_found_body' => 'De back-ups voor :application_name worden als gezond beschouwd. Goed gedaan!',
+
+    'unhealthy_backup_found_subject' => 'Belangrijk: De back-ups voor :application_name zijn niet meer gezond',
+    'unhealthy_backup_found_subject_title' => 'Belangrijk: De back-ups voor :application_name zijn niet gezond. :problem',
+    'unhealthy_backup_found_body' => 'De back-ups voor :application_name op schijf :disk_name zijn niet gezond.',
+    'unhealthy_backup_found_not_reachable' => 'De back-upbestemming kon niet worden bereikt. :error',
+    'unhealthy_backup_found_empty' => 'Er zijn geen back-ups van deze applicatie beschikbaar.',
+    'unhealthy_backup_found_old' => 'De laatste back-up gemaakt op :date is te oud.',
+    'unhealthy_backup_found_unknown' => 'Sorry, een exacte reden kon niet worden bepaald.',
+    'unhealthy_backup_found_full' => 'De back-ups gebruiken te veel opslagruimte. Momenteel wordt er :disk_usage gebruikt wat hoger is dan de toegestane limiet van :disk_limit.',
+];

--- a/resources/lang/vendor/backup/no/notifications.php
+++ b/resources/lang/vendor/backup/no/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Exception: :message',
+    'exception_trace' => 'Exception trace: :trace',
+    'exception_message_title' => 'Exception',
+    'exception_trace_title' => 'Exception trace',
+
+    'backup_failed_subject' => 'Backup feilet for :application_name',
+    'backup_failed_body' => 'Viktg: En feil oppstod under backing av :application_name',
+
+    'backup_successful_subject' => 'Gjennomført backup av :application_name',
+    'backup_successful_subject_title' => 'Gjennomført backup!',
+    'backup_successful_body' => 'Gode nyheter, en ny backup av :application_name ble opprettet på disken :disk_name.',
+
+    'cleanup_failed_subject' => 'Opprydding av backup for :application_name feilet.',
+    'cleanup_failed_body' => 'En feil oppstod under opprydding av backups for :application_name',
+
+    'cleanup_successful_subject' => 'Opprydding av backup for :application_name gjennomført',
+    'cleanup_successful_subject_title' => 'Opprydding av backup gjennomført!',
+    'cleanup_successful_body' => 'Oppryddingen av backup for :application_name på disken :disk_name har blitt gjennomført.',
+
+    'healthy_backup_found_subject' => 'Alle backups for :application_name på disken :disk_name er OK',
+    'healthy_backup_found_subject_title' => 'Alle backups for :application_name er OK',
+    'healthy_backup_found_body' => 'Alle backups for :application_name er ok. Godt jobba!',
+
+    'unhealthy_backup_found_subject' => 'Viktig: Backups for :application_name ikke OK',
+    'unhealthy_backup_found_subject_title' => 'Viktig: Backups for :application_name er ikke OK. :problem',
+    'unhealthy_backup_found_body' => 'Backups for :application_name på disken :disk_name er ikke OK.',
+    'unhealthy_backup_found_not_reachable' => 'Kunne ikke finne backup-destinasjonen. :error',
+    'unhealthy_backup_found_empty' => 'Denne applikasjonen mangler backups.',
+    'unhealthy_backup_found_old' => 'Den siste backupem fra :date er for gammel.',
+    'unhealthy_backup_found_unknown' => 'Beklager, kunne ikke finne nøyaktig årsak.',
+    'unhealthy_backup_found_full' => 'Backups bruker for mye lagringsplass. Nåværende diskbruk er :disk_usage, som er mer enn den tillatte grensen på :disk_limit.',
+];

--- a/resources/lang/vendor/backup/pl/notifications.php
+++ b/resources/lang/vendor/backup/pl/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Błąd: :message',
+    'exception_trace' => 'Zrzut błędu: :trace',
+    'exception_message_title' => 'Błąd',
+    'exception_trace_title' => 'Zrzut błędu',
+
+    'backup_failed_subject' => 'Tworzenie kopii zapasowej aplikacji :application_name nie powiodło się',
+    'backup_failed_body' => 'Ważne: Wystąpił błąd podczas tworzenia kopii zapasowej aplikacji :application_name',
+
+    'backup_successful_subject' => 'Pomyślnie utworzono kopię zapasową aplikacji :application_name',
+    'backup_successful_subject_title' => 'Nowa kopia zapasowa!',
+    'backup_successful_body' => 'Wspaniała wiadomość, nowa kopia zapasowa aplikacji :application_name została pomyślnie utworzona na dysku o nazwie :disk_name.',
+
+    'cleanup_failed_subject' => 'Czyszczenie kopii zapasowych aplikacji :application_name nie powiodło się.',
+    'cleanup_failed_body' => 'Wystąpił błąd podczas czyszczenia kopii zapasowej aplikacji :application_name',
+
+    'cleanup_successful_subject' => 'Kopie zapasowe aplikacji :application_name zostały pomyślnie wyczyszczone',
+    'cleanup_successful_subject_title' => 'Kopie zapasowe zostały pomyślnie wyczyszczone!',
+    'cleanup_successful_body' => 'Czyszczenie kopii zapasowych aplikacji :application_name na dysku :disk_name zakończone sukcesem.',
+
+    'healthy_backup_found_subject' => 'Kopie zapasowe aplikacji :application_name na dysku :disk_name są poprawne',
+    'healthy_backup_found_subject_title' => 'Kopie zapasowe aplikacji :application_name są poprawne',
+    'healthy_backup_found_body' => 'Kopie zapasowe aplikacji :application_name są poprawne. Dobra robota!',
+
+    'unhealthy_backup_found_subject' => 'Ważne: Kopie zapasowe aplikacji :application_name są niepoprawne',
+    'unhealthy_backup_found_subject_title' => 'Ważne: Kopie zapasowe aplikacji :application_name są niepoprawne. :problem',
+    'unhealthy_backup_found_body' => 'Kopie zapasowe aplikacji :application_name na dysku :disk_name są niepoprawne.',
+    'unhealthy_backup_found_not_reachable' => 'Miejsce docelowe kopii zapasowej nie jest osiągalne. :error',
+    'unhealthy_backup_found_empty' => 'W aplikacji nie ma żadnej kopii zapasowych tej aplikacji.',
+    'unhealthy_backup_found_old' => 'Ostatnia kopia zapasowa wykonania dnia :date jest zbyt stara.',
+    'unhealthy_backup_found_unknown' => 'Niestety, nie można ustalić dokładnego błędu.',
+    'unhealthy_backup_found_full' => 'Kopie zapasowe zajmują zbyt dużo miejsca. Obecne użycie dysku :disk_usage jest większe od ustalonego limitu :disk_limit.',
+];

--- a/resources/lang/vendor/backup/pt-BR/notifications.php
+++ b/resources/lang/vendor/backup/pt-BR/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Exception message: :message',
+    'exception_trace' => 'Exception trace: :trace',
+    'exception_message_title' => 'Exception message',
+    'exception_trace_title' => 'Exception trace',
+
+    'backup_failed_subject' => 'Falha no backup da aplicação :application_name',
+    'backup_failed_body' => 'Importante: Ocorreu um erro ao fazer o backup da aplicação :application_name',
+
+    'backup_successful_subject' => 'Backup realizado com sucesso: :application_name',
+    'backup_successful_subject_title' => 'Backup Realizado com sucesso!',
+    'backup_successful_body' => 'Boas notícias, um novo backup da aplicação :application_name foi criado no disco :disk_name.',
+
+    'cleanup_failed_subject' => 'Falha na limpeza dos backups da aplicação :application_name.',
+    'cleanup_failed_body' => 'Um erro ocorreu ao fazer a limpeza dos backups da aplicação :application_name',
+
+    'cleanup_successful_subject' => 'Limpeza dos backups da aplicação :application_name concluída!',
+    'cleanup_successful_subject_title' => 'Limpeza dos backups concluída!',
+    'cleanup_successful_body' => 'A limpeza dos backups da aplicação :application_name no disco :disk_name foi concluída.',
+
+    'healthy_backup_found_subject' => 'Os backups da aplicação :application_name no disco :disk_name estão em dia',
+    'healthy_backup_found_subject_title' => 'Os backups da aplicação :application_name estão em dia',
+    'healthy_backup_found_body' => 'Os backups da aplicação :application_name estão em dia. Bom trabalho!',
+
+    'unhealthy_backup_found_subject' => 'Importante: Os backups da aplicação :application_name não estão em dia',
+    'unhealthy_backup_found_subject_title' => 'Importante: Os backups da aplicação :application_name não estão em dia. :problem',
+    'unhealthy_backup_found_body' => 'Os backups da aplicação :application_name no disco :disk_name não estão em dia.',
+    'unhealthy_backup_found_not_reachable' => 'O destino dos backups não pode ser alcançado. :error',
+    'unhealthy_backup_found_empty' => 'Não existem backups para essa aplicação.',
+    'unhealthy_backup_found_old' => 'O último backup realizado em :date é considerado muito antigo.',
+    'unhealthy_backup_found_unknown' => 'Desculpe, a exata razão não pode ser encontrada.',
+    'unhealthy_backup_found_full' => 'Os backups estão usando muito espaço de armazenamento. A utilização atual é de :disk_usage, o que é maior que o limite permitido de :disk_limit.',
+];

--- a/resources/lang/vendor/backup/pt/notifications.php
+++ b/resources/lang/vendor/backup/pt/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Exception message: :message',
+    'exception_trace' => 'Exception trace: :trace',
+    'exception_message_title' => 'Exception message',
+    'exception_trace_title' => 'Exception trace',
+
+    'backup_failed_subject' => 'Falha no backup da aplicação :application_name',
+    'backup_failed_body' => 'Importante: Ocorreu um erro ao executar o backup da aplicação :application_name',
+
+    'backup_successful_subject' => 'Backup realizado com sucesso: :application_name',
+    'backup_successful_subject_title' => 'Backup Realizado com Sucesso!',
+    'backup_successful_body' => 'Boas notícias, foi criado um novo backup no disco :disk_name referente à aplicação :application_name.',
+
+    'cleanup_failed_subject' => 'Falha na limpeza dos backups da aplicação :application_name.',
+    'cleanup_failed_body' => 'Ocorreu um erro ao executar a limpeza dos backups da aplicação :application_name',
+
+    'cleanup_successful_subject' => 'Limpeza dos backups da aplicação :application_name concluída!',
+    'cleanup_successful_subject_title' => 'Limpeza dos backups concluída!',
+    'cleanup_successful_body' => 'Concluída a limpeza dos backups da aplicação :application_name no disco :disk_name.',
+
+    'healthy_backup_found_subject' => 'Os backups da aplicação :application_name no disco :disk_name estão em dia',
+    'healthy_backup_found_subject_title' => 'Os backups da aplicação :application_name estão em dia',
+    'healthy_backup_found_body' => 'Os backups da aplicação :application_name estão em dia. Bom trabalho!',
+
+    'unhealthy_backup_found_subject' => 'Importante: Os backups da aplicação :application_name não estão em dia',
+    'unhealthy_backup_found_subject_title' => 'Importante: Os backups da aplicação :application_name não estão em dia. :problem',
+    'unhealthy_backup_found_body' => 'Os backups da aplicação :application_name no disco :disk_name não estão em dia.',
+    'unhealthy_backup_found_not_reachable' => 'O destino dos backups não pode ser alcançado. :error',
+    'unhealthy_backup_found_empty' => 'Não existem backups para essa aplicação.',
+    'unhealthy_backup_found_old' => 'O último backup realizado em :date é demasiado antigo.',
+    'unhealthy_backup_found_unknown' => 'Desculpe, impossível determinar a razão exata.',
+    'unhealthy_backup_found_full' => 'Os backups estão a utilizar demasiado espaço de armazenamento. A utilização atual é de :disk_usage, o que é maior que o limite permitido de :disk_limit.',
+];

--- a/resources/lang/vendor/backup/ro/notifications.php
+++ b/resources/lang/vendor/backup/ro/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Cu excepția mesajului: :message',
+    'exception_trace' => 'Urmă excepţie: :trace',
+    'exception_message_title' => 'Mesaj de excepție',
+    'exception_trace_title' => 'Urmă excepţie',
+
+    'backup_failed_subject' => 'Nu s-a putut face copie de rezervă pentru :application_name',
+    'backup_failed_body' => 'Important: A apărut o eroare în timpul generării copiei de rezervă pentru :application_name',
+
+    'backup_successful_subject' => 'Copie de rezervă efectuată cu succes pentru :application_name',
+    'backup_successful_subject_title' => 'O nouă copie de rezervă a fost efectuată cu succes!',
+    'backup_successful_body' => 'Vești bune, o nouă copie de rezervă pentru :application_name a fost creată cu succes pe discul cu numele :disk_name.',
+
+    'cleanup_failed_subject' => 'Curățarea copiilor de rezervă pentru :application_name nu a reușit.',
+    'cleanup_failed_body' => 'A apărut o eroare în timpul curățirii copiilor de rezervă pentru :application_name',
+
+    'cleanup_successful_subject' => 'Curățarea copiilor de rezervă pentru :application_name a fost făcută cu succes',
+    'cleanup_successful_subject_title' => 'Curățarea copiilor de rezervă a fost făcută cu succes!',
+    'cleanup_successful_body' => 'Curățarea copiilor de rezervă pentru :application_name de pe discul cu numele :disk_name a fost făcută cu succes.',
+
+    'healthy_backup_found_subject' => 'Copiile de rezervă pentru :application_name de pe discul :disk_name sunt în regulă',
+    'healthy_backup_found_subject_title' => 'Copiile de rezervă pentru :application_name sunt în regulă',
+    'healthy_backup_found_body' => 'Copiile de rezervă pentru :application_name sunt considerate în regulă. Bună treabă!',
+
+    'unhealthy_backup_found_subject' => 'Important: Copiile de rezervă pentru :application_name nu sunt în regulă',
+    'unhealthy_backup_found_subject_title' => 'Important: Copiile de rezervă pentru :application_name nu sunt în regulă. :problem',
+    'unhealthy_backup_found_body' => 'Copiile de rezervă pentru :application_name de pe discul :disk_name nu sunt în regulă.',
+    'unhealthy_backup_found_not_reachable' => 'Nu se poate ajunge la destinația copiilor de rezervă. :error',
+    'unhealthy_backup_found_empty' => 'Nu există copii de rezervă ale acestei aplicații.',
+    'unhealthy_backup_found_old' => 'Cea mai recentă copie de rezervă făcută la :date este considerată prea veche.',
+    'unhealthy_backup_found_unknown' => 'Ne pare rău, un motiv exact nu poate fi determinat.',
+    'unhealthy_backup_found_full' => 'Copiile de rezervă folosesc prea mult spațiu de stocare. Utilizarea curentă este de :disk_usage care este mai mare decât limita permisă de :disk_limit.',
+];

--- a/resources/lang/vendor/backup/ru/notifications.php
+++ b/resources/lang/vendor/backup/ru/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Сообщение об ошибке: :message',
+    'exception_trace' => 'Сведения об ошибке: :trace',
+    'exception_message_title' => 'Сообщение об ошибке',
+    'exception_trace_title' => 'Сведения об ошибке',
+
+    'backup_failed_subject' => 'Не удалось сделать резервную копию :application_name',
+    'backup_failed_body' => 'Внимание: Произошла ошибка во время резервного копирования :application_name',
+
+    'backup_successful_subject' => 'Успешно создана новая резервная копия :application_name',
+    'backup_successful_subject_title' => 'Успешно создана новая резервная копия!',
+    'backup_successful_body' => 'Отличная новость, новая резервная копия :application_name успешно создана и сохранена на диск :disk_name.',
+
+    'cleanup_failed_subject' => 'Не удалось очистить резервные копии :application_name',
+    'cleanup_failed_body' => 'Произошла ошибка при очистке резервных копий :application_name',
+
+    'cleanup_successful_subject' => 'Очистка от резервных копий :application_name прошла успешно',
+    'cleanup_successful_subject_title' => 'Очистка резервных копий прошла удачно!',
+    'cleanup_successful_body' => 'Очистка от старых резервных копий :application_name на диске :disk_name прошла удачно.',
+
+    'healthy_backup_found_subject' => 'Резервная копия :application_name с диска :disk_name установлена',
+    'healthy_backup_found_subject_title' => 'Резервная копия :application_name установлена',
+    'healthy_backup_found_body' => 'Резервная копия :application_name успешно установлена. Хорошая работа!',
+
+    'unhealthy_backup_found_subject' => 'Внимание: резервная копия :application_name не установилась',
+    'unhealthy_backup_found_subject_title' => 'Внимание: резервная копия для :application_name не установилась. :problem',
+    'unhealthy_backup_found_body' => 'Резервная копия для :application_name на диске :disk_name не установилась.',
+    'unhealthy_backup_found_not_reachable' => 'Резервная копия не смогла установиться. :error',
+    'unhealthy_backup_found_empty' => 'Резервные копии для этого приложения отсутствуют.',
+    'unhealthy_backup_found_old' => 'Последнее резервное копирование создано :date является устаревшим.',
+    'unhealthy_backup_found_unknown' => 'Извините, точная причина не может быть определена.',
+    'unhealthy_backup_found_full' => 'Резервные копии используют слишком много памяти. Используется :disk_usage что выше допустимого предела: :disk_limit.',
+];

--- a/resources/lang/vendor/backup/tr/notifications.php
+++ b/resources/lang/vendor/backup/tr/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Hata mesajı: :message',
+    'exception_trace' => 'Hata izleri: :trace',
+    'exception_message_title' => 'Hata mesajı',
+    'exception_trace_title' => 'Hata izleri',
+
+    'backup_failed_subject' => 'Yedeklenemedi :application_name',
+    'backup_failed_body' => 'Önemli: Yedeklenirken bir hata oluştu :application_name',
+
+    'backup_successful_subject' => 'Başarılı :application_name yeni yedeklemesi',
+    'backup_successful_subject_title' => 'Başarılı bir yeni yedekleme!',
+    'backup_successful_body' => 'Harika bir haber, :application_name âit yeni bir yedekleme :disk_name adlı diskte başarıyla oluşturuldu.',
+
+    'cleanup_failed_subject' => ':application_name yedeklemeleri temizlenmesi başarısız.',
+    'cleanup_failed_body' => ':application_name yedeklerini temizlerken bir hata oluştu ',
+
+    'cleanup_successful_subject' => ':application_name yedeklemeleri temizlenmesi başarılı.',
+    'cleanup_successful_subject_title' => 'Yedeklerin temizlenmesi başarılı!',
+    'cleanup_successful_body' => ':application_name yedeklemeleri temizlenmesi ,:disk_name diskinden silindi',
+
+    'healthy_backup_found_subject' => ':application_name yedeklenmesi ,:disk_name adlı diskte sağlıklı',
+    'healthy_backup_found_subject_title' => ':application_name yedeklenmesi sağlıklı',
+    'healthy_backup_found_body' => ':application_name için yapılan yedeklemeler sağlıklı sayılır. Aferin!',
+
+    'unhealthy_backup_found_subject' => 'Önemli: :application_name için yedeklemeler sağlıksız',
+    'unhealthy_backup_found_subject_title' => 'Önemli: :application_name için yedeklemeler sağlıksız. :problem',
+    'unhealthy_backup_found_body' => 'Yedeklemeler: :application_name disk: :disk_name sağlıksız.',
+    'unhealthy_backup_found_not_reachable' => 'Yedekleme hedefine ulaşılamıyor. :error',
+    'unhealthy_backup_found_empty' => 'Bu uygulamanın yedekleri yok.',
+    'unhealthy_backup_found_old' => ':date tarihinde yapılan en son yedekleme çok eski kabul ediliyor.',
+    'unhealthy_backup_found_unknown' => 'Üzgünüm, kesin bir sebep belirlenemiyor.',
+    'unhealthy_backup_found_full' => 'Yedeklemeler çok fazla depolama alanı kullanıyor. Şu anki kullanım: :disk_usage, izin verilen sınırdan yüksek: :disk_limit.',
+];

--- a/resources/lang/vendor/backup/uk/notifications.php
+++ b/resources/lang/vendor/backup/uk/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => 'Повідомлення про помилку: :message',
+    'exception_trace' => 'Деталі помилки: :trace',
+    'exception_message_title' => 'Повідомлення помилки',
+    'exception_trace_title' => 'Деталі помилки',
+
+    'backup_failed_subject' => 'Не вдалось зробити резервну копію :application_name',
+    'backup_failed_body' => 'Увага: Трапилась помилка під час резервного копіювання :application_name',
+
+    'backup_successful_subject' => 'Успішне резервне копіювання :application_name',
+    'backup_successful_subject_title' => 'Успішно створена резервна копія!',
+    'backup_successful_body' => 'Чудова новина, нова резервна копія :application_name успішно створена і збережена на диск :disk_name.',
+
+    'cleanup_failed_subject' => 'Не вдалось очистити резервні копії :application_name',
+    'cleanup_failed_body' => 'Сталася помилка під час очищення резервних копій :application_name',
+
+    'cleanup_successful_subject' => 'Успішне очищення від резервних копій :application_name',
+    'cleanup_successful_subject_title' => 'Очищення резервних копій пройшло вдало!',
+    'cleanup_successful_body' => 'Очищенно від старих резервних копій :application_name на диску :disk_name пойшло успішно.',
+
+    'healthy_backup_found_subject' => 'Резервна копія :application_name з диску :disk_name установлена',
+    'healthy_backup_found_subject_title' => 'Резервна копія :application_name установлена',
+    'healthy_backup_found_body' => 'Резервна копія :application_name успішно установлена. Хороша робота!',
+
+    'unhealthy_backup_found_subject' => 'Увага: резервна копія :application_name не установилась',
+    'unhealthy_backup_found_subject_title' => 'Увага: резервна копія для :application_name не установилась. :problem',
+    'unhealthy_backup_found_body' => 'Резервна копія для :application_name на диску :disk_name не установилась.',
+    'unhealthy_backup_found_not_reachable' => 'Резервна копія не змогла установитись. :error',
+    'unhealthy_backup_found_empty' => 'Резервні копії для цього додатку відсутні.',
+    'unhealthy_backup_found_old' => 'Останнє резервне копіювання створено :date є застарілим.',
+    'unhealthy_backup_found_unknown' => 'Вибачте, але ми не змогли визначити точну причину.',
+    'unhealthy_backup_found_full' => 'Резервні копії використовують занадто багато пам`яті. Використовується :disk_usage що вище за допустиму межу :disk_limit.',
+];

--- a/resources/lang/vendor/backup/zh-CN/notifications.php
+++ b/resources/lang/vendor/backup/zh-CN/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => '异常信息: :message',
+    'exception_trace' => '异常跟踪: :trace',
+    'exception_message_title' => '异常信息',
+    'exception_trace_title' => '异常跟踪',
+
+    'backup_failed_subject' => ':application_name 备份失败',
+    'backup_failed_body' => '重要说明：备份 :application_name 时发生错误',
+
+    'backup_successful_subject' => ':application_name 备份成功',
+    'backup_successful_subject_title' => '备份成功！',
+    'backup_successful_body' => '好消息, :application_name 备份成功，位于磁盘 :disk_name 中。',
+
+    'cleanup_failed_subject' => '清除 :application_name 的备份失败。',
+    'cleanup_failed_body' => '清除备份 :application_name 时发生错误',
+
+    'cleanup_successful_subject' => '成功清除 :application_name 的备份',
+    'cleanup_successful_subject_title' => '成功清除备份！',
+    'cleanup_successful_body' => '成功清除 :disk_name 磁盘上 :application_name 的备份。',
+
+    'healthy_backup_found_subject' => ':disk_name 磁盘上 :application_name 的备份是健康的',
+    'healthy_backup_found_subject_title' => ':application_name 的备份是健康的',
+    'healthy_backup_found_body' => ':application_name 的备份是健康的。干的好！',
+
+    'unhealthy_backup_found_subject' => '重要说明：:application_name 的备份不健康',
+    'unhealthy_backup_found_subject_title' => '重要说明：:application_name 备份不健康。 :problem',
+    'unhealthy_backup_found_body' => ':disk_name 磁盘上 :application_name 的备份不健康。',
+    'unhealthy_backup_found_not_reachable' => '无法访问备份目标。 :error',
+    'unhealthy_backup_found_empty' => '根本没有此应用程序的备份。',
+    'unhealthy_backup_found_old' => '最近的备份创建于 :date ，太旧了。',
+    'unhealthy_backup_found_unknown' => '对不起，确切原因无法确定。',
+    'unhealthy_backup_found_full' => '备份占用了太多存储空间。当前占用了 :disk_usage ，高于允许的限制 :disk_limit。',
+];

--- a/resources/lang/vendor/backup/zh-TW/notifications.php
+++ b/resources/lang/vendor/backup/zh-TW/notifications.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'exception_message' => '異常訊息: :message',
+    'exception_trace' => '異常追蹤: :trace',
+    'exception_message_title' => '異常訊息',
+    'exception_trace_title' => '異常追蹤',
+
+    'backup_failed_subject' => ':application_name 備份失敗',
+    'backup_failed_body' => '重要說明：備份 :application_name 時發生錯誤',
+
+    'backup_successful_subject' => ':application_name 備份成功',
+    'backup_successful_subject_title' => '備份成功！',
+    'backup_successful_body' => '好消息, :application_name 備份成功，位於磁盤 :disk_name 中。',
+
+    'cleanup_failed_subject' => '清除 :application_name 的備份失敗。',
+    'cleanup_failed_body' => '清除備份 :application_name 時發生錯誤',
+
+    'cleanup_successful_subject' => '成功清除 :application_name 的備份',
+    'cleanup_successful_subject_title' => '成功清除備份！',
+    'cleanup_successful_body' => '成功清除 :disk_name 磁盤上 :application_name 的備份。',
+
+    'healthy_backup_found_subject' => ':disk_name 磁盤上 :application_name 的備份是健康的',
+    'healthy_backup_found_subject_title' => ':application_name 的備份是健康的',
+    'healthy_backup_found_body' => ':application_name 的備份是健康的。幹的好！',
+
+    'unhealthy_backup_found_subject' => '重要說明：:application_name 的備份不健康',
+    'unhealthy_backup_found_subject_title' => '重要說明：:application_name 備份不健康。 :problem',
+    'unhealthy_backup_found_body' => ':disk_name 磁盤上 :application_name 的備份不健康。',
+    'unhealthy_backup_found_not_reachable' => '無法訪問備份目標。 :error',
+    'unhealthy_backup_found_empty' => '根本沒有此應用程序的備份。',
+    'unhealthy_backup_found_old' => '最近的備份創建於 :date ，太舊了。',
+    'unhealthy_backup_found_unknown' => '對不起，確切原因無法確定。',
+    'unhealthy_backup_found_full' => '備份佔用了太多存儲空間。當前佔用了 :disk_usage ，高於允許的限制 :disk_limit。',
+];


### PR DESCRIPTION
### Description

[spatie/laravel-backup](https://github.com/spatie/laravel-backup) is a package for automated backup creation.

The default configuration includes the following data in a backup:

- Complete database dump
- `public/uploads`
- `storage/uploads`
- `.env`

I incorporated the data [mentioned in the docs](https://www.bookstackapp.com/docs/admin/backup-restore/).

This does not add any possibility to create backups from the UI. Backups can be created by running the following Artisan command:

```shell
php artisan backup:run
```

If the user wishes he may create a database-only backup:

```shell
php artisan backup:run --only-db
```

I like this package because it lets me create backups with ease and without having to deal with custom scripts. And I'm lazy `¯\_(ツ)_/¯`

### Points to discuss
#### Configuration

The package is highly configurable and I already changed some of the defaults, for example the following:

https://github.com/axelrindle/BookStack/blob/336bd2204614de3f20016e4eb4dc12e1a113ca26/app/Config/backup.php#L119-L122

In my eyes the biggest point to discuss is: should there be anything else to configure via environment variables? I'd say **no** to keep the complexity of the config file small.

#### Restore

The package does not provide the possibility to restore backups which still leaves that up to the user.

> I don't think it'd be worth maintaining such logic in the core project [...]
>
> -- <cite>https://github.com/BookStackApp/BookStack/issues/723#issuecomment-1110220775</cite>

I agree with that.

#### Resources

The packages published a lot of language resources. I'm currently questioning whether they should reside in the application's resources as I don't think there will be any changes to them.

### Relations

I read through the comments in #185, #723 and #2405.

Closes #723, closes #2405.