### PR TITLE
Modify HttpFetchException flow to log the exception

### DIFF
--- a/app/Exceptions/HttpFetchException.php
+++ b/app/Exceptions/HttpFetchException.php
@@ -2,22 +2,8 @@
 
 namespace BookStack\Exceptions;
 
-class HttpFetchException extends PrettyException
+use Exception;
+
+class HttpFetchException extends Exception
 {
-    /**
-     * Construct exception within BookStack\Uploads\HttpFetcher.
-     */
-    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
-    {
-        parent::__construct($message, $code, $previous);
-
-        if ($previous) {
-            $this->setDetails($previous->getMessage());
-        }
-    }
-
-    public function getStatusCode(): int
-    {
-        return 500;
-    }
 }

--- a/app/Exceptions/HttpFetchException.php
+++ b/app/Exceptions/HttpFetchException.php
@@ -2,8 +2,22 @@
 
 namespace BookStack\Exceptions;
 
-use Exception;
-
-class HttpFetchException extends Exception
+class HttpFetchException extends PrettyException
 {
+    /**
+     * Construct exception within BookStack\Uploads\HttpFetcher.
+     */
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        if ($previous) {
+            $this->setDetails($previous->getMessage());
+        }
+    }
+
+    public function getStatusCode(): int
+    {
+        return 500;
+    }
 }

--- a/app/Uploads/HttpFetcher.php
+++ b/app/Uploads/HttpFetcher.php
@@ -29,7 +29,8 @@ class HttpFetcher
         curl_close($ch);
 
         if ($err) {
-            throw new HttpFetchException($err);
+            $errno = curl_errno($ch);
+            throw new HttpFetchException($err, $errno);
         }
 
         return $data;

--- a/app/Uploads/UserAvatars.php
+++ b/app/Uploads/UserAvatars.php
@@ -33,8 +33,8 @@ class UserAvatars
             $avatar = $this->saveAvatarImage($user);
             $user->avatar()->associate($avatar);
             $user->save();
-        } catch (Exception $e) {
-            Log::error('Failed to save user avatar image');
+        } catch (HttpFetchException $e) {
+            Log::error('Failed to save user avatar image', ['exception' => $e]);
         }
     }
 
@@ -48,8 +48,8 @@ class UserAvatars
             $avatar = $this->createAvatarImageFromData($user, $imageData, $extension);
             $user->avatar()->associate($avatar);
             $user->save();
-        } catch (Exception $e) {
-            Log::error('Failed to save user avatar image');
+        } catch (HttpFetchException $e) {
+            Log::error('Failed to save user avatar image', ['exception' => $e]);
         }
     }
 
@@ -107,14 +107,14 @@ class UserAvatars
     /**
      * Gets an image from url and returns it as a string of image data.
      *
-     * @throws Exception
+     * @throws HttpFetchException
      */
     protected function getAvatarImageData(string $url): string
     {
         try {
             $imageData = $this->http->fetch($url);
         } catch (HttpFetchException $exception) {
-            throw new Exception(trans('errors.cannot_get_image_from_url', ['url' => $url]));
+            throw new HttpFetchException(trans('errors.cannot_get_image_from_url', ['url' => $url]), $exception->getCode(), $exception);
         }
 
         return $imageData;

--- a/app/Uploads/UserAvatars.php
+++ b/app/Uploads/UserAvatars.php
@@ -33,7 +33,7 @@ class UserAvatars
             $avatar = $this->saveAvatarImage($user);
             $user->avatar()->associate($avatar);
             $user->save();
-        } catch (HttpFetchException $e) {
+        } catch (Exception $e) {
             Log::error('Failed to save user avatar image', ['exception' => $e]);
         }
     }
@@ -48,7 +48,7 @@ class UserAvatars
             $avatar = $this->createAvatarImageFromData($user, $imageData, $extension);
             $user->avatar()->associate($avatar);
             $user->save();
-        } catch (HttpFetchException $e) {
+        } catch (Exception $e) {
             Log::error('Failed to save user avatar image', ['exception' => $e]);
         }
     }


### PR DESCRIPTION
Currently, `HttpFetchException` is caught and logged, but without the exception (that would contain the actual curl error):

https://github.com/BookStackApp/BookStack/blob/ec775aec02c0887d5cf2dc23c938a75b7eaf67d2/app/Uploads/UserAvatars.php#L46-L53

In that helper method, the exception is caught and re-thrown, but without the original exception as previous exception:

https://github.com/BookStackApp/BookStack/blob/ec775aec02c0887d5cf2dc23c938a75b7eaf67d2/app/Uploads/UserAvatars.php#L112-L121

The proposed change is to add the exception to the logged message for improved debugging, and to make the exception a `PrettyException` for when it's shown to the user. By using `PrettyException`, the details property is available to show the original (technical) error message, although that may be removed if it should rather not be shown to the user.