### PR TITLE
Notifications: User language for notification text

### DIFF
--- a/app/Activity/Notifications/MessageParts/LinkedMailMessageLine.php
+++ b/app/Activity/Notifications/MessageParts/LinkedMailMessageLine.php
@@ -3,13 +3,14 @@
 namespace BookStack\Activity\Notifications\MessageParts;
 
 use Illuminate\Contracts\Support\Htmlable;
+use Stringable;
 
 /**
  * A line of text with linked text included, intended for use
  * in MailMessages. The line should have a ':link' placeholder for
  * where the link should be inserted within the line.
  */
-class LinkedMailMessageLine implements Htmlable
+class LinkedMailMessageLine implements Htmlable, Stringable
 {
     public function __construct(
         protected string $url,
@@ -22,5 +23,11 @@ class LinkedMailMessageLine implements Htmlable
     {
         $link = '<a href="' . e($this->url) . '">' . e($this->linkText) . '</a>';
         return str_replace(':link', $link, e($this->line));
+    }
+
+    public function __toString(): string
+    {
+        $link = "{$this->linkText} ({$this->url})";
+        return str_replace(':link', $link, $this->line);
     }
 }

--- a/app/Activity/Notifications/MessageParts/ListMessageLine.php
+++ b/app/Activity/Notifications/MessageParts/ListMessageLine.php
@@ -3,12 +3,13 @@
 namespace BookStack\Activity\Notifications\MessageParts;
 
 use Illuminate\Contracts\Support\Htmlable;
+use Stringable;
 
 /**
  * A bullet point list of content, where the keys of the given list array
  * are bolded header elements, and the values follow.
  */
-class ListMessageLine implements Htmlable
+class ListMessageLine implements Htmlable, Stringable
 {
     public function __construct(
         protected array $list
@@ -22,5 +23,14 @@ class ListMessageLine implements Htmlable
             $list[] = '<strong>' . e($header) . '</strong> ' . e($content);
         }
         return implode("<br>\n", $list);
+    }
+
+    public function __toString(): string
+    {
+        $list = [];
+        foreach ($this->list as $header => $content) {
+            $list[] = $header . ' ' . $content;
+        }
+        return implode("\n", $list);
     }
 }

--- a/app/Activity/Notifications/Messages/BaseActivityNotification.php
+++ b/app/Activity/Notifications/Messages/BaseActivityNotification.php
@@ -4,12 +4,11 @@ namespace BookStack\Activity\Notifications\Messages;
 
 use BookStack\Activity\Models\Loggable;
 use BookStack\Activity\Notifications\MessageParts\LinkedMailMessageLine;
+use BookStack\Notifications\MailNotification;
 use BookStack\Users\Models\User;
 use Illuminate\Bus\Queueable;
-use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
 
-abstract class BaseActivityNotification extends Notification
+abstract class BaseActivityNotification extends MailNotification
 {
     use Queueable;
 
@@ -18,22 +17,6 @@ abstract class BaseActivityNotification extends Notification
         protected User $user,
     ) {
     }
-
-    /**
-     * Get the notification's delivery channels.
-     *
-     * @param  mixed  $notifiable
-     * @return array
-     */
-    public function via($notifiable)
-    {
-        return ['mail'];
-    }
-
-    /**
-     * Get the mail representation of the notification.
-     */
-    abstract public function toMail(mixed $notifiable): MailMessage;
 
     /**
      * Get the array representation of the notification.
@@ -52,12 +35,12 @@ abstract class BaseActivityNotification extends Notification
     /**
      * Build the common reason footer line used in mail messages.
      */
-    protected function buildReasonFooterLine(): LinkedMailMessageLine
+    protected function buildReasonFooterLine(string $language): LinkedMailMessageLine
     {
         return new LinkedMailMessageLine(
             url('/preferences/notifications'),
-            trans('notifications.footer_reason'),
-            trans('notifications.footer_reason_link'),
+            trans('notifications.footer_reason', [], $language),
+            trans('notifications.footer_reason_link', [], $language),
         );
     }
 }

--- a/app/Activity/Notifications/Messages/CommentCreationNotification.php
+++ b/app/Activity/Notifications/Messages/CommentCreationNotification.php
@@ -5,26 +5,29 @@ namespace BookStack\Activity\Notifications\Messages;
 use BookStack\Activity\Models\Comment;
 use BookStack\Activity\Notifications\MessageParts\ListMessageLine;
 use BookStack\Entities\Models\Page;
+use BookStack\Users\Models\User;
 use Illuminate\Notifications\Messages\MailMessage;
 
 class CommentCreationNotification extends BaseActivityNotification
 {
-    public function toMail(mixed $notifiable): MailMessage
+    public function toMail(User $notifiable): MailMessage
     {
         /** @var Comment $comment */
         $comment = $this->detail;
         /** @var Page $page */
         $page = $comment->entity;
 
-        return (new MailMessage())
-            ->subject(trans('notifications.new_comment_subject', ['pageName' => $page->getShortName()]))
-            ->line(trans('notifications.new_comment_intro', ['appName' => setting('app-name')]))
+        $language = $notifiable->getLanguage();
+
+        return $this->newMailMessage($language)
+            ->subject(trans('notifications.new_comment_subject', ['pageName' => $page->getShortName()], $language))
+            ->line(trans('notifications.new_comment_intro', ['appName' => setting('app-name')], $language))
             ->line(new ListMessageLine([
-                trans('notifications.detail_page_name') => $page->name,
-                trans('notifications.detail_commenter') => $this->user->name,
-                trans('notifications.detail_comment') => strip_tags($comment->html),
+                trans('notifications.detail_page_name', [], $language) => $page->name,
+                trans('notifications.detail_commenter', [], $language) => $this->user->name,
+                trans('notifications.detail_comment', [], $language) => strip_tags($comment->html),
             ]))
-            ->action(trans('notifications.action_view_comment'), $page->getUrl('#comment' . $comment->local_id))
-            ->line($this->buildReasonFooterLine());
+            ->action(trans('notifications.action_view_comment', [], $language), $page->getUrl('#comment' . $comment->local_id))
+            ->line($this->buildReasonFooterLine($language));
     }
 }

--- a/app/Activity/Notifications/Messages/PageCreationNotification.php
+++ b/app/Activity/Notifications/Messages/PageCreationNotification.php
@@ -4,23 +4,26 @@ namespace BookStack\Activity\Notifications\Messages;
 
 use BookStack\Activity\Notifications\MessageParts\ListMessageLine;
 use BookStack\Entities\Models\Page;
+use BookStack\Users\Models\User;
 use Illuminate\Notifications\Messages\MailMessage;
 
 class PageCreationNotification extends BaseActivityNotification
 {
-    public function toMail(mixed $notifiable): MailMessage
+    public function toMail(User $notifiable): MailMessage
     {
         /** @var Page $page */
         $page = $this->detail;
 
-        return (new MailMessage())
-            ->subject(trans('notifications.new_page_subject', ['pageName' => $page->getShortName()]))
-            ->line(trans('notifications.new_page_intro', ['appName' => setting('app-name')]))
+        $language = $notifiable->getLanguage();
+
+        return $this->newMailMessage($language)
+            ->subject(trans('notifications.new_page_subject', ['pageName' => $page->getShortName()], $language))
+            ->line(trans('notifications.new_page_intro', ['appName' => setting('app-name')], $language))
             ->line(new ListMessageLine([
-                trans('notifications.detail_page_name') => $page->name,
-                trans('notifications.detail_created_by') => $this->user->name,
+                trans('notifications.detail_page_name', [], $language) => $page->name,
+                trans('notifications.detail_created_by', [], $language) => $this->user->name,
             ]))
-            ->action(trans('notifications.action_view_page'), $page->getUrl())
-            ->line($this->buildReasonFooterLine());
+            ->action(trans('notifications.action_view_page', [], $language), $page->getUrl())
+            ->line($this->buildReasonFooterLine($language));
     }
 }

--- a/app/Activity/Notifications/Messages/PageUpdateNotification.php
+++ b/app/Activity/Notifications/Messages/PageUpdateNotification.php
@@ -4,24 +4,27 @@ namespace BookStack\Activity\Notifications\Messages;
 
 use BookStack\Activity\Notifications\MessageParts\ListMessageLine;
 use BookStack\Entities\Models\Page;
+use BookStack\Users\Models\User;
 use Illuminate\Notifications\Messages\MailMessage;
 
 class PageUpdateNotification extends BaseActivityNotification
 {
-    public function toMail(mixed $notifiable): MailMessage
+    public function toMail(User $notifiable): MailMessage
     {
         /** @var Page $page */
         $page = $this->detail;
 
-        return (new MailMessage())
-            ->subject(trans('notifications.updated_page_subject', ['pageName' => $page->getShortName()]))
-            ->line(trans('notifications.updated_page_intro', ['appName' => setting('app-name')]))
+        $language = $notifiable->getLanguage();
+
+        return $this->newMailMessage($language)
+            ->subject(trans('notifications.updated_page_subject', ['pageName' => $page->getShortName()], $language))
+            ->line(trans('notifications.updated_page_intro', ['appName' => setting('app-name')], $language))
             ->line(new ListMessageLine([
-                trans('notifications.detail_page_name') => $page->name,
-                trans('notifications.detail_updated_by') => $this->user->name,
+                trans('notifications.detail_page_name', [], $language) => $page->name,
+                trans('notifications.detail_updated_by', [], $language) => $this->user->name,
             ]))
-            ->line(trans('notifications.updated_page_debounce'))
-            ->action(trans('notifications.action_view_page'), $page->getUrl())
-            ->line($this->buildReasonFooterLine());
+            ->line(trans('notifications.updated_page_debounce', [], $language))
+            ->action(trans('notifications.action_view_page', [], $language), $page->getUrl())
+            ->line($this->buildReasonFooterLine($language));
     }
 }

--- a/app/Notifications/ConfirmEmail.php
+++ b/app/Notifications/ConfirmEmail.php
@@ -2,28 +2,17 @@
 
 namespace BookStack\Notifications;
 
+use BookStack\Users\Models\User;
+use Illuminate\Notifications\Messages\MailMessage;
+
 class ConfirmEmail extends MailNotification
 {
-    public $token;
-
-    /**
-     * Create a new notification instance.
-     *
-     * @param string $token
-     */
-    public function __construct($token)
-    {
-        $this->token = $token;
+    public function __construct(
+        public string $token
+    ) {
     }
 
-    /**
-     * Get the mail representation of the notification.
-     *
-     * @param mixed $notifiable
-     *
-     * @return \Illuminate\Notifications\Messages\MailMessage
-     */
-    public function toMail($notifiable)
+    public function toMail(User $notifiable): MailMessage
     {
         $appName = ['appName' => setting('app-name')];
 

--- a/app/Notifications/MailNotification.php
+++ b/app/Notifications/MailNotification.php
@@ -2,14 +2,20 @@
 
 namespace BookStack\Notifications;
 
+use BookStack\Users\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class MailNotification extends Notification implements ShouldQueue
+abstract class MailNotification extends Notification implements ShouldQueue
 {
     use Queueable;
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    abstract public function toMail(User $notifiable): MailMessage;
 
     /**
      * Get the notification's channels.
@@ -25,14 +31,14 @@ class MailNotification extends Notification implements ShouldQueue
 
     /**
      * Create a new mail message.
-     *
-     * @return MailMessage
      */
-    protected function newMailMessage()
+    protected function newMailMessage(string $language = ''): MailMessage
     {
+        $data = ['language' => $language ?: null];
+
         return (new MailMessage())->view([
             'html' => 'vendor.notifications.email',
             'text' => 'vendor.notifications.email-plain',
-        ]);
+        ], $data);
     }
 }

--- a/app/Notifications/ResetPassword.php
+++ b/app/Notifications/ResetPassword.php
@@ -2,31 +2,17 @@
 
 namespace BookStack\Notifications;
 
+use BookStack\Users\Models\User;
+use Illuminate\Notifications\Messages\MailMessage;
+
 class ResetPassword extends MailNotification
 {
-    /**
-     * The password reset token.
-     *
-     * @var string
-     */
-    public $token;
-
-    /**
-     * Create a notification instance.
-     *
-     * @param string $token
-     */
-    public function __construct($token)
-    {
-        $this->token = $token;
+    public function __construct(
+        public string $token
+    ) {
     }
 
-    /**
-     * Build the mail representation of the notification.
-     *
-     * @return \Illuminate\Notifications\Messages\MailMessage
-     */
-    public function toMail()
+    public function toMail(User $notifiable): MailMessage
     {
         return $this->newMailMessage()
             ->subject(trans('auth.email_reset_subject', ['appName' => setting('app-name')]))

--- a/app/Notifications/TestEmail.php
+++ b/app/Notifications/TestEmail.php
@@ -2,16 +2,12 @@
 
 namespace BookStack\Notifications;
 
+use BookStack\Users\Models\User;
+use Illuminate\Notifications\Messages\MailMessage;
+
 class TestEmail extends MailNotification
 {
-    /**
-     * Get the mail representation of the notification.
-     *
-     * @param mixed $notifiable
-     *
-     * @return \Illuminate\Notifications\Messages\MailMessage
-     */
-    public function toMail($notifiable)
+    public function toMail(User $notifiable): MailMessage
     {
         return $this->newMailMessage()
                 ->subject(trans('settings.maint_send_test_email_mail_subject'))

--- a/app/Notifications/UserInvite.php
+++ b/app/Notifications/UserInvite.php
@@ -7,25 +7,17 @@ use Illuminate\Notifications\Messages\MailMessage;
 
 class UserInvite extends MailNotification
 {
-    public $token;
-
-    /**
-     * Create a new notification instance.
-     */
-    public function __construct(string $token)
-    {
-        $this->token = $token;
+    public function __construct(
+        public string $token
+    ) {
     }
 
-    /**
-     * Get the mail representation of the notification.
-     */
     public function toMail(User $notifiable): MailMessage
     {
         $appName = ['appName' => setting('app-name')];
-        $language = setting()->getUser($notifiable, 'language');
+        $language = $notifiable->getLanguage();
 
-        return $this->newMailMessage()
+        return $this->newMailMessage($language)
                 ->subject(trans('auth.user_invite_email_subject', $appName, $language))
                 ->greeting(trans('auth.user_invite_email_greeting', $appName, $language))
                 ->line(trans('auth.user_invite_email_text', [], $language))

--- a/app/Translation/LanguageManager.php
+++ b/app/Translation/LanguageManager.php
@@ -2,6 +2,7 @@
 
 namespace BookStack\Translation;
 
+use BookStack\Users\Models\User;
 use Illuminate\Http\Request;
 
 class LanguageManager
@@ -77,6 +78,15 @@ class LanguageManager
             return $this->autoDetectLocale($request, $default);
         }
 
+        return setting()->getUser($user, 'language', $default);
+    }
+
+    /**
+     * Get the language for the given user.
+     */
+    public function getLanguageForUser(User $user): string
+    {
+        $default = config('app.locale');
         return setting()->getUser($user, 'language', $default);
     }
 

--- a/app/Users/Models/User.php
+++ b/app/Users/Models/User.php
@@ -11,6 +11,7 @@ use BookStack\App\Model;
 use BookStack\App\Sluggable;
 use BookStack\Entities\Tools\SlugGenerator;
 use BookStack\Notifications\ResetPassword;
+use BookStack\Translation\LanguageManager;
 use BookStack\Uploads\Image;
 use Carbon\Carbon;
 use Exception;
@@ -336,6 +337,14 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         }
 
         return '';
+    }
+
+    /**
+     * Get the system language for this user.
+     */
+    public function getLanguage(): string
+    {
+        return app()->make(LanguageManager::class)->getLanguageForUser($this);
     }
 
     /**

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,6 +21,7 @@
     <server name="APP_AUTO_LANG_PUBLIC" value="true"/>
     <server name="APP_URL" value="http://bookstack.dev"/>
     <server name="ALLOWED_IFRAME_HOSTS" value=""/>
+    <server name="ALLOWED_SSR_HOSTS" value="*"/>
     <server name="CACHE_DRIVER" value="array"/>
     <server name="SESSION_DRIVER" value="array"/>
     <server name="QUEUE_CONNECTION" value="sync"/>

--- a/resources/views/vendor/notifications/email.blade.php
+++ b/resources/views/vendor/notifications/email.blade.php
@@ -159,7 +159,7 @@ $style = [
                                                             <tr>
                                                                 <td style="{{ $fontFamily }}">
                                                                     <p style="{{ $style['paragraph-sub'] }}">
-                                                                        {{ trans('common.email_action_help', ['actionText' => $actionText]) }}
+                                                                        {{ trans('common.email_action_help', ['actionText' => $actionText], $language) }}
                                                                     </p>
 
                                                                     <p style="{{ $style['paragraph-sub'] }}">
@@ -187,7 +187,7 @@ $style = [
                                                     <p style="{{ $style['paragraph-sub'] }}">
                                                         &copy; {{ date('Y') }}
                                                         <a style="{{ $style['anchor'] }}" href="{{ url('/') }}" target="_blank">{{ setting('app-name') }}</a>.
-                                                        {{ trans('common.email_rights') }}
+                                                        {{ trans('common.email_rights', [], $language) }}
                                                     </p>
                                                 </td>
                                             </tr>

--- a/tests/Activity/WatchTest.php
+++ b/tests/Activity/WatchTest.php
@@ -257,7 +257,7 @@ class WatchTest extends TestCase
 
         $notifications->assertSentTo($editor, function (CommentCreationNotification $notification) use ($editor, $admin, $entities) {
             $mail = $notification->toMail($editor);
-            $mailContent = html_entity_decode(strip_tags($mail->render()));
+            $mailContent = html_entity_decode(strip_tags($mail->render()), ENT_QUOTES);
             return $mail->subject === 'New comment on page: ' . $entities['page']->getShortName()
                 && str_contains($mailContent, 'View Comment')
                 && str_contains($mailContent, 'Page Name: ' . $entities['page']->name)
@@ -280,7 +280,7 @@ class WatchTest extends TestCase
 
         $notifications->assertSentTo($editor, function (PageUpdateNotification $notification) use ($editor, $admin) {
             $mail = $notification->toMail($editor);
-            $mailContent = html_entity_decode(strip_tags($mail->render()));
+            $mailContent = html_entity_decode(strip_tags($mail->render()), ENT_QUOTES);
             return $mail->subject === 'Updated page: Updated page'
                 && str_contains($mailContent, 'View Page')
                 && str_contains($mailContent, 'Page Name: Updated page')
@@ -309,7 +309,7 @@ class WatchTest extends TestCase
 
         $notifications->assertSentTo($editor, function (PageCreationNotification $notification) use ($editor, $admin) {
             $mail = $notification->toMail($editor);
-            $mailContent = html_entity_decode(strip_tags($mail->render()));
+            $mailContent = html_entity_decode(strip_tags($mail->render()), ENT_QUOTES);
             return $mail->subject === 'New page: My new page'
                 && str_contains($mailContent, 'View Page')
                 && str_contains($mailContent, 'Page Name: My new page')
@@ -347,7 +347,7 @@ class WatchTest extends TestCase
             $notification = $notificationInfo[0]['notification'];
             $this->assertInstanceOf(BaseActivityNotification::class, $notification);
             $mail = $notification->toMail($editor);
-            $mailContent = html_entity_decode(strip_tags($mail->render()));
+            $mailContent = html_entity_decode(strip_tags($mail->render()), ENT_QUOTES);
             $this->assertStringContainsString('Name der Seite:', $mailContent);
             $this->assertStringContainsString('Diese Benachrichtigung wurde', $mailContent);
             $this->assertStringContainsString('Sollte es beim Anklicken der Schaltfläche', $mailContent);


### PR DESCRIPTION
For #4480.

### Todo

- [x] Add test case to cover.
- [x] Update notifications to use user language preference.
- [x] Test what occurs when a non-expected language preference exists.
- [x] Test bottom text, that's not controlled in notification class.
  - [x] Check this for user invites (and other existing notifications) too. Likely need to add system in other places to properly pass notifications.

