### PR TITLE
Allow for multiple "aud" values

### DIFF
--- a/app/Auth/Access/Oidc/OidcIdToken.php
+++ b/app/Auth/Access/Oidc/OidcIdToken.php
@@ -180,21 +180,20 @@ class OidcIdToken
         }
 
         $aud = is_string($this->payload['aud']) ? [$this->payload['aud']] : $this->payload['aud'];
-        if (count($aud) !== 1) {
-            throw new OidcInvalidTokenException('Token audience value has ' . count($aud) . ' values, Expected 1');
-        }
-
-        if ($aud[0] !== $clientId) {
-            throw new OidcInvalidTokenException('Token audience value did not match the expected client_id');
-        }
 
         // 3. If the ID Token contains multiple audiences, the Client SHOULD verify that an azp Claim is present.
         // NOTE: Addressed by enforcing a count of 1 above.
 
         // 4. If an azp (authorized party) Claim is present, the Client SHOULD verify that its client_id
         // is the Claim Value.
-        if (isset($this->payload['azp']) && $this->payload['azp'] !== $clientId) {
-            throw new OidcInvalidTokenException('Token authorized party exists but does not match the expected client_id');
+        if (count($aud) !== 1) {
+            if (isset($this->payload['azp']) && $this->payload['azp'] !== $clientId) {
+                throw new OidcInvalidTokenException('Token authorized party exists but does not match the expected client_id');
+            } elseif (!isset($this->payload['azp'])) {
+                throw new OidcInvalidTokenException('Token audience value has ' . count($aud) . ' values, expected 1');
+            }
+        } else {
+            throw new OidcInvalidTokenException('Token audience value did not match the expected client_id');
         }
 
         // 5. The current time MUST be before the time represented by the exp Claim

--- a/app/Auth/Access/Oidc/OidcIdToken.php
+++ b/app/Auth/Access/Oidc/OidcIdToken.php
@@ -180,27 +180,14 @@ class OidcIdToken
 
         $aud = is_string($this->payload['aud']) ? [$this->payload['aud']] : $this->payload['aud'];
 
-        if (count($aud) > 1 && !in_array($clientId, $aud)) {
-            throw new OidcInvalidTokenException('Token audience value did not match the expected client_id');
-        }
-
         // 3. If the ID Token contains multiple audiences, the Client SHOULD verify that an azp Claim is present.
         // 4. If an azp (authorized party) Claim is present, the Client SHOULD verify that its client_id
         // is the Claim Value.
-        if (count($aud) > 0 && isset($this->payload['azp']) && $this->payload['azp'] !== $clientId) {
-            throw new OidcInvalidTokenException('Token authorized party exists but does not match the expected client_id');
-        }
-
-
-
-        if (count($aud) !== 1) {
-            if (isset($this->payload['azp']) && $this->payload['azp'] !== $clientId) {
-                throw new OidcInvalidTokenException('Token authorized party exists but does not match the expected client_id');
-            } elseif (!isset($this->payload['azp'])) {
-                throw new OidcInvalidTokenException('Token audience value has ' . count($aud) . ' values, expected 1');
-            }
-        } else {
+        if (!in_array($clientId, $aud)) {
             throw new OidcInvalidTokenException('Token audience value did not match the expected client_id');
+        }
+        if (count($aud) > 1 && isset($this->payload['azp']) && $this->payload['azp'] !== $clientId) {
+            throw new OidcInvalidTokenException('Token authorized party exists but does not match the expected client_id');
         }
 
         // 5. The current time MUST be before the time represented by the exp Claim


### PR DESCRIPTION
Our oidc authentication endpoint (zitadel) returns multiple audience fields for the user and places the expected value in `azp`.

In `OidcIdToken.php` you were assuming that there can only be one audience, while [RCF 7519](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.3) does not.

I added a check that allows to use `azp` once there are multiple  `aud` values available in the token and the client id is found therein.

<details>
<summary>An example payload of our oicd server looks like this...:</summary>

```
{
  "iss": "https://oicd.example.com",
  "aud": [
    "823417009781275377@oicd",  
    "593371374829733854@oicd",
    "298754342231354326@oicd",       <--- this one is the $clientId
    "207625234567516721@oicd",
    "111111111111111111"
  ],
  "azp": "298754342231354326@oicd",   <---
  "at_hash": "h4ivntmqlr3v43_svT",
  "c_hash": "iv43lw34n4312A7af$_Vzc",

  "amr": [
    "password",
    "pwd",
    "mfa",
    "user"
  ],
  "exp": 1680264155,
  "iat": 1680260555,
  "auth_time": 1680247938,
  "email": "my.email@example.com",
  "email_verified": true,
  "family_name": "Name",
  "given_name": "GivenName",
  "name": "GivenName Name",
  "nickname": "GivenName Name",
  "preferred_username": "my.email@example.com",
  "sub": "111111111111111111",
  "updated_at": 1680255197,
  "urn:zitadel:iam:org:project:roles": {
    "admin": {
      "12345": "oicd.example.com"
    },
    "user": {
      "12345": "oicd.example.com"
    } 
  } 
}
```

</details>