### PR TITLE
Added max-width to videos to prevent them escaping the page content area

### DIFF
--- a/resources/sass/_pages.scss
+++ b/resources/sass/_pages.scss
@@ -182,6 +182,10 @@ body.tox-fullscreen, body.markdown-fullscreen {
   .cm-editor {
     margin-bottom: 1.375em;
   }
+
+  video {
+    max-width: 100%;
+  }
 }
 
 // Page content pointers

--- a/resources/sass/_reset.scss
+++ b/resources/sass/_reset.scss
@@ -38,3 +38,6 @@ q {
 table {
   border-collapse: collapse;
   border-spacing: 0; }
+
+video {
+   width: 100%; }

--- a/resources/sass/_reset.scss
+++ b/resources/sass/_reset.scss
@@ -38,6 +38,3 @@ q {
 table {
   border-collapse: collapse;
   border-spacing: 0; }
-
-video {
-   width: 100%; }


### PR DESCRIPTION
This is to prevent that videos included in pages don't exceed the page border. This is to avoid the following issue: 
![image](https://user-images.githubusercontent.com/33733474/234785320-5175b788-cc47-4285-94e3-98809420d928.png)

Which now becomes this:

![image](https://user-images.githubusercontent.com/33733474/234785481-c46a24ad-7809-416d-aa29-bbb05e4cc2d5.png)

I didn't build the project and only added the CSS code into my instance's "head config" but as far as I know this fix should work. 
