### PR TITLE
Improvements to file/image upload handling UX

### DIFF
--- a/app/Entities/Models/Book.php
+++ b/app/Entities/Models/Book.php
@@ -40,26 +40,19 @@ class Book extends Entity implements HasCoverImage
 
     /**
      * Returns book cover image, if book cover not exists return default cover image.
-     *
-     * @param int $width  - Width of the image
-     * @param int $height - Height of the image
-     *
-     * @return string
      */
-    public function getBookCover($width = 440, $height = 250)
+    public function getBookCover(int $width = 440, int $height = 250): string
     {
         $default = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
-        if (!$this->image_id) {
+        if (!$this->image_id || !$this->cover) {
             return $default;
         }
 
         try {
-            $cover = $this->cover ? url($this->cover->getThumb($width, $height, false)) : $default;
+            return $this->cover->getThumb($width, $height, false) ?? $default;
         } catch (Exception $err) {
-            $cover = $default;
+            return $default;
         }
-
-        return $cover;
     }
 
     /**

--- a/app/Entities/Models/Bookshelf.php
+++ b/app/Entities/Models/Bookshelf.php
@@ -3,6 +3,7 @@
 namespace BookStack\Entities\Models;
 
 use BookStack\Uploads\Image;
+use Exception;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -49,28 +50,21 @@ class Bookshelf extends Entity implements HasCoverImage
     }
 
     /**
-     * Returns BookShelf cover image, if cover does not exists return default cover image.
-     *
-     * @param int $width  - Width of the image
-     * @param int $height - Height of the image
-     *
-     * @return string
+     * Returns shelf cover image, if cover not exists return default cover image.
      */
-    public function getBookCover($width = 440, $height = 250)
+    public function getBookCover(int $width = 440, int $height = 250): string
     {
         // TODO - Make generic, focused on books right now, Perhaps set-up a better image
         $default = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
-        if (!$this->image_id) {
+        if (!$this->image_id || !$this->cover) {
             return $default;
         }
 
         try {
-            $cover = $this->cover ? url($this->cover->getThumb($width, $height, false)) : $default;
-        } catch (\Exception $err) {
-            $cover = $default;
+            return $this->cover->getThumb($width, $height, false) ?? $default;
+        } catch (Exception $err) {
+            return $default;
         }
-
-        return $cover;
     }
 
     /**

--- a/app/Entities/Tools/ExportFormatter.php
+++ b/app/Entities/Tools/ExportFormatter.php
@@ -222,7 +222,7 @@ class ExportFormatter
             foreach ($imageTagsOutput[0] as $index => $imgMatch) {
                 $oldImgTagString = $imgMatch;
                 $srcString = $imageTagsOutput[2][$index];
-                $imageEncoded = $this->imageService->imageUriToBase64($srcString);
+                $imageEncoded = $this->imageService->imageUrlToBase64($srcString);
                 if ($imageEncoded === null) {
                     $imageEncoded = $srcString;
                 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\Exceptions\PostTooLargeException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
@@ -59,6 +60,10 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Throwable $e)
     {
+        if ($e instanceof PostTooLargeException) {
+            $e = new NotifyException(trans('errors.server_post_limit'), '/', 413);
+        }
+
         if ($this->isApiRequest($request)) {
             return $this->renderApiException($e);
         }
@@ -71,7 +76,7 @@ class Handler extends ExceptionHandler
      */
     protected function isApiRequest(Request $request): bool
     {
-        return strpos($request->path(), 'api/') === 0;
+        return str_starts_with($request->path(), 'api/');
     }
 
     /**

--- a/app/Uploads/Controllers/DrawioImageController.php
+++ b/app/Uploads/Controllers/DrawioImageController.php
@@ -10,11 +10,9 @@ use Illuminate\Http\Request;
 
 class DrawioImageController extends Controller
 {
-    protected $imageRepo;
-
-    public function __construct(ImageRepo $imageRepo)
-    {
-        $this->imageRepo = $imageRepo;
+    public function __construct(
+        protected ImageRepo $imageRepo
+    ) {
     }
 
     /**

--- a/app/Uploads/Controllers/GalleryImageController.php
+++ b/app/Uploads/Controllers/GalleryImageController.php
@@ -6,6 +6,8 @@ use BookStack\Exceptions\ImageUploadException;
 use BookStack\Http\Controller;
 use BookStack\Uploads\ImageRepo;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\ValidationException;
 
 class GalleryImageController extends Controller

--- a/app/Uploads/Controllers/GalleryImageController.php
+++ b/app/Uploads/Controllers/GalleryImageController.php
@@ -5,6 +5,7 @@ namespace BookStack\Uploads\Controllers;
 use BookStack\Exceptions\ImageUploadException;
 use BookStack\Http\Controller;
 use BookStack\Uploads\ImageRepo;
+use BookStack\Util\OutOfMemoryHandler;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
@@ -52,6 +53,10 @@ class GalleryImageController extends Controller
         } catch (ValidationException $exception) {
             return $this->jsonError(implode("\n", $exception->errors()['file']));
         }
+
+        new OutOfMemoryHandler(function () {
+            return $this->jsonError(trans('errors.image_upload_memory_limit'));
+        });
 
         try {
             $imageUpload = $request->file('file');

--- a/app/Uploads/Controllers/ImageController.php
+++ b/app/Uploads/Controllers/ImageController.php
@@ -44,7 +44,7 @@ class ImageController extends Controller
      */
     public function update(Request $request, string $id)
     {
-        $this->validate($request, [
+        $data = $this->validate($request, [
             'name' => ['required', 'min:2', 'string'],
         ]);
 
@@ -52,9 +52,7 @@ class ImageController extends Controller
         $this->checkImagePermission($image);
         $this->checkOwnablePermission('image-update', $image);
 
-        $image = $this->imageRepo->updateImageDetails($image, $request->all());
-
-        $this->imageRepo->loadThumbs($image);
+        $image = $this->imageRepo->updateImageDetails($image, $data);
 
         return view('pages.parts.image-manager-form', [
             'image'          => $image,
@@ -99,7 +97,7 @@ class ImageController extends Controller
             $dependantPages = $this->imageRepo->getPagesUsingImage($image);
         }
 
-        $this->imageRepo->loadThumbs($image);
+        $this->imageRepo->loadThumbs($image, false);
 
         return view('pages.parts.image-manager-form', [
             'image'          => $image,

--- a/app/Uploads/Controllers/ImageController.php
+++ b/app/Uploads/Controllers/ImageController.php
@@ -11,7 +11,6 @@ use BookStack\Uploads\ImageService;
 use BookStack\Util\OutOfMemoryHandler;
 use Exception;
 use Illuminate\Http\Request;
-use Illuminate\Validation\ValidationException;
 
 class ImageController extends Controller
 {
@@ -39,9 +38,6 @@ class ImageController extends Controller
 
     /**
      * Update image details.
-     *
-     * @throws ImageUploadException
-     * @throws ValidationException
      */
     public function update(Request $request, string $id)
     {
@@ -74,6 +70,10 @@ class ImageController extends Controller
         $this->checkImagePermission($image);
         $this->checkOwnablePermission('image-update', $image);
         $file = $request->file('file');
+
+        new OutOfMemoryHandler(function () {
+            return $this->jsonError(trans('errors.image_upload_memory_limit'));
+        });
 
         try {
             $this->imageRepo->updateImageFile($image, $file);

--- a/app/Uploads/Controllers/ImageGalleryApiController.php
+++ b/app/Uploads/Controllers/ImageGalleryApiController.php
@@ -6,6 +6,7 @@ use BookStack\Entities\Models\Page;
 use BookStack\Http\ApiController;
 use BookStack\Uploads\Image;
 use BookStack\Uploads\ImageRepo;
+use BookStack\Uploads\ImageResizer;
 use Illuminate\Http\Request;
 
 class ImageGalleryApiController extends ApiController
@@ -15,7 +16,8 @@ class ImageGalleryApiController extends ApiController
     ];
 
     public function __construct(
-        protected ImageRepo $imageRepo
+        protected ImageRepo $imageRepo,
+        protected ImageResizer $imageResizer,
     ) {
     }
 
@@ -130,7 +132,7 @@ class ImageGalleryApiController extends ApiController
      */
     protected function formatForSingleResponse(Image $image): array
     {
-        $this->imageRepo->loadThumbs($image, false);
+        $this->imageResizer->loadGalleryThumbnailsForImage($image, false);
         $data = $image->toArray();
         $data['created_by'] = $image->createdBy;
         $data['updated_by'] = $image->updatedBy;
@@ -138,6 +140,7 @@ class ImageGalleryApiController extends ApiController
 
         $escapedUrl = htmlentities($image->url);
         $escapedName = htmlentities($image->name);
+
         if ($image->type === 'drawio') {
             $data['content']['html'] = "<div drawio-diagram=\"{$image->id}\"><img src=\"{$escapedUrl}\"></div>";
             $data['content']['markdown'] = $data['content']['html'];

--- a/app/Uploads/Controllers/ImageGalleryApiController.php
+++ b/app/Uploads/Controllers/ImageGalleryApiController.php
@@ -130,7 +130,7 @@ class ImageGalleryApiController extends ApiController
      */
     protected function formatForSingleResponse(Image $image): array
     {
-        $this->imageRepo->loadThumbs($image);
+        $this->imageRepo->loadThumbs($image, false);
         $data = $image->toArray();
         $data['created_by'] = $image->createdBy;
         $data['updated_by'] = $image->updatedBy;

--- a/app/Uploads/Image.php
+++ b/app/Uploads/Image.php
@@ -52,7 +52,7 @@ class Image extends Model
      */
     public function getThumb(?int $width, ?int $height, bool $keepRatio = false): ?string
     {
-        return app()->make(ImageService::class)->getThumbnail($this, $width, $height, $keepRatio, false, true);
+        return app()->make(ImageResizer::class)->resizeToThumbnailUrl($this, $width, $height, $keepRatio, false, true);
     }
 
     /**

--- a/app/Uploads/Image.php
+++ b/app/Uploads/Image.php
@@ -52,7 +52,7 @@ class Image extends Model
      */
     public function getThumb(?int $width, ?int $height, bool $keepRatio = false): ?string
     {
-        return app()->make(ImageResizer::class)->resizeToThumbnailUrl($this, $width, $height, $keepRatio, false, true);
+        return app()->make(ImageResizer::class)->resizeToThumbnailUrl($this, $width, $height, $keepRatio, false);
     }
 
     /**

--- a/app/Uploads/Image.php
+++ b/app/Uploads/Image.php
@@ -45,13 +45,14 @@ class Image extends Model
     }
 
     /**
-     * Get an (already existing) thumbnail for this image.
+     * Get a thumbnail URL for this image.
+     * Attempts to generate the thumbnail if not already existing.
      *
      * @throws \Exception
      */
     public function getThumb(?int $width, ?int $height, bool $keepRatio = false): ?string
     {
-        return app()->make(ImageService::class)->getThumbnail($this, $width, $height, $keepRatio);
+        return app()->make(ImageService::class)->getThumbnail($this, $width, $height, $keepRatio, false, true);
     }
 
     /**

--- a/app/Uploads/Image.php
+++ b/app/Uploads/Image.php
@@ -45,11 +45,11 @@ class Image extends Model
     }
 
     /**
-     * Get a thumbnail for this image.
+     * Get an (already existing) thumbnail for this image.
      *
      * @throws \Exception
      */
-    public function getThumb(?int $width, ?int $height, bool $keepRatio = false): string
+    public function getThumb(?int $width, ?int $height, bool $keepRatio = false): ?string
     {
         return app()->make(ImageService::class)->getThumbnail($this, $width, $height, $keepRatio);
     }

--- a/app/Uploads/ImageRepo.php
+++ b/app/Uploads/ImageRepo.php
@@ -13,7 +13,8 @@ class ImageRepo
 {
     public function __construct(
         protected ImageService $imageService,
-        protected PermissionApplicator $permissions
+        protected PermissionApplicator $permissions,
+        protected ImageResizer $imageResizer,
     ) {
     }
 
@@ -225,14 +226,12 @@ class ImageRepo
     }
 
     /**
-     * Get the thumbnail for an image.
-     * If $keepRatio is true only the width will be used.
-     * Checks the cache then storage to avoid creating / accessing the filesystem on every check.
+     * Get a thumbnail URL for the given image.
      */
     protected function getThumbnail(Image $image, ?int $width, ?int $height, bool $keepRatio, bool $shouldCreate): ?string
     {
         try {
-            return $this->imageService->getThumbnail($image, $width, $height, $keepRatio, $shouldCreate);
+            return $this->imageResizer->resizeToThumbnailUrl($image, $width, $height, $keepRatio, $shouldCreate);
         } catch (Exception $exception) {
             return null;
         }

--- a/app/Uploads/ImageResizer.php
+++ b/app/Uploads/ImageResizer.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace BookStack\Uploads;
+
+use BookStack\Exceptions\ImageUploadException;
+use GuzzleHttp\Psr7\Utils;
+use Intervention\Image\Exception\NotSupportedException;
+use Intervention\Image\Image as InterventionImage;
+use Intervention\Image\ImageManager;
+
+class ImageResizer
+{
+    public function __construct(
+        protected ImageManager $intervention
+    ) {
+    }
+
+    /**
+     * Resize the image of given data to the specified size, and return the new image data.
+     *
+     * @throws ImageUploadException
+     */
+    protected function resizeImageData(string $imageData, ?int $width, ?int $height, bool $keepRatio): string
+    {
+        try {
+            $thumb = $this->intervention->make($imageData);
+        } catch (NotSupportedException $e) {
+            throw new ImageUploadException(trans('errors.cannot_create_thumbs'));
+        }
+
+        $this->orientImageToOriginalExif($thumb, $imageData);
+
+        if ($keepRatio) {
+            $thumb->resize($width, $height, function ($constraint) {
+                $constraint->aspectRatio();
+                $constraint->upsize();
+            });
+        } else {
+            $thumb->fit($width, $height);
+        }
+
+        $thumbData = (string) $thumb->encode();
+
+        // Use original image data if we're keeping the ratio
+        // and the resizing does not save any space.
+        if ($keepRatio && strlen($thumbData) > strlen($imageData)) {
+            return $imageData;
+        }
+
+        return $thumbData;
+    }
+
+    /**
+     * Orientate the given intervention image based upon the given original image data.
+     * Intervention does have an `orientate` method but the exif data it needs is lost before it
+     * can be used (At least when created using binary string data) so we need to do some
+     * implementation on our side to use the original image data.
+     * Bulk of logic taken from: https://github.com/Intervention/image/blob/b734a4988b2148e7d10364b0609978a88d277536/src/Intervention/Image/Commands/OrientateCommand.php
+     * Copyright (c) Oliver Vogel, MIT License.
+     */
+    protected function orientImageToOriginalExif(InterventionImage $image, string $originalData): void
+    {
+        if (!extension_loaded('exif')) {
+            return;
+        }
+
+        $stream = Utils::streamFor($originalData)->detach();
+        $exif = @exif_read_data($stream);
+        $orientation = $exif ? ($exif['Orientation'] ?? null) : null;
+
+        switch ($orientation) {
+            case 2:
+                $image->flip();
+                break;
+            case 3:
+                $image->rotate(180);
+                break;
+            case 4:
+                $image->rotate(180)->flip();
+                break;
+            case 5:
+                $image->rotate(270)->flip();
+                break;
+            case 6:
+                $image->rotate(270);
+                break;
+            case 7:
+                $image->rotate(90)->flip();
+                break;
+            case 8:
+                $image->rotate(90);
+                break;
+        }
+    }
+}

--- a/app/Uploads/ImageStorage.php
+++ b/app/Uploads/ImageStorage.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace BookStack\Uploads;
+
+use Illuminate\Contracts\Filesystem\Filesystem as StorageDisk;
+use Illuminate\Filesystem\FilesystemManager;
+use Illuminate\Support\Str;
+use League\Flysystem\WhitespacePathNormalizer;
+
+class ImageStorage
+{
+    public function __construct(
+        protected FilesystemManager $fileSystem,
+    ) {
+    }
+
+    /**
+     * Get the storage disk for the given image type.
+     */
+    public function getDisk(string $imageType = ''): StorageDisk
+    {
+        return $this->fileSystem->disk($this->getDiskName($imageType));
+    }
+
+    /**
+     * Check if local secure image storage (Fetched behind authentication)
+     * is currently active in the instance.
+     */
+    public function usingSecureImages(string $imageType = 'gallery'): bool
+    {
+        return $this->getDiskName($imageType) === 'local_secure_images';
+    }
+
+    /**
+     * Check if "local secure restricted" (Fetched behind auth, with permissions enforced)
+     * is currently active in the instance.
+     */
+    public function usingSecureRestrictedImages()
+    {
+        return config('filesystems.images') === 'local_secure_restricted';
+    }
+
+    /**
+     * Change the originally provided path to fit any disk-specific requirements.
+     * This also ensures the path is kept to the expected root folders.
+     */
+    public function adjustPathForDisk(string $path, string $imageType = ''): string
+    {
+        $path = (new WhitespacePathNormalizer())->normalizePath(str_replace('uploads/images/', '', $path));
+
+        if ($this->usingSecureImages($imageType)) {
+            return $path;
+        }
+
+        return 'uploads/images/' . $path;
+    }
+
+    /**
+     * Clean up an image file name to be both URL and storage safe.
+     */
+    public function cleanImageFileName(string $name): string
+    {
+        $name = str_replace(' ', '-', $name);
+        $nameParts = explode('.', $name);
+        $extension = array_pop($nameParts);
+        $name = implode('-', $nameParts);
+        $name = Str::slug($name);
+
+        if (strlen($name) === 0) {
+            $name = Str::random(10);
+        }
+
+        return $name . '.' . $extension;
+    }
+
+    /**
+     * Get the name of the storage disk to use.
+     */
+    protected function getDiskName(string $imageType): string
+    {
+        $storageType = config('filesystems.images');
+        $localSecureInUse = ($storageType === 'local_secure' || $storageType === 'local_secure_restricted');
+
+        // Ensure system images (App logo) are uploaded to a public space
+        if ($imageType === 'system' && $localSecureInUse) {
+            return 'local';
+        }
+
+        // Rename local_secure options to get our image specific storage driver which
+        // is scoped to the relevant image directories.
+        if ($localSecureInUse) {
+            return 'local_secure_images';
+        }
+
+        return $storageType;
+    }
+
+    /**
+     * Get a storage path for the given image URL.
+     * Ensures the path will start with "uploads/images".
+     * Returns null if the url cannot be resolved to a local URL.
+     */
+    public function urlToPath(string $url): ?string
+    {
+        $url = ltrim(trim($url), '/');
+
+        // Handle potential relative paths
+        $isRelative = !str_starts_with($url, 'http');
+        if ($isRelative) {
+            if (str_starts_with(strtolower($url), 'uploads/images')) {
+                return trim($url, '/');
+            }
+
+            return null;
+        }
+
+        // Handle local images based on paths on the same domain
+        $potentialHostPaths = [
+            url('uploads/images/'),
+            $this->getPublicUrl('/uploads/images/'),
+        ];
+
+        foreach ($potentialHostPaths as $potentialBasePath) {
+            $potentialBasePath = strtolower($potentialBasePath);
+            if (str_starts_with(strtolower($url), $potentialBasePath)) {
+                return 'uploads/images/' . trim(substr($url, strlen($potentialBasePath)), '/');
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Gets a public facing url for an image by checking relevant environment variables.
+     * If s3-style store is in use it will default to guessing a public bucket URL.
+     */
+    public function getPublicUrl(string $filePath): string
+    {
+        $storageUrl = config('filesystems.url');
+
+        // Get the standard public s3 url if s3 is set as storage type
+        // Uses the nice, short URL if bucket name has no periods in otherwise the longer
+        // region-based url will be used to prevent http issues.
+        if (!$storageUrl && config('filesystems.images') === 's3') {
+            $storageDetails = config('filesystems.disks.s3');
+            if (!str_contains($storageDetails['bucket'], '.')) {
+                $storageUrl = 'https://' . $storageDetails['bucket'] . '.s3.amazonaws.com';
+            } else {
+                $storageUrl = 'https://s3-' . $storageDetails['region'] . '.amazonaws.com/' . $storageDetails['bucket'];
+            }
+        }
+
+        $basePath = $storageUrl ?: url('/');
+
+        return rtrim($basePath, '/') . $filePath;
+    }
+
+    /**
+     * Save image data for the given path in the public space, if possible,
+     * for the provided storage mechanism.
+     */
+    public function storeInPublicSpace(StorageDisk $storage, string $path, string $data): void
+    {
+        $storage->put($path, $data);
+
+        // Set visibility when a non-AWS-s3, s3-like storage option is in use.
+        // Done since this call can break s3-like services but desired for other image stores.
+        // Attempting to set ACL during above put request requires different permissions
+        // hence would technically be a breaking change for actual s3 usage.
+        if (!$this->isS3Like()) {
+            $storage->setVisibility($path, 'public');
+        }
+    }
+
+    /**
+     * Check if the image storage in use is an S3-like (but not likely S3) external system.
+     */
+    protected function isS3Like(): bool
+    {
+        $usingS3 = strtolower(config('filesystems.images')) === 's3';
+        return $usingS3 && !is_null(config('filesystems.disks.s3.endpoint'));
+    }
+}

--- a/app/Uploads/ImageStorageDisk.php
+++ b/app/Uploads/ImageStorageDisk.php
@@ -50,7 +50,7 @@ class ImageStorageDisk
     /**
      * Get the file at the given path.
      */
-    public function get(string $path): bool
+    public function get(string $path): ?string
     {
         return $this->filesystem->get($this->adjustPathForDisk($path));
     }
@@ -106,6 +106,7 @@ class ImageStorageDisk
      */
     public function mimeType(string $path): string
     {
+        $path = $this->adjustPathForDisk($path);
         return $this->filesystem instanceof FilesystemAdapter ? $this->filesystem->mimeType($path) : '';
     }
 
@@ -114,7 +115,7 @@ class ImageStorageDisk
      */
     public function response(string $path): StreamedResponse
     {
-        return $this->filesystem->response($path);
+        return $this->filesystem->response($this->adjustPathForDisk($path));
     }
 
     /**

--- a/app/Uploads/ImageStorageDisk.php
+++ b/app/Uploads/ImageStorageDisk.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace BookStack\Uploads;
+
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemAdapter;
+use League\Flysystem\WhitespacePathNormalizer;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ImageStorageDisk
+{
+    public function __construct(
+        protected string $diskName,
+        protected Filesystem $filesystem,
+    ) {
+    }
+
+    /**
+     * Check if local secure image storage (Fetched behind authentication)
+     * is currently active in the instance.
+     */
+    public function usingSecureImages(): bool
+    {
+        return $this->diskName === 'local_secure_images';
+    }
+
+    /**
+     * Change the originally provided path to fit any disk-specific requirements.
+     * This also ensures the path is kept to the expected root folders.
+     */
+    protected function adjustPathForDisk(string $path): string
+    {
+        $path = (new WhitespacePathNormalizer())->normalizePath(str_replace('uploads/images/', '', $path));
+
+        if ($this->usingSecureImages()) {
+            return $path;
+        }
+
+        return 'uploads/images/' . $path;
+    }
+
+    /**
+     * Check if a file at the given path exists.
+     */
+    public function exists(string $path): bool
+    {
+        return $this->filesystem->exists($this->adjustPathForDisk($path));
+    }
+
+    /**
+     * Get the file at the given path.
+     */
+    public function get(string $path): bool
+    {
+        return $this->filesystem->get($this->adjustPathForDisk($path));
+    }
+
+    /**
+     * Save the given image data at the given path. Can choose to set
+     * the image as public which will update its visibility after saving.
+     */
+    public function put(string $path, string $data, bool $makePublic = false): void
+    {
+        $path = $this->adjustPathForDisk($path);
+        $this->filesystem->put($path, $data);
+
+        // Set visibility when a non-AWS-s3, s3-like storage option is in use.
+        // Done since this call can break s3-like services but desired for other image stores.
+        // Attempting to set ACL during above put request requires different permissions
+        // hence would technically be a breaking change for actual s3 usage.
+        if ($makePublic && !$this->isS3Like()) {
+            $this->filesystem->setVisibility($path, 'public');
+        }
+    }
+
+    /**
+     * Destroys an image at the given path.
+     * Searches for image thumbnails in addition to main provided path.
+     */
+    public function destroyAllMatchingNameFromPath(string $path): void
+    {
+        $path = $this->adjustPathForDisk($path);
+
+        $imageFolder = dirname($path);
+        $imageFileName = basename($path);
+        $allImages = collect($this->filesystem->allFiles($imageFolder));
+
+        // Delete image files
+        $imagesToDelete = $allImages->filter(function ($imagePath) use ($imageFileName) {
+            return basename($imagePath) === $imageFileName;
+        });
+        $this->filesystem->delete($imagesToDelete->all());
+
+        // Cleanup of empty folders
+        $foldersInvolved = array_merge([$imageFolder], $this->filesystem->directories($imageFolder));
+        foreach ($foldersInvolved as $directory) {
+            if ($this->isFolderEmpty($directory)) {
+                $this->filesystem->deleteDirectory($directory);
+            }
+        }
+    }
+
+    /**
+     * Get the mime type of the file at the given path.
+     * Only works for local filesystem adapters.
+     */
+    public function mimeType(string $path): string
+    {
+        return $this->filesystem instanceof FilesystemAdapter ? $this->filesystem->mimeType($path) : '';
+    }
+
+    /**
+     * Get a stream response for the image at the given path.
+     */
+    public function response(string $path): StreamedResponse
+    {
+        return $this->filesystem->response($path);
+    }
+
+    /**
+     * Check if the image storage in use is an S3-like (but not likely S3) external system.
+     */
+    protected function isS3Like(): bool
+    {
+        $usingS3 = $this->diskName === 's3';
+        return $usingS3 && !is_null(config('filesystems.disks.s3.endpoint'));
+    }
+
+    /**
+     * Check whether a folder is empty.
+     */
+    protected function isFolderEmpty(string $path): bool
+    {
+        $files = $this->filesystem->files($path);
+        $folders = $this->filesystem->directories($path);
+
+        return count($files) === 0 && count($folders) === 0;
+    }
+}

--- a/app/Users/Models/User.php
+++ b/app/Users/Models/User.php
@@ -244,7 +244,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         }
 
         try {
-            $avatar = $this->avatar ? url($this->avatar->getThumb($size, $size, false)) : $default;
+            $avatar = $this->avatar?->getThumb($size, $size, false) ?? $default;
         } catch (Exception $err) {
             $avatar = $default;
         }

--- a/app/Util/OutOfMemoryHandler.php
+++ b/app/Util/OutOfMemoryHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace BookStack\Util;
+
+use BookStack\Exceptions\Handler;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+
+/**
+ * Create a handler which runs the provided actions upon an
+ * out-of-memory event. This allows reserving of memory to allow
+ * the desired action to run as needed.
+ *
+ * Essentially provides a wrapper and memory reserving around the
+ * memory handling added to the default app error handler.
+ */
+class OutOfMemoryHandler
+{
+    protected $onOutOfMemory;
+    protected string $memoryReserve = '';
+
+    public function __construct(callable $onOutOfMemory, int $memoryReserveMB = 4)
+    {
+        $this->onOutOfMemory = $onOutOfMemory;
+
+        $this->memoryReserve = str_repeat('x', $memoryReserveMB * 1_000_000);
+        $this->getHandler()->prepareForOutOfMemory(function () {
+            return $this->handle();
+        });
+    }
+
+    protected function handle(): mixed
+    {
+        $result = null;
+        $this->memoryReserve = '';
+
+        if ($this->onOutOfMemory) {
+            $result = call_user_func($this->onOutOfMemory);
+            $this->forget();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Forget the handler so no action is taken place on out of memory.
+     */
+    public function forget(): void
+    {
+        $this->memoryReserve = '';
+        $this->onOutOfMemory = null;
+        $this->getHandler()->forgetOutOfMemoryHandler();
+    }
+
+    protected function getHandler(): Handler
+    {
+        return app()->make(ExceptionHandler::class);
+    }
+}

--- a/lang/en/components.php
+++ b/lang/en/components.php
@@ -34,6 +34,8 @@ return [
     'image_delete_success' => 'Image successfully deleted',
     'image_replace' => 'Replace Image',
     'image_replace_success' => 'Image file successfully updated',
+    'image_rebuild_thumbs' => 'Regenerate Size Variations',
+    'image_rebuild_thumbs_success' => 'Image size variations successfully rebuilt!',
 
     // Code Editor
     'code_editor' => 'Edit Code',

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -44,6 +44,7 @@ return [
     'cannot_get_image_from_url' => 'Cannot get image from :url',
     'cannot_create_thumbs' => 'The server cannot create thumbnails. Please check you have the GD PHP extension installed.',
     'server_upload_limit' => 'The server does not allow uploads of this size. Please try a smaller file size.',
+    'server_post_limit' => 'The server cannot receive the provided amount of data. Try again with less data or a smaller file.',
     'uploaded'  => 'The server does not allow uploads of this size. Please try a smaller file size.',
 
     // Drawing & Images

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -51,6 +51,7 @@ return [
     'image_upload_error' => 'An error occurred uploading the image',
     'image_upload_type_error' => 'The image type being uploaded is invalid',
     'image_upload_replace_type' => 'Image file replacements must be of the same type',
+    'image_thumbnail_memory_limit' => 'Failed to create image size variations due to system resource limits',
     'drawing_data_not_found' => 'Drawing data could not be loaded. The drawing file might no longer exist or you may not have permission to access it.',
 
     // Attachments

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -51,8 +51,9 @@ return [
     'image_upload_error' => 'An error occurred uploading the image',
     'image_upload_type_error' => 'The image type being uploaded is invalid',
     'image_upload_replace_type' => 'Image file replacements must be of the same type',
-    'image_upload_memory_limit' => 'Failed to handle image upload and/or create thumbnails due to system resource limits',
-    'image_thumbnail_memory_limit' => 'Failed to create image size variations due to system resource limits',
+    'image_upload_memory_limit' => 'Failed to handle image upload and/or create thumbnails due to system resource limits.',
+    'image_thumbnail_memory_limit' => 'Failed to create image size variations due to system resource limits.',
+    'image_gallery_thumbnail_memory_limit' => 'Failed to create gallery thumbnails due to system resource limits.',
     'drawing_data_not_found' => 'Drawing data could not be loaded. The drawing file might no longer exist or you may not have permission to access it.',
 
     // Attachments

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -51,6 +51,7 @@ return [
     'image_upload_error' => 'An error occurred uploading the image',
     'image_upload_type_error' => 'The image type being uploaded is invalid',
     'image_upload_replace_type' => 'Image file replacements must be of the same type',
+    'image_upload_memory_limit' => 'Failed to handle image upload and/or create thumbnails due to system resource limits',
     'image_thumbnail_memory_limit' => 'Failed to create image size variations due to system resource limits',
     'drawing_data_not_found' => 'Drawing data could not be loaded. The drawing file might no longer exist or you may not have permission to access it.',
 

--- a/resources/js/components/image-manager.js
+++ b/resources/js/components/image-manager.js
@@ -1,6 +1,4 @@
-import {
-    onChildEvent, onSelect, removeLoading, showLoading,
-} from '../services/dom';
+import {onChildEvent, onSelect, removeLoading, showLoading,} from '../services/dom';
 import {Component} from './component';
 
 export class ImageManager extends Component {
@@ -229,8 +227,8 @@ export class ImageManager extends Component {
         this.loadGallery();
     }
 
-    onImageSelectEvent(event) {
-        const image = JSON.parse(event.detail.data);
+    async onImageSelectEvent(event) {
+        let image = JSON.parse(event.detail.data);
         const isDblClick = ((image && image.id === this.lastSelected.id)
             && Date.now() - this.lastSelectedTime < 400);
         const alreadySelected = event.target.classList.contains('selected');
@@ -238,12 +236,15 @@ export class ImageManager extends Component {
             el.classList.remove('selected');
         });
 
-        if (!alreadySelected) {
+        if (!alreadySelected && !isDblClick) {
             event.target.classList.add('selected');
-            this.loadImageEditForm(image.id);
-        } else {
+            image = await this.loadImageEditForm(image.id);
+        } else if (!isDblClick) {
             this.resetEditForm();
+        } else if (isDblClick) {
+            image = this.lastSelected;
         }
+
         this.selectButton.classList.toggle('hidden', alreadySelected);
 
         if (isDblClick && this.callback) {
@@ -265,6 +266,9 @@ export class ImageManager extends Component {
         this.formContainer.innerHTML = formHtml;
         this.formContainerPlaceholder.setAttribute('hidden', '');
         window.$components.init(this.formContainer);
+
+        const imageDataEl = this.formContainer.querySelector('#image-manager-form-image-data');
+        return JSON.parse(imageDataEl.text);
     }
 
     runLoadMore() {

--- a/resources/js/components/image-manager.js
+++ b/resources/js/components/image-manager.js
@@ -1,4 +1,6 @@
-import {onChildEvent, onSelect, removeLoading, showLoading,} from '../services/dom';
+import {
+    onChildEvent, onSelect, removeLoading, showLoading,
+} from '../services/dom';
 import {Component} from './component';
 
 export class ImageManager extends Component {

--- a/resources/js/components/image-manager.js
+++ b/resources/js/components/image-manager.js
@@ -90,6 +90,15 @@ export class ImageManager extends Component {
             }
         });
 
+        // Rebuild thumbs click
+        onChildEvent(this.formContainer, '#image-manager-rebuild-thumbs', 'click', async (_, button) => {
+            button.disabled = true;
+            if (this.lastSelected) {
+                await this.rebuildThumbnails(this.lastSelected.id);
+            }
+            button.disabled = false;
+        });
+
         // Edit form submit
         this.formContainer.addEventListener('ajax-form-success', () => {
             this.refreshGallery();
@@ -266,6 +275,16 @@ export class ImageManager extends Component {
 
     canLoadMore() {
         return this.loadMore.querySelector('button') && !this.loadMore.hasAttribute('hidden');
+    }
+
+    async rebuildThumbnails(imageId) {
+        try {
+            const response = await window.$http.put(`/images/${imageId}/rebuild-thumbnails`);
+            window.$events.success(response.data);
+            this.refreshGallery();
+        } catch (err) {
+            window.$events.showResponseError(err);
+        }
     }
 
 }

--- a/resources/js/markdown/actions.js
+++ b/resources/js/markdown/actions.js
@@ -34,7 +34,7 @@ export class Actions {
         const imageManager = window.$components.first('image-manager');
 
         imageManager.show(image => {
-            const imageUrl = image.thumbs.display || image.url;
+            const imageUrl = image.thumbs?.display || image.url;
             const selectedText = this.#getSelectionText();
             const newText = `[![${selectedText || image.name}](${imageUrl})](${image.url})`;
             this.#replaceSelection(newText, newText.length);
@@ -417,7 +417,7 @@ export class Actions {
             const newContent = `[![](${data.thumbs.display})](${data.url})`;
             this.#findAndReplaceContent(placeHolderText, newContent);
         } catch (err) {
-            window.$events.emit('error', this.editor.config.text.imageUploadError);
+            window.$events.error(err?.data?.message || this.editor.config.text.imageUploadError);
             this.#findAndReplaceContent(placeHolderText, '');
             console.error(err);
         }

--- a/resources/js/wysiwyg/drop-paste-handling.js
+++ b/resources/js/wysiwyg/drop-paste-handling.js
@@ -61,7 +61,7 @@ function paste(editor, options, event) {
                 editor.dom.replace(newEl, id);
             }).catch(err => {
                 editor.dom.remove(id);
-                window.$events.emit('error', options.translations.imageUploadErrorText);
+                window.$events.error(err?.data?.message || options.translations.imageUploadErrorText);
                 console.error(err);
             });
         }, 10);

--- a/resources/js/wysiwyg/plugins-imagemanager.js
+++ b/resources/js/wysiwyg/plugins-imagemanager.js
@@ -11,7 +11,7 @@ function register(editor) {
             /** @type {ImageManager} * */
             const imageManager = window.$components.first('image-manager');
             imageManager.show(image => {
-                const imageUrl = image.thumbs.display || image.url;
+                const imageUrl = image.thumbs?.display || image.url;
                 let html = `<a href="${image.url}" target="_blank">`;
                 html += `<img src="${imageUrl}" alt="${image.name}">`;
                 html += '</a>';

--- a/resources/sass/_components.scss
+++ b/resources/sass/_components.scss
@@ -382,7 +382,7 @@ body.flexbox-support #entity-selector-wrap .popup-body .form-group {
 .image-manager-list {
   padding: 3px;
   display: grid;
-  grid-template-columns: repeat( auto-fit, minmax(140px, 1fr) );
+  grid-template-columns: repeat( auto-fill, minmax(max(140px, 17%), 1fr) );
   gap: 3px;
   z-index: 3;
   > div {

--- a/resources/sass/_components.scss
+++ b/resources/sass/_components.scss
@@ -457,6 +457,18 @@ body.flexbox-support #entity-selector-wrap .popup-body .form-group {
   text-align: center;
 }
 
+.image-manager-list .image-manager-list-warning {
+  grid-column: 1 / -1;
+  aspect-ratio: auto;
+}
+
+.image-manager-warning {
+  @include lightDark(background, #FFF, #333);
+  color: var(--color-warning);
+  font-weight: bold;
+  border-inline: 3px solid var(--color-warning);
+}
+
 .image-manager-sidebar {
   width: 300px;
   margin: 0 auto;

--- a/resources/views/pages/parts/image-manager-form.blade.php
+++ b/resources/views/pages/parts/image-manager-form.blade.php
@@ -44,6 +44,9 @@
                                     id="image-manager-replace"
                                     refs="dropzone@select-button"
                                     class="text-item">{{ trans('components.image_replace') }}</button>
+                            <button type="button"
+                                    id="image-manager-rebuild-thumbs"
+                                    class="text-item">{{ trans('components.image_rebuild_thumbs') }}</button>
                         @endif
                     </div>
                 </div>

--- a/resources/views/pages/parts/image-manager-form.blade.php
+++ b/resources/views/pages/parts/image-manager-form.blade.php
@@ -8,7 +8,16 @@
      option:dropzone:file-accept="image/*"
      class="image-manager-details">
 
+    @if($warning ?? '')
+        <div class="image-manager-warning px-m py-xs flex-container-row gap-xs items-center mb-l">
+            <div>@icon('warning')</div>
+            <div class="flex">{{ $warning }}</div>
+        </div>
+    @endif
+
     <div refs="dropzone@status-area dropzone@drop-target"></div>
+
+    <script id="image-manager-form-image-data" type="application/json">@json($image)</script>
 
     <form component="ajax-form"
           option:ajax-form:success-message="{{ trans('components.image_update_success') }}"

--- a/resources/views/pages/parts/image-manager-list.blade.php
+++ b/resources/views/pages/parts/image-manager-list.blade.php
@@ -1,3 +1,9 @@
+@if($warning ?? '')
+    <div class="image-manager-list-warning image-manager-warning px-m py-xs flex-container-row gap-xs items-center">
+        <div>@icon('warning')</div>
+        <div class="flex">{{ $warning }}</div>
+    </div>
+@endif
 @foreach($images as $index => $image)
 <div>
     <button component="event-emit-select"
@@ -5,7 +11,7 @@
          option:event-emit-select:data="{{ json_encode($image) }}"
          class="image anim fadeIn text-link"
          style="animation-delay: {{ min($index * 10, 260) . 'ms' }};">
-        <img src="{{ $image->thumbs['gallery'] }}"
+        <img src="{{ $image->thumbs['gallery'] ?? '' }}"
              alt="{{ $image->name }}"
              role="none"
              width="150"

--- a/routes/web.php
+++ b/routes/web.php
@@ -142,6 +142,7 @@ Route::middleware('auth')->group(function () {
     Route::post('/images/drawio', [UploadControllers\DrawioImageController::class, 'create']);
     Route::get('/images/edit/{id}', [UploadControllers\ImageController::class, 'edit']);
     Route::put('/images/{id}/file', [UploadControllers\ImageController::class, 'updateFile']);
+    Route::put('/images/{id}/rebuild-thumbnails', [UploadControllers\ImageController::class, 'rebuildThumbnails']);
     Route::put('/images/{id}', [UploadControllers\ImageController::class, 'update']);
     Route::delete('/images/{id}', [UploadControllers\ImageController::class, 'destroy']);
 

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Foundation\Http\Middleware\ValidatePostSize;
 use Illuminate\Support\Facades\Log;
 
 class ErrorTest extends TestCase
@@ -44,5 +45,17 @@ class ErrorTest extends TestCase
         $resp = $this->actingAs($this->users->viewer())->get('/uploads/images/gallery/2021-05/anonexistingimage.png');
         $resp->assertStatus(404);
         $resp->assertSeeText('Image Not Found');
+    }
+
+    public function test_posts_above_php_limit_shows_friendly_error()
+    {
+        // Fake super large JSON request
+        $resp = $this->asEditor()->call('GET', '/books', [], [], [], [
+            'CONTENT_LENGTH' => '10000000000',
+            'HTTP_ACCEPT' => 'application/json',
+        ]);
+
+        $resp->assertStatus(413);
+        $resp->assertJson(['error' => 'The server cannot receive the provided amount of data. Try again with less data or a smaller file.']);
     }
 }

--- a/tests/Helpers/FileProvider.php
+++ b/tests/Helpers/FileProvider.php
@@ -133,10 +133,19 @@ class FileProvider
      */
     public function deleteAtRelativePath(string $path): void
     {
-        $fullPath = public_path($path);
+        $fullPath = $this->relativeToFullPath($path);
         if (file_exists($fullPath)) {
             unlink($fullPath);
         }
+    }
+
+    /**
+     * Convert a relative path used by default in this provider to a full
+     * absolute local filesystem path.
+     */
+    public function relativeToFullPath(string $path): string
+    {
+        return public_path($path);
     }
 
     /**

--- a/tests/Uploads/ImageTest.php
+++ b/tests/Uploads/ImageTest.php
@@ -552,6 +552,29 @@ class ImageTest extends TestCase
         $this->files->deleteAtRelativePath($relPath);
     }
 
+    public function test_image_manager_regen_thumbnails()
+    {
+        $this->asEditor();
+        $imageName = 'first-image.png';
+        $relPath = $this->files->expectedImagePath('gallery', $imageName);
+
+        $this->files->uploadGalleryImage($this, $imageName, $this->entities->page()->id);
+        $image = Image::first();
+
+        $resp = $this->get("/images/edit/{$image->id}");
+        $this->withHtml($resp)->assertElementExists('button#image-manager-rebuild-thumbs');
+
+        $expectedThumbPath = dirname($relPath) . '/scaled-1680-/' . basename($relPath);
+        $this->files->deleteAtRelativePath($expectedThumbPath);
+        $this->assertFileDoesNotExist($this->files->relativeToFullPath($expectedThumbPath));
+
+        $resp = $this->put("/images/{$image->id}/rebuild-thumbnails");
+        $resp->assertOk();
+
+        $this->assertFileExists($this->files->relativeToFullPath($expectedThumbPath));
+        $this->files->deleteAtRelativePath($relPath);
+    }
+
     protected function getTestProfileImage()
     {
         $imageName = 'profile.png';

--- a/tests/Uploads/ImageTest.php
+++ b/tests/Uploads/ImageTest.php
@@ -557,6 +557,7 @@ class ImageTest extends TestCase
         $this->asEditor();
         $imageName = 'first-image.png';
         $relPath = $this->files->expectedImagePath('gallery', $imageName);
+        $this->files->deleteAtRelativePath($relPath);
 
         $this->files->uploadGalleryImage($this, $imageName, $this->entities->page()->id);
         $image = Image::first();


### PR DESCRIPTION
Related to #4454.

- Adds friendlier handling, with proper message, for requests caught by Laravel's ValidatePostSize middleware.
- Refactors and splits out much of the image file handling.

### Todo

- [x] Roll out OOM handling to other endpoints where thumbs are created
  - [x] Roll out to gallery responses, so images are created via these means but the original view is still returned if an OOM occurance happens. Needs juggling of view and thumbnail gen.
    - [x] Drawings
    - [x] Images
- [x] Test new thumbnail regen endpoint
- [x] Fix large thumbnails when image manager only has single/few images in list.

### Notes

- See `Illuminate\Foundation\Bootstrap\HandleExceptions` for example of reserving memory and handling errors (via `register_shutdown_function`). Can run custom hook through `register_shutdown_function`.  Need to test conflicts with Laravel's own handling.
- Need to consider for API also.

### Screenshots

Preview of added image manager handling:

![Screenshot 2023-10-01 at 12-54-46 Editing Page Comment testing The BookStack](https://github.com/BookStackApp/BookStack/assets/8343178/0de8503a-eb58-45d8-8a1b-f09d20c0f110)

