### PR TITLE
Allow a user to disable peer check when using TLS/STARTTLS

### DIFF
--- a/.env.example.complete
+++ b/.env.example.complete
@@ -79,6 +79,7 @@ MAIL_PORT=1025
 MAIL_USERNAME=null
 MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null
+MAIL_VERIFY_PEER=true
 
 # Command to use when email is sent via sendmail
 MAIL_SENDMAIL_COMMAND="/usr/sbin/sendmail -bs"

--- a/app/Config/mail.php
+++ b/app/Config/mail.php
@@ -32,6 +32,7 @@ return [
             'encryption' => env('MAIL_ENCRYPTION', 'tls'),
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
+            'verify_peer' => env('MAIL_VERIFY_PEER', true),
             'timeout' => null,
             'local_domain' => env('MAIL_EHLO_DOMAIN'),
         ],


### PR DESCRIPTION
This is useful when developing and on Docker setups. Despite setting encryption to null, if a server supports STARTTLS with a self-signed certificate, the mailer try to upgrade the connection with STARTTLS.

Fix #3166