### PR TITLE
PHP8.2 Support

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['7.4', '8.0', '8.1', '8.2']
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['7.4', '8.0', '8.1', '8.2']
     steps:
     - uses: actions/checkout@v1
 


### PR DESCRIPTION
Early PHP 8.2 support checking to ensure no major issues before release.
PHP7.4 to be dropped in future release. 