### PR TITLE
WIP: Default page templates

### DIFF
--- a/app/Entities/Models/Book.php
+++ b/app/Entities/Models/Book.php
@@ -27,7 +27,7 @@ class Book extends Entity implements HasCoverImage
 
     public $searchFactor = 1.2;
 
-    protected $fillable = ['name', 'description'];
+    protected $fillable = ['name', 'description', 'default_template'];
     protected $hidden = ['pivot', 'image_id', 'deleted_at'];
 
     /**
@@ -76,6 +76,14 @@ class Book extends Entity implements HasCoverImage
     public function coverImageTypeKey(): string
     {
         return 'cover_book';
+    }
+
+    /**
+     * Get the Page that is used as default template for newly created pages within this Book.
+     */
+    public function defaultTemplate(): BelongsTo
+    {
+        return $this->belongsTo(Page::class, 'default_template');
     }
 
     /**

--- a/app/Entities/Repos/PageRepo.php
+++ b/app/Entities/Repos/PageRepo.php
@@ -148,6 +148,12 @@ class PageRepo
             $page->book_id = $parent->id;
         }
 
+        if ($page->book->defaultTemplate) {
+            $page->forceFill([
+                'html'  => $page->book->defaultTemplate->html,
+            ]);
+        }
+
         $page->save();
         $page->refresh()->rebuildPermissions();
 

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -6,6 +6,7 @@ use BookStack\Actions\ActivityQueries;
 use BookStack\Actions\ActivityType;
 use BookStack\Actions\View;
 use BookStack\Entities\Models\Bookshelf;
+use BookStack\Entities\Models\Page;
 use BookStack\Entities\Repos\BookRepo;
 use BookStack\Entities\Tools\BookContents;
 use BookStack\Entities\Tools\Cloner;
@@ -79,8 +80,14 @@ class BookController extends Controller
 
         $this->setPageTitle(trans('entities.books_create'));
 
+        $templates = Page::visible()
+            ->where('template', '=', true)
+            ->orderBy('name', 'asc')
+            ->get();
+
         return view('books.create', [
             'bookshelf' => $bookshelf,
+            'templates' => $templates,
         ]);
     }
 
@@ -98,6 +105,7 @@ class BookController extends Controller
             'description' => ['string', 'max:1000'],
             'image'       => array_merge(['nullable'], $this->getImageValidationRules()),
             'tags'        => ['array'],
+            'default_template'  => ['nullable', 'exists:pages,id'], 
         ]);
 
         $bookshelf = null;
@@ -151,7 +159,12 @@ class BookController extends Controller
         $this->checkOwnablePermission('book-update', $book);
         $this->setPageTitle(trans('entities.books_edit_named', ['bookName' => $book->getShortName()]));
 
-        return view('books.edit', ['book' => $book, 'current' => $book]);
+        $templates = Page::visible()
+            ->where('template', '=', true)
+            ->orderBy('name', 'asc')
+            ->get();
+
+        return view('books.edit', ['book' => $book, 'current' => $book, 'templates' => $templates]);
     }
 
     /**
@@ -171,6 +184,7 @@ class BookController extends Controller
             'description' => ['string', 'max:1000'],
             'image'       => array_merge(['nullable'], $this->getImageValidationRules()),
             'tags'        => ['array'],
+            'default_template'  => ['nullable', 'exists:pages,id'], 
         ]);
 
         if ($request->has('image_reset')) {

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -74,7 +74,6 @@ class PageController extends Controller
         $page = $this->pageRepo->getNewDraftPage($parent);
         $this->pageRepo->publishDraft($page, [
             'name' => $request->get('name'),
-            'html' => '',
         ]);
 
         return redirect($page->getUrl('/edit'));

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -3,6 +3,7 @@
 namespace BookStack\Http\Controllers;
 
 use BookStack\Actions\View;
+use BookStack\Entities\Models\Book;
 use BookStack\Entities\Models\Page;
 use BookStack\Entities\Repos\PageRepo;
 use BookStack\Entities\Tools\BookContents;
@@ -265,11 +266,13 @@ class PageController extends Controller
         $page = $this->pageRepo->getBySlug($bookSlug, $pageSlug);
         $this->checkOwnablePermission('page-delete', $page);
         $this->setPageTitle(trans('entities.pages_delete_named', ['pageName' => $page->getShortName()]));
+        $times_used_as_template = Book::where('default_template', '=', $page->id)->count();
 
         return view('pages.delete', [
             'book'    => $page->book,
             'page'    => $page,
             'current' => $page,
+            'times_used_as_template' => $times_used_as_template,
         ]);
     }
 

--- a/database/migrations/2022_12_02_104541_add_default_template_to_books.php
+++ b/database/migrations/2022_12_02_104541_add_default_template_to_books.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDefaultTemplateToBooks extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('books', function (Blueprint $table) {
+            $table->integer('default_template')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('books', function (Blueprint $table) {
+            $table->dropColumn('default_template');
+        });
+    }
+}

--- a/resources/lang/en/entities.php
+++ b/resources/lang/en/entities.php
@@ -328,6 +328,8 @@ return [
     'templates_replace_content' => 'Replace page content',
     'templates_append_content' => 'Append to page content',
     'templates_prepend_content' => 'Prepend to page content',
+    'default_template' => 'Default Page Template',
+    'default_template_explain' => "Assign a default template that will be used for all new pages in this book.",
 
     // Profile View
     'profile_user_for_x' => 'User for :time',

--- a/resources/lang/en/entities.php
+++ b/resources/lang/en/entities.php
@@ -192,6 +192,7 @@ return [
     'pages_delete_draft' => 'Delete Draft Page',
     'pages_delete_success' => 'Page deleted',
     'pages_delete_draft_success' => 'Draft page deleted',
+    'pages_delete_warning_template' => '{0}|{1}Be careful: this page is used as a template for :count book.|[2,*]Be careful: this page is used as a template for :count books.',
     'pages_delete_confirm' => 'Are you sure you want to delete this page?',
     'pages_delete_draft_confirm' => 'Are you sure you want to delete this draft page?',
     'pages_editing_named' => 'Editing Page :pageName',

--- a/resources/sass/_forms.scss
+++ b/resources/sass/_forms.scss
@@ -454,7 +454,7 @@ div[editor-type="markdown"] .title-input.page-title input[type="text"] {
   &.flexible input {
     width: 100%;
   }
-  .search-box-cancel {
+  button.search-box-cancel {
     left: auto;
     right: 0;
   }

--- a/resources/views/books/create.blade.php
+++ b/resources/views/books/create.blade.php
@@ -28,7 +28,10 @@
         <main class="content-wrap card">
             <h1 class="list-heading">{{ trans('entities.books_create') }}</h1>
             <form action="{{ isset($bookshelf) ? $bookshelf->getUrl('/create-book') : url('/books') }}" method="POST" enctype="multipart/form-data">
-                @include('books.parts.form', ['returnLocation' => isset($bookshelf) ? $bookshelf->getUrl() : url('/books')])
+                @include('books.parts.form', [
+                    'templates' => $templates, 
+                    'returnLocation' => isset($bookshelf) ? $bookshelf->getUrl() : url('/books')
+                ])
             </form>
         </main>
     </div>

--- a/resources/views/books/edit.blade.php
+++ b/resources/views/books/edit.blade.php
@@ -18,7 +18,11 @@
             <h1 class="list-heading">{{ trans('entities.books_edit') }}</h1>
             <form action="{{ $book->getUrl() }}" method="POST" enctype="multipart/form-data">
                 <input type="hidden" name="_method" value="PUT">
-                @include('books.parts.form', ['model' => $book, 'returnLocation' => $book->getUrl()])
+                @include('books.parts.form', [
+                    'model' => $book, 
+                    'templates' => $templates,
+                    'returnLocation' => $book->getUrl()
+                ])
             </form>
         </main>
 

--- a/resources/views/books/parts/form.blade.php
+++ b/resources/views/books/parts/form.blade.php
@@ -35,6 +35,15 @@
     </div>
 </div>
 
+<div class="form-group collapsible" component="collapsible" id="template-control">
+    <button refs="collapsible@trigger" type="button" class="collapse-title text-primary" aria-expanded="false">
+        <label for="template-manager">{{ trans('entities.default_template') }}</label>
+    </button>
+    <div refs="collapsible@content" class="collapse-content">
+        @include('entities.template-manager', ['entity' => $book ?? null, 'templates' => $templates])
+    </div>
+</div>
+
 <div class="form-group text-right">
     <a href="{{ $returnLocation }}" class="button outline">{{ trans('common.cancel') }}</a>
     <button type="submit" class="button">{{ trans('entities.books_save') }}</button>

--- a/resources/views/entities/template-manager.blade.php
+++ b/resources/views/entities/template-manager.blade.php
@@ -1,0 +1,10 @@
+<p class="text-muted small">
+    {!! nl2br(e(trans('entities.default_template_explain'))) !!}
+</p>
+
+<select name="default_template" id="default_template">
+    <option value="">---</option>
+    @foreach ($templates as $template)
+        <option @if(isset($entity) && $entity->default_template === $template->id) selected @endif value="{{ $template->id }}">{{ $template->name }}</option>
+    @endforeach
+</select>

--- a/resources/views/pages/delete.blade.php
+++ b/resources/views/pages/delete.blade.php
@@ -19,6 +19,9 @@
         <div class="card content-wrap auto-height">
             <h1 class="list-heading">{{ $page->draft ? trans('entities.pages_delete_draft') : trans('entities.pages_delete') }}</h1>
 
+            @if ($times_used_as_template > 0)
+                <p>{{ trans_choice('entities.pages_delete_warning_template', $times_used_as_template) }}</p>
+            @endif
 
             <div class="grid half v-center">
                 <div>

--- a/resources/views/pages/guest-create.blade.php
+++ b/resources/views/pages/guest-create.blade.php
@@ -22,7 +22,7 @@
 
                 <div class="form-group title-input">
                     <label for="name">{{ trans('entities.pages_name') }}</label>
-                    @include('form.text', ['name' => 'name'])
+                    @include('form.text', ['name' => 'name', 'autofocus' => true])
                 </div>
 
                 <div class="form-group text-right">

--- a/resources/views/pages/parts/template-manager.blade.php
+++ b/resources/views/pages/parts/template-manager.blade.php
@@ -14,7 +14,7 @@
     <div class="search-box flexible mb-m" style="display: {{ count($templates) > 0 ? 'block' : 'none' }}">
         <input refs="template-manager@searchInput" type="text" name="template-search" placeholder="{{ trans('common.search') }}">
         <button refs="template-manager@searchButton" tabindex="-1" type="button">@icon('search')</button>
-        <button refs="template-manager@searchCancel" class="search-box-cancel text-neg" type="button" style="display: none">@icon('close')</button>
+        <button refs="template-manager@searchCancel" class="search-box-cancel text-neg" tabindex="-1" type="button" style="display: none">@icon('close')</button>
     </div>
 
     <div refs="template-manager@list">


### PR DESCRIPTION
I took a stab at implementing default page templates as indicated in #1803.

### What I have implemented:
- There's a book-level setting to pick a default template
- A new page automatically copies the template's html on creation
- A new guests page also has the template applied to it
- Deleted pages don't work as a template anymore
- When deleting a page that is used as a default template somewhere, there's a warning on the delete confirmation screen

![image](https://user-images.githubusercontent.com/23380289/207837303-b5f49192-192f-4200-8941-0a13a67ddd3d.png)

![image](https://user-images.githubusercontent.com/23380289/207836843-ee00e031-f101-406e-a72b-9a02a68049aa.png)


### What I haven't fully considered or implemented yet:
- Any permission/scope problems
- If there's a difference in handling HTML vs. markdown templates
- A better selector to pick the default template (pagination, AJAX search) like the one in the book.edit sidebar (template-manager)
- Should other entities also support a default template? _(User, Shelf, Chapter)_ If so, which one has priority when multiple default templates are chosen on different levels?
- Applying a template from a URL parameter (@cod3monk and #3794)


### Random small fixes I came across:
- Autofocus on the name field on guest-create.blade
- Template Manager: fixed cancel icon placement


If anyone with more thorough knowledge of the codebase would like to shine some light onto this PR, that would be great.