### PR TITLE
Fixes #4489: Adding last resort truncation to User Model's getShortName() function

### DIFF
--- a/app/Users/Models/User.php
+++ b/app/Users/Models/User.php
@@ -345,7 +345,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
             return $splitName[0];
         }
 
-        return '';
+        return mb_substr($this->name, 0, $chars) . '..';
     }
 
     /**

--- a/app/Users/Models/User.php
+++ b/app/Users/Models/User.php
@@ -345,7 +345,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
             return $splitName[0];
         }
 
-        return mb_substr($this->name, 0, $chars) . '..';
+        return mb_substr($this->name, 0, $chars-3) . '…';
     }
 
     /**

--- a/tests/Entity/CommentTest.php
+++ b/tests/Entity/CommentTest.php
@@ -152,4 +152,20 @@ class CommentTest extends TestCase
         $respHtml = $this->withHtml($this->get($page->getUrl('/edit')));
         $respHtml->assertElementContains('.comment-box .content', 'My great comment to see in the editor');
     }
+
+    public function test_comment_creator_name_truncated()
+    {   
+        $longNamedUser = $this->users->admin();
+        $longNamedUser->name = 'Wolfeschlegelsteinhausenbergerdorff';
+        $longNamedUser->save();
+        $this->actingAs($longNamedUser);
+
+        $page = $this->entities->page();
+
+        $comment = Comment::factory()->make();
+        $this->postJson("/comment/$page->id", $comment->getAttributes());
+
+        $pageResp = $this->get($page->getUrl());
+        $pageResp->assertSee('Wolfeschlegel…');
+    }
 }


### PR DESCRIPTION
This pull request closes issue #4489 

by providing a last resort option to the getShortName() function within the User model. This option is necessary because the function fails to return anything in some cases. If the name is too long and cannot be split by spaces, it will be trimmed to the specified number of characters, followed by two dots ('..').
 