### PR TITLE
Fix timestamp in API docs example response

### DIFF
--- a/dev/api/responses/chapters-list.json
+++ b/dev/api/responses/chapters-list.json
@@ -7,7 +7,7 @@
       "slug": "content-creation",
       "description": "How to create documentation on whatever subject you need to write about.",
       "priority": 3,
-      "created_at": "2019-05-05:",
+      "created_at": "2019-05-05T21:49:56.000000Z",
       "updated_at": "2019-09-28T11:24:23.000000Z",
       "created_by": 1,
       "updated_by": 1,


### PR DESCRIPTION
Hello! The `created_at` timestamp in the API docs seems to be malformed. I inserted the value from `chapters-read.json`.