### PR TITLE
added toggleable feature to force books to exist in a single shelf

### DIFF
--- a/app/Permissions/PermissionsController.php
+++ b/app/Permissions/PermissionsController.php
@@ -136,6 +136,11 @@ class PermissionsController extends Controller
 
         $this->permissionsUpdater->updateFromPermissionsForm($shelf, $request);
 
+        if(setting()->get('app-force-books-to-shelf'))
+        {
+            $this->copyShelfPermissionsToBooks($slug);
+        }
+
         $this->showSuccessNotification(trans('entities.shelves_permissions_updated'));
 
         return redirect($shelf->getUrl());

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -70,6 +70,7 @@ return [
     'selected_book_not_found' => 'The selected book was not found',
     'selected_book_chapter_not_found' => 'The selected Book or Chapter was not found',
     'guests_cannot_save_drafts' => 'Guests cannot save drafts',
+    'force_book_to_shelf' => 'Books must be created on a shelf',
 
     // Users
     'users_cannot_delete_only_admin' => 'You cannot delete the only admin',

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -46,6 +46,9 @@ return [
     'app_disable_comments' => 'Disable Comments',
     'app_disable_comments_toggle' => 'Disable comments',
     'app_disable_comments_desc' => 'Disables comments across all pages in the application. <br> Existing comments are not shown.',
+    'app_force_book_belong_to_shelf' => 'Force books to belong to a shelf',
+    'app_force_book_belong_to_shelf_toggle' => 'Force books to belong to a shelf',
+    'app_force_book_belong_to_shelf_desc' => 'This setting will force all books to belong to a single shelf. Newly created books will inherit the permissions of the shelf they are created under.',
 
     // Color settings
     'color_scheme' => 'Application Color Scheme',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bookstack",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/resources/views/books/index.blade.php
+++ b/resources/views/books/index.blade.php
@@ -36,7 +36,7 @@
     <div class="actions mb-xl">
         <h5>{{ trans('common.actions') }}</h5>
         <div class="icon-list text-link">
-            @if(user()->can('book-create-all'))
+            @if(!setting('app-force-books-to-shelf') && user()->can('book-create-all'))
                 <a href="{{ url("/create-book") }}" data-shortcut="new" class="icon-list-item">
                     <span>@icon('add')</span>
                     <span>{{ trans('entities.books_create') }}</span>

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -124,7 +124,7 @@
                     <span>{{ trans('common.copy') }}</span>
                 </a>
             @endif
-            @if(userCan('restrictions-manage', $book))
+            @if(userCan('restrictions-manage', $book) && !setting('app-force-books-to-shelf'))
                 <a href="{{ $book->getUrl('/permissions') }}" data-shortcut="permissions" class="icon-list-item">
                     <span>@icon('lock')</span>
                     <span>{{ trans('entities.permissions') }}</span>

--- a/resources/views/settings/features.blade.php
+++ b/resources/views/settings/features.blade.php
@@ -56,6 +56,20 @@
                 </div>
             </div>
 
+            <div class="grid half gap-xl">
+                <div>
+                    <label class="setting-list-label">{{ trans('settings.app_force_book_belong_to_shelf') }}</label>
+                    <p class="small">{!! trans('settings.app_force_book_belong_to_shelf_desc') !!}</p>
+                </div>
+                <div>
+                    @include('form.toggle-switch', [
+                        'name' => 'setting-app-force-books-to-shelf',
+                        'value' => setting('app-force-books-to-shelf'),
+                        'label' => trans('settings.app_force_book_belong_to_shelf_toggle'),
+                    ])
+                </div>
+            </div>
+
 
         </div>
 

--- a/resources/views/shelves/show.blade.php
+++ b/resources/views/shelves/show.blade.php
@@ -111,7 +111,7 @@
         <h5>{{ trans('common.actions') }}</h5>
         <div class="icon-list text-link">
 
-            @if(userCan('book-create-all') && userCan('bookshelf-update', $shelf))
+            @if(userCan('bookshelf-update', $shelf))
                 <a href="{{ $shelf->getUrl('/create-book') }}" data-shortcut="new" class="icon-list-item">
                     <span class="icon">@icon('add')</span>
                     <span>{{ trans('entities.books_new_action') }}</span>


### PR DESCRIPTION
My goal was to implement this in a way that was not disruptive to the m:m relationship between books and shelves. This change caters to larger organizations that want to be more restrictive in how users (or teams) can interact with books and shelves within their own domain. 

- Books will only exist on a single shelf
- Newly created books will automatically inherit the permissions of the shelf they were created on

If the feature is enabled:
- Create Book link is hidden from the books/index view (I wanted this to allow the user to select a shelf, but thought that might create more disruption than value)
- Permissions link is hidden from the books/show view
- Books can only be created from the "Shelf" view
- Users still require 'book-create-all' to be able to create books