### PR TITLE
Add WKHTMLTOPDF to .env.example.complete

### DIFF
--- a/.env.example.complete
+++ b/.env.example.complete
@@ -373,3 +373,9 @@ LOG_FAILED_LOGIN_CHANNEL=errorlog_plain_webserver
 # For the IPv6 address '2001:db8:85a3:8d3:1319:8a2e:370:7348' this would result as:
 # '2001:db8:85a3:8d3:x:x:x:x'
 IP_ADDRESS_PRECISION=4
+
+# Use wkhtmltopdf to generate PDF documents instead of dompdf.
+# Set the path to the wkhtmltopdf binary
+# Example: WKHTMLTOPDF=/home/user/bins/wkhtmltopdf
+# Refer to https://www.bookstackapp.com/docs/admin/pdf-rendering/#using-wkhtmltopdf
+WKHTMLTOPDF=false


### PR DESCRIPTION
The WKHTMLTOPDF environment variable was missing from the .env.example.complete file.
This pull request adds the variable to the file with a commented example path to the wkhtmltopdf binary.

