### PR TITLE
Change JsonDebugException to Responsable interface

### DIFF
--- a/app/Exceptions/JsonDebugException.php
+++ b/app/Exceptions/JsonDebugException.php
@@ -4,8 +4,9 @@ namespace BookStack\Exceptions;
 
 use Exception;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Contracts\Support\Responsable;
 
-class JsonDebugException extends Exception
+class JsonDebugException extends Exception implements Responsable
 {
     protected array $data;
 
@@ -22,7 +23,7 @@ class JsonDebugException extends Exception
      * Convert this exception into a response.
      * We add a manual data conversion to UTF8 to ensure any binary data is presentable as a JSON string.
      */
-    public function render(): JsonResponse
+    public function toResponse($request): JsonResponse
     {
         $cleaned = mb_convert_encoding($this->data, 'UTF-8');
 


### PR DESCRIPTION
In all other exceptions, when a Response is supposed to be returned, the Responsable interface is used instead of render.

It's a simple small issue that only regards code quality.