### PR TITLE
Changed the way settings are loaded

### DIFF
--- a/tests/Commands/UpdateUrlCommandTest.php
+++ b/tests/Commands/UpdateUrlCommandTest.php
@@ -39,6 +39,8 @@ class UpdateUrlCommandTest extends TestCase
         setting()->put('my-custom-item', 'https://example.com/donkey/cat');
         $this->runUpdate('https://example.com', 'https://cats.example.com');
 
+        setting()->flushCache();
+
         $settingVal = setting('my-custom-item');
         $this->assertEquals('https://cats.example.com/donkey/cat', $settingVal);
     }
@@ -47,6 +49,9 @@ class UpdateUrlCommandTest extends TestCase
     {
         setting()->put('my-custom-array-item', [['name' => 'a https://example.com/donkey/cat url']]);
         $this->runUpdate('https://example.com', 'https://cats.example.com');
+
+        setting()->flushCache();
+
         $settingVal = setting('my-custom-array-item');
         $this->assertEquals('a https://cats.example.com/donkey/cat url', $settingVal[0]['name']);
     }


### PR DESCRIPTION
This new method batch-loads them from the database, and removes the cache-layer with the intention that a couple of batch fetches from the DB is more efficient than hitting the cache each time.