### PR TITLE
Suggestion issue fixed (#4175) 

### DIFF
--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -218,15 +218,8 @@ class SearchRunner
         $subQuery->where('entity_type', '=', $entity->getMorphClass());
         $subQuery->where(function (Builder $query) use ($terms) {
             foreach ($terms as $inputTerm) {
-                if (strpos($inputTerm, "\\") !== false) {
-                    // if "\\" is found in $inputTerm
-                    $inputTerm = str_repeat($inputTerm, 2);
-                    $query->orWhere('term', 'like', "%$inputTerm%");
-                    $inputTerm = str_repeat($inputTerm, 2);
-                    $query->where('term', 'not like', "%$inputTerm%");
-                } else {
-                    $query->orWhere('term', 'like', "$inputTerm%");
-                }
+                $inputTerm = (strpos($inputTerm, "\\") !== false) ? str_repeat($inputTerm, 2) : $inputTerm;
+                $query->orWhere('term', 'like', ($inputTerm . '%'))->where(function ($query) use ($inputTerm) {$query->where('term', 'not like', ($inputTerm . '%'))->orWhere('term', 'like', ("%" . $inputTerm . "%"));});
             }
         });
         $subQuery->groupBy('entity_type', 'entity_id');

--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -219,7 +219,9 @@ class SearchRunner
         $subQuery->where(function (Builder $query) use ($terms) {
             foreach ($terms as $inputTerm) {
                 $inputTerm = (strpos($inputTerm, "\\") !== false) ? str_repeat($inputTerm, 2) : $inputTerm;
-                $query->orWhere('term', 'like', ($inputTerm . '%'))->where(function ($query) use ($inputTerm) {$query->where('term', 'not like', ($inputTerm . '%'))->orWhere('term', 'like', ("%" . $inputTerm . "%"));});
+                $query->orWhere('term', 'like', ($inputTerm . '%'))->where(function ($query) use ($inputTerm) {
+                    $query->where('term', 'not like', ($inputTerm . '%'))->orWhere('term', 'like', ("%" . $inputTerm . "%"));
+                });
             }
         });
         $subQuery->groupBy('entity_type', 'entity_id');

--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -218,10 +218,8 @@ class SearchRunner
         $subQuery->where('entity_type', '=', $entity->getMorphClass());
         $subQuery->where(function (Builder $query) use ($terms) {
             foreach ($terms as $inputTerm) {
-                $inputTerm = (strpos($inputTerm, "\\") !== false) ? str_repeat($inputTerm, 2) : $inputTerm;
-                $query->orWhere('term', 'like', ($inputTerm . '%'))->where(function ($query) use ($inputTerm) {
-                    $query->where('term', 'not like', ($inputTerm . '%'))->orWhere('term', 'like', ("%" . $inputTerm . "%"));
-                });
+                $inputTerm = (strpos($inputTerm, "\\") !== false) ? str_replace("\\", "\\\\", $inputTerm) : $inputTerm;
+                $query->orWhere('term', 'like', $inputTerm . '%');
             }
         });
         $subQuery->groupBy('entity_type', 'entity_id');

--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -218,7 +218,7 @@ class SearchRunner
         $subQuery->where('entity_type', '=', $entity->getMorphClass());
         $subQuery->where(function (Builder $query) use ($terms) {
             foreach ($terms as $inputTerm) {
-                $inputTerm == "\\"?$inputTerm = str_repeat($inputTerm, 2):"";
+                $inputTerm = ($inputTerm == "\\") ? str_repeat($inputTerm, 2) : $inputTerm;
                 $query->orWhere('term', 'like',"%$inputTerm%");
             }
         });

--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -218,7 +218,7 @@ class SearchRunner
         $subQuery->where('entity_type', '=', $entity->getMorphClass());
         $subQuery->where(function (Builder $query) use ($terms) {
             foreach ($terms as $inputTerm) {
-                $inputTerm = ($inputTerm == "\\") ? str_repeat($inputTerm, 2) : $inputTerm;
+                $inputTerm = ($inputTerm == "\\") ? str_repeat($inputTerm,2) : $inputTerm;
                 $query->orWhere('term', 'like',"%$inputTerm%");
             }
         });

--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -218,8 +218,8 @@ class SearchRunner
         $subQuery->where('entity_type', '=', $entity->getMorphClass());
         $subQuery->where(function (Builder $query) use ($terms) {
             foreach ($terms as $inputTerm) {
-                $inputTerm = ($inputTerm == "\\") ? str_repeat($inputTerm,2) : $inputTerm;
-                $query->orWhere('term', 'like',"%$inputTerm%");
+                $inputTerm = ($inputTerm == "\\") ? str_repeat($inputTerm, 2) : $inputTerm;
+                $query->orWhere('term', 'like', "%$inputTerm%");
             }
         });
         $subQuery->groupBy('entity_type', 'entity_id');

--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -224,7 +224,7 @@ class SearchRunner
                     $query->orWhere('term', 'like', "%$inputTerm%");
                     $inputTerm = str_repeat($inputTerm, 2);
                     $query->where('term', 'not like', "%$inputTerm%");
-                }else{
+                } else {
                     $query->orWhere('term', 'like', "$inputTerm%");
                 }
             }

--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -218,7 +218,8 @@ class SearchRunner
         $subQuery->where('entity_type', '=', $entity->getMorphClass());
         $subQuery->where(function (Builder $query) use ($terms) {
             foreach ($terms as $inputTerm) {
-                $query->orWhere('term', 'like', $inputTerm . '%');
+                $inputTerm == "\\"?$inputTerm = str_repeat($inputTerm, 2):"";
+                $query->orWhere('term', 'like',"%$inputTerm%");
             }
         });
         $subQuery->groupBy('entity_type', 'entity_id');

--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -218,8 +218,15 @@ class SearchRunner
         $subQuery->where('entity_type', '=', $entity->getMorphClass());
         $subQuery->where(function (Builder $query) use ($terms) {
             foreach ($terms as $inputTerm) {
-                $inputTerm = ($inputTerm == "\\") ? str_repeat($inputTerm, 2) : $inputTerm;
-                $query->orWhere('term', 'like', "%$inputTerm%");
+                if (strpos($inputTerm, "\\") !== false) {
+                    // if "\\" is found in $inputTerm
+                    $inputTerm = str_repeat($inputTerm, 2);
+                    $query->orWhere('term', 'like', "%$inputTerm%");
+                    $inputTerm = str_repeat($inputTerm, 2);
+                    $query->where('term', 'not like', "%$inputTerm%");
+                }else{
+                    $query->orWhere('term', 'like', "$inputTerm%");
+                }
             }
         });
         $subQuery->groupBy('entity_type', 'entity_id');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bookstack",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "bookstack",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
1. @LHBL2003 was Identified the [issue](https://github.com/BookStackApp/BookStack/issues/4175). When we give single special character, it does not provide any search result even that character is exists in the Bookstack.

- I checked MYSQL console for why it's happening like this. So I found for that exact query. Single ` \ ` we need to give four `\\\`. Then only it will consider like only one.

![image](https://user-images.githubusercontent.com/57084732/234658453-ef786963-0c5c-4dc2-858d-d0527968f9c8.png)

- Came back to the [code](https://github.com/BookStackApp/BookStack/blob/development/app/Search/SearchRunner.php)

- ``` $inputTerm = ($inputTerm == "\\") ? str_repeat($inputTerm, 2) : $inputTerm; ```

- Added condition for that backslash, then it worked.

2. Also, I noticed that I can't able to get the word called `stack` and the actual word was `Bookstack`. So I modified that query in PHP.

-  `$query->orWhere('term', 'like', $inputTerm. '%');` to  `$query->orWhere('term', 'like', "%$inputTerm%");`

Finally, the issues are resolved :tada:


![image](https://user-images.githubusercontent.com/57084732/234657084-456a863f-f113-419c-b460-06959494fd7e.png)
