### PR TITLE
OIDC: Add RP-initiated logout implementation

### DIFF
--- a/.env.example.complete
+++ b/.env.example.complete
@@ -274,6 +274,10 @@ OIDC_GROUPS_CLAIM=groups
 OIDC_REMOVE_FROM_GROUPS=false
 OIDC_EXTERNAL_ID_CLAIM=sub
 
+# OIDC Logout Feature: Its value should be value of end_session_endpoint from <issuer>/.well-known/openid-configuration 
+OIDC_END_SESSION_ENDPOINT=null
+
+
 # Disable default third-party services such as Gravatar and Draw.IO
 # Service-specific options will override this option
 DISABLE_EXTERNAL_SERVICES=false

--- a/app/Access/Controllers/OidcController.php
+++ b/app/Access/Controllers/OidcController.php
@@ -63,4 +63,18 @@ class OidcController extends Controller
 
         return redirect()->intended();
     }
+
+    /**
+     * OIDC Logout Feature: Start the authorization logout flow via OIDC.
+     */
+    public function logout()
+    {
+        try {
+            return $this->oidcService->logout();
+        } catch (OidcException $exception) {
+            $this->showErrorNotification($exception->getMessage());
+            return redirect('/logout');
+        }
+    }
+
 }

--- a/app/Access/Oidc/OidcService.php
+++ b/app/Access/Oidc/OidcService.php
@@ -301,7 +301,7 @@ class OidcService
     public function logout() {
 
         $config = $this->config();
-        $app_url = env('APP_URL', null);
+        $app_url = env('APP_URL', '');
         $end_session_endpoint = $config["end_session_endpoint"];
 
         $oidctoken = session()->get("oidctoken");

--- a/app/Config/oidc.php
+++ b/app/Config/oidc.php
@@ -47,4 +47,9 @@ return [
     'groups_claim' => env('OIDC_GROUPS_CLAIM', 'groups'),
     // When syncing groups, remove any groups that no longer match. Otherwise sync only adds new groups.
     'remove_from_groups' => env('OIDC_REMOVE_FROM_GROUPS', false),
+
+    // OIDC Logout Feature: OAuth2 end_session_endpoint
+    'end_session_endpoint' => env('OIDC_END_SESSION_ENDPOINT', null),
+
 ];
+

--- a/resources/views/common/header.blade.php
+++ b/resources/views/common/header.blade.php
@@ -93,8 +93,22 @@
                             </a>
                         </li>
                         <li>
+<?php
+// OIDC Logout Feature: Use /oidc/logout if authentication method is oidc.
+if (config('auth.method') === 'oidc')  {
+?>
+                            <form action="/oidc/logout"
+                                  method="get">
+<?php
+// OIDC Logout Feature: Use /oidc/logout if authentication method is oidc.
+} else {
+?>
                             <form action="{{ url(config('auth.method') === 'saml2' ? '/saml2/logout' : '/logout') }}"
                                   method="post">
+<?php
+// OIDC Logout Feature: Use /oidc/logout if authentication method is oidc.
+}
+?>
                                 {{ csrf_field() }}
                                 <button class="icon-item" data-shortcut="logout">
                                     @icon('logout')

--- a/routes/web.php
+++ b/routes/web.php
@@ -323,6 +323,8 @@ Route::get('/saml2/acs', [AccessControllers\Saml2Controller::class, 'processAcs'
 // OIDC routes
 Route::post('/oidc/login', [AccessControllers\OidcController::class, 'login']);
 Route::get('/oidc/callback', [AccessControllers\OidcController::class, 'callback']);
+// OIDC Logout Feature: Added to cater OIDC logout
+Route::get('/oidc/logout', [AccessControllers\OidcController::class, 'logout']);
 
 // User invitation routes
 Route::get('/register/invite/{token}', [AccessControllers\UserInviteController::class, 'showSetPassword']);


### PR DESCRIPTION
#### Reference Issues/PRS: 3715

https://github.com/BookStackApp/BookStack/issues/3715

#### What does this implement/fix? Explain your changes.

If the authentication is through an OIDC provider, this change also logs the user out of the provider as well when the user clicks on "Logout" on Bookstack.

Please add the parameter OIDC_END_SESSION_ENDPOINT in .env file based on end_session_endpoint from <issuer>/.well-known/openid-configuration
e.g.
OIDC_END_SESSION_ENDPOINT=

#### Any other comments?

No