### PR TITLE
Allow roles to be an array

### DIFF
--- a/app/Auth/Access/Oidc/OidcService.php
+++ b/app/Auth/Access/Oidc/OidcService.php
@@ -186,6 +186,11 @@ class OidcService
             return [];
         }
 
+        // Use keys of nested arrays as values here
+        if (gettype(reset($groupsList)) === "array") {
+            $groupsList = array_keys($groupsList);
+        }
+
         return array_values(array_filter($groupsList, function ($val) {
             return is_string($val);
         }));


### PR DESCRIPTION
Our oidc authentication endpoint (ZITADEL) does not return roles as simple array but single arrays per given role.

This pull request contains a simple fix to use the so given role names (keys of subarrays) as expected by BookStack.

An example payload of from ZITADEL looks like this...:

```
{
  "iss": "https://oicd.example.com",
  "aud": [
    "823417009781275377@oicd",  
    "593371374829733854@oicd",
    "298754342231354326@oicd",
    "207625234567516721@oicd",
    "111111111111111111"
  ],
  "azp": "298754342231354326@oicd",
  "at_hash": "h4ivntmqlr3v43_svT",
  "c_hash": "iv43lw34n4312A7af$_Vzc",

  "amr": [
    "password",
    "pwd",
    "mfa",
    "user"
  ],
  "exp": 1680264155,
  "iat": 1680260555,
  "auth_time": 1680247938,
  "email": "my.email@example.com",
  "email_verified": true,
  "family_name": "Name",
  "given_name": "GivenName",
  "name": "GivenName Name",
  "nickname": "GivenName Name",
  "preferred_username": "my.email@example.com",
  "sub": "111111111111111111",
  "updated_at": 1680255197,
  "urn:zitadel:iam:org:project:roles": {  <--- groups scope
    "admin": {                            <--- subarray for role admin: instance=12345, issuer=oicd.example.com
      "12345": "oicd.example.com"
    },
    "user": {
      "12345": "oicd.example.com"
    } 
  } 
}
```