### PR TITLE
Comments: Added extra comment-specific activities

### DIFF
--- a/app/Activity/ActivityType.php
+++ b/app/Activity/ActivityType.php
@@ -27,6 +27,10 @@ class ActivityType
     const BOOKSHELF_DELETE = 'bookshelf_delete';
 
     const COMMENTED_ON = 'commented_on';
+    const COMMENT_CREATE = 'comment_create';
+    const COMMENT_UPDATE = 'comment_update';
+    const COMMENT_DELETE = 'comment_delete';
+
     const PERMISSIONS_UPDATE = 'permissions_update';
 
     const REVISION_RESTORE = 'revision_restore';

--- a/app/Activity/CommentRepo.php
+++ b/app/Activity/CommentRepo.php
@@ -33,6 +33,7 @@ class CommentRepo
         $comment->parent_id = $parent_id;
 
         $entity->comments()->save($comment);
+        ActivityService::add(ActivityType::COMMENT_CREATE, $comment);
         ActivityService::add(ActivityType::COMMENTED_ON, $entity);
 
         return $comment;
@@ -48,6 +49,8 @@ class CommentRepo
         $comment->html = $this->commentToHtml($text);
         $comment->save();
 
+        ActivityService::add(ActivityType::COMMENT_UPDATE, $comment);
+
         return $comment;
     }
 
@@ -57,6 +60,8 @@ class CommentRepo
     public function delete(Comment $comment): void
     {
         $comment->delete();
+
+        ActivityService::add(ActivityType::COMMENT_DELETE, $comment);
     }
 
     /**

--- a/app/Activity/Models/Comment.php
+++ b/app/Activity/Models/Comment.php
@@ -13,8 +13,10 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * @property string   $html
  * @property int|null $parent_id
  * @property int      $local_id
+ * @property string   $entity_type
+ * @property int      $entity_id
  */
-class Comment extends Model
+class Comment extends Model implements Loggable
 {
     use HasFactory;
     use HasCreatorAndUpdater;
@@ -56,5 +58,10 @@ class Comment extends Model
     public function getUpdatedAttribute()
     {
         return $this->updated_at->diffForHumans();
+    }
+
+    public function logDescriptor(): string
+    {
+        return "Comment #{$this->local_id} (ID: {$this->id}) for {$this->entity_type} (ID: {$this->entity_id})";
     }
 }

--- a/app/Activity/Tools/ActivityLogger.php
+++ b/app/Activity/Tools/ActivityLogger.php
@@ -6,6 +6,7 @@ use BookStack\Activity\DispatchWebhookJob;
 use BookStack\Activity\Models\Activity;
 use BookStack\Activity\Models\Loggable;
 use BookStack\Activity\Models\Webhook;
+use BookStack\App\Model;
 use BookStack\Entities\Models\Entity;
 use BookStack\Facades\Theme;
 use BookStack\Theming\ThemeEvents;
@@ -16,8 +17,6 @@ class ActivityLogger
 {
     /**
      * Add a generic activity event to the database.
-     *
-     * @param string|Loggable $detail
      */
     public function add(string $type, $detail = '')
     {
@@ -55,7 +54,7 @@ class ActivityLogger
      * and instead uses the 'extra' field with the entities name.
      * Used when an entity is deleted.
      */
-    public function removeEntity(Entity $entity)
+    public function removeEntity(Entity $entity): void
     {
         $entity->activity()->update([
             'detail'       => $entity->name,
@@ -76,10 +75,7 @@ class ActivityLogger
         }
     }
 
-    /**
-     * @param string|Loggable $detail
-     */
-    protected function dispatchWebhooks(string $type, $detail): void
+    protected function dispatchWebhooks(string $type, string|Loggable $detail): void
     {
         $webhooks = Webhook::query()
             ->whereHas('trackedEvents', function (Builder $query) use ($type) {
@@ -98,7 +94,7 @@ class ActivityLogger
      * Log out a failed login attempt, Providing the given username
      * as part of the message if the '%u' string is used.
      */
-    public function logFailedLogin(string $username)
+    public function logFailedLogin(string $username): void
     {
         $message = config('logging.failed_login.message');
         if (!$message) {

--- a/lang/en/activities.php
+++ b/lang/en/activities.php
@@ -110,7 +110,12 @@ return [
     'recycle_bin_restore' => 'restored from recycle bin',
     'recycle_bin_destroy' => 'removed from recycle bin',
 
-    // Other
+    // Comments
     'commented_on'                => 'commented on',
+    'comment_create'              => 'added comment',
+    'comment_update'              => 'updated comment',
+    'comment_delete'              => 'deleted comment',
+
+    // Other
     'permissions_update'          => 'updated permissions',
 ];

--- a/tests/Entity/CommentTest.php
+++ b/tests/Entity/CommentTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Entity;
 
+use BookStack\Activity\ActivityType;
 use BookStack\Activity\Models\Comment;
 use BookStack\Entities\Models\Page;
 use Tests\TestCase;
@@ -29,6 +30,8 @@ class CommentTest extends TestCase
             'text'        => $comment->text,
             'parent_id'   => 2,
         ]);
+
+        $this->assertActivityExists(ActivityType::COMMENT_CREATE);
     }
 
     public function test_comment_edit()
@@ -53,6 +56,8 @@ class CommentTest extends TestCase
             'text'      => $newText,
             'entity_id' => $page->id,
         ]);
+
+        $this->assertActivityExists(ActivityType::COMMENT_UPDATE);
     }
 
     public function test_comment_delete()
@@ -71,6 +76,8 @@ class CommentTest extends TestCase
         $this->assertDatabaseMissing('comments', [
             'id' => $comment->id,
         ]);
+
+        $this->assertActivityExists(ActivityType::COMMENT_DELETE);
     }
 
     public function test_comments_converts_markdown_input_to_html()


### PR DESCRIPTION
Kept existing "COMMENTED_ON" activity for upgrade compatibility, specifically for existing webhook usage and for showing comment activities in activity lists.

Precursor to content notifications.

### Todo

- [x] Cover with, or update existing, testing.