### PR TITLE
Add popular PHP templating languages to code editor

### DIFF
--- a/resources/js/code.mjs
+++ b/resources/js/code.mjs
@@ -26,10 +26,12 @@ import 'codemirror/mode/python/python';
 import 'codemirror/mode/ruby/ruby';
 import 'codemirror/mode/rust/rust';
 import 'codemirror/mode/shell/shell';
+import 'codemirror/mode/smarty/smarty';
 import 'codemirror/mode/sql/sql';
 import 'codemirror/mode/stex/stex';
 import 'codemirror/mode/swift/swift';
 import 'codemirror/mode/toml/toml';
+import 'codemirror/mode/twig/twig';
 import 'codemirror/mode/vb/vb';
 import 'codemirror/mode/vbscript/vbscript';
 import 'codemirror/mode/xml/xml';
@@ -94,11 +96,13 @@ const modeMap = {
     rs: 'rust',
     shell: 'shell',
     sh: 'shell',
+    smarty: 'smarty',
     sql: 'text/x-sql',
     stext: 'text/x-stex',
     swift: 'text/x-swift',
     toml: 'toml',
     ts: 'text/typescript',
+    twig: 'twig',
     typescript: 'text/typescript',
     vbs: 'vbscript',
     vbscript: 'vbscript',

--- a/resources/views/pages/parts/code-editor.blade.php
+++ b/resources/views/pages/parts/code-editor.blade.php
@@ -25,8 +25,8 @@
                             $languages = [
                                 'Bash', 'CSS', 'C', 'C++', 'C#', 'Dart', 'Diff', 'Fortran', 'F#', 'Go', 'Haskell', 'HTML', 'INI',
                                 'Java', 'JavaScript', 'JSON', 'Julia', 'Kotlin', 'LaTeX', 'Lua', 'MarkDown', 'MATLAB', 'Nginx', 'OCaml',
-                                'Octave', 'Pascal', 'Perl', 'PHP', 'Powershell', 'Python', 'Ruby', 'Rust', 'Shell', 'SQL', 'Swift',
-                                 'TypeScript', 'VBScript', 'VB.NET', 'XML', 'YAML',
+                                'Octave', 'Pascal', 'Perl', 'PHP', 'Powershell', 'Python', 'Ruby', 'Rust', 'Shell', 'Smarty', 'SQL', 'Swift',
+                                'Twig', 'TypeScript', 'VBScript', 'VB.NET', 'XML', 'YAML',
                             ];
                         @endphp
 


### PR DESCRIPTION
Smarty and Twig are two very popular PHP templating engines and might be useful to some Bookstack users too.