### PR TITLE
Fixed : Comment notification settings are visible even if comments ar…

### DIFF
--- a/resources/views/users/preferences/notifications.blade.php
+++ b/resources/views/users/preferences/notifications.blade.php
@@ -20,20 +20,22 @@
                                 'label' => trans('preferences.notifications_opt_own_page_changes'),
                             ])
                         </div>
-                        <div>
-                            @include('form.toggle-switch', [
-                                'name' => 'preferences[own-page-comments]',
-                                'value' => $preferences->notifyOnOwnPageComments(),
-                                'label' => trans('preferences.notifications_opt_own_page_comments'),
-                            ])
-                        </div>
-                        <div>
-                            @include('form.toggle-switch', [
-                                'name' => 'preferences[comment-replies]',
-                                'value' => $preferences->notifyOnCommentReplies(),
-                                'label' => trans('preferences.notifications_opt_comment_replies'),
-                            ])
-                        </div>
+                        @if (!setting('app-disable-comments'))
+                            <div>
+                                @include('form.toggle-switch', [
+                                    'name' => 'preferences[own-page-comments]',
+                                    'value' => $preferences->notifyOnOwnPageComments(),
+                                    'label' => trans('preferences.notifications_opt_own_page_comments'),
+                                ])
+                            </div>
+                            <div>
+                                @include('form.toggle-switch', [
+                                    'name' => 'preferences[comment-replies]',
+                                    'value' => $preferences->notifyOnCommentReplies(),
+                                    'label' => trans('preferences.notifications_opt_comment_replies'),
+                                ])
+                            </div>
+                        @endif
                     </div>
 
                     <div class="mt-auto">

--- a/tests/User/UserPreferencesTest.php
+++ b/tests/User/UserPreferencesTest.php
@@ -318,4 +318,35 @@ class UserPreferencesTest extends TestCase
         $resp = $this->get($page->getUrl('/edit'));
         $resp->assertSee('option:code-editor:favourites="javascript,ruby"', false);
     }
+
+    public function test_comment_notifications_hidden_when_comments_disabled()
+    {
+        $editor = $this->users->editor();
+
+
+        setting()->putUser($editor, 'app-disable-comments', true);
+
+        $settingLabel1 = trans('preferences.notifications_opt_own_page_comments');
+        $settingLabel2 = trans('preferences.notifications_opt_comment_replies');
+
+        $resp = $this->actingAs($editor)->get('/preferences/notifications');
+
+        $resp->assertDontSee($settingLabel1, true);
+        $resp->assertDontSee($settingLabel2, true);
+    }
+
+    public function test_comment_notifications_visible_when_comments_enabled()
+    {
+        $editor = $this->users->editor();
+
+        setting()->putUser($editor, 'app-disable-comments', false);
+
+        $settingLabel1 = trans('preferences.notifications_opt_own_page_comments');
+        $settingLabel2 = trans('preferences.notifications_opt_comment_replies');
+
+        $resp = $this->actingAs($editor)->get('/preferences/notifications');
+
+        $resp->assertSee($settingLabel1, true);
+        $resp->assertSee($settingLabel2, true);
+    }
 }


### PR DESCRIPTION
…e disabled

Added a UX condition to display comment notification settings, only if the user has enabled the comment notifications.