### PR TITLE
New include tag parser

### DIFF
--- a/app/Entities/Tools/PageContent.php
+++ b/app/Entities/Tools/PageContent.php
@@ -5,8 +5,6 @@ namespace BookStack\Entities\Tools;
 use BookStack\Entities\Models\Page;
 use BookStack\Entities\Tools\Markdown\MarkdownToHtml;
 use BookStack\Exceptions\ImageUploadException;
-use BookStack\Facades\Theme;
-use BookStack\Theming\ThemeEvents;
 use BookStack\Uploads\ImageRepo;
 use BookStack\Uploads\ImageService;
 use BookStack\Util\HtmlContentFilter;
@@ -293,8 +291,14 @@ class PageContent
         $parser = new PageIncludeParser($doc, $contentProvider);
         $nodesAdded = 1;
 
-        for ($includeDepth = 0; $includeDepth < 3 && $nodesAdded !== 0; $includeDepth++) {
+        for ($includeDepth = 0; $includeDepth < 1 && $nodesAdded !== 0; $includeDepth++) {
             $nodesAdded = $parser->parse();
+        }
+
+        if ($includeDepth > 1) {
+            $idMap = [];
+            $changeMap = [];
+            $this->updateIdsRecursively($doc->getBody(), 0, $idMap, $changeMap);
         }
 
         if (!config('app.allow_content_scripts')) {

--- a/app/Entities/Tools/PageIncludeContent.php
+++ b/app/Entities/Tools/PageIncludeContent.php
@@ -14,7 +14,7 @@ class PageIncludeContent
      */
     protected array $contents = [];
 
-    protected bool $isTopLevel;
+    protected bool $isTopLevel = false;
 
     public function __construct(
         string $html,

--- a/app/Entities/Tools/PageIncludeContent.php
+++ b/app/Entities/Tools/PageIncludeContent.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace BookStack\Entities\Tools;
+
+use BookStack\Util\HtmlDocument;
+use DOMNode;
+
+class PageIncludeContent
+{
+    protected static array $topLevelTags = ['table', 'ul', 'ol', 'pre'];
+
+    /**
+     * @var DOMNode[]
+     */
+    protected array $contents = [];
+
+    protected bool $isTopLevel;
+
+    public function __construct(
+        string $html,
+        PageIncludeTag $tag,
+    ) {
+        $this->parseHtml($html, $tag);
+    }
+
+    protected function parseHtml(string $html, PageIncludeTag $tag): void
+    {
+        if (empty($html)) {
+            return;
+        }
+
+        $doc = new HtmlDocument($html);
+
+        $sectionId = $tag->getSectionId();
+        if (!$sectionId) {
+            $this->contents = [...$doc->getBodyChildren()];
+            $this->isTopLevel = true;
+            return;
+        }
+
+        $section = $doc->getElementById($sectionId);
+        if (!$section) {
+            return;
+        }
+
+        $isTopLevel = in_array(strtolower($section->nodeName), static::$topLevelTags);
+        $this->isTopLevel = $isTopLevel;
+        $this->contents = $isTopLevel ? [$section] : [...$section->childNodes];
+    }
+
+    public function isInline(): bool
+    {
+        return !$this->isTopLevel;
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->contents);
+    }
+
+    /**
+     * @return DOMNode[]
+     */
+    public function toDomNodes(): array
+    {
+        return $this->contents;
+    }
+}

--- a/app/Entities/Tools/PageIncludeParser.php
+++ b/app/Entities/Tools/PageIncludeParser.php
@@ -19,6 +19,9 @@ class PageIncludeParser
      */
     protected array $toCleanup = [];
 
+    /**
+     * @param Closure(PageIncludeTag $tag): PageContent $pageContentForId
+     */
     public function __construct(
         protected HtmlDocument $doc,
         protected Closure $pageContentForId,
@@ -35,8 +38,8 @@ class PageIncludeParser
         $tags = $this->locateAndIsolateIncludeTags();
 
         foreach ($tags as $tag) {
-            $htmlContent = $this->pageContentForId->call($this, $tag->getPageId());
-            $content = new PageIncludeContent($htmlContent, $tag);
+            /** @var PageIncludeContent $content */
+            $content = $this->pageContentForId->call($this, $tag);
 
             if (!$content->isInline()) {
                 $parentP = $this->getParentParagraph($tag->domNode);

--- a/app/Entities/Tools/PageIncludeParser.php
+++ b/app/Entities/Tools/PageIncludeParser.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BookStack\Entities\Tools;
+
+use BookStack\Util\HtmlDocument;
+use Closure;
+
+class PageIncludeParser
+{
+    protected static string $includeTagRegex = "/{{@\s?([0-9].*?)}}/";
+
+    public function __construct(
+        protected string $pageHtml,
+        protected Closure $pageContentForId,
+    ) {
+    }
+
+    public function parse(): string
+    {
+        $html = new HtmlDocument($this->pageHtml);
+
+        $includeHosts = $html->queryXPath("//body//*[contains(text(), '{{@')]");
+        $node = $includeHosts->item(0);
+
+        // One of the direct child textnodes of the "$includeHosts" should be
+        // the one with the include tag within.
+        $textNode = $node->childNodes->item(0);
+
+        // TODO:
+        // Hunt down the specific text nodes with matches
+        // Split out tag text node from rest of content
+        // Fetch tag content->
+          // If range or top-block: delete tag text node, [Promote to top-block], delete old top-block if empty
+          // If inline: Replace current text node with new text or elem
+        // !! "Range" or "inline" status should come from tag parser and content fetcher, not guessed direct from content
+        //     since we could have a range of inline elements
+
+        // [Promote to top-block]
+        // Tricky operation.
+        // Can throw in before or after current top-block depending on relative position
+        // Could [Split] top-block but complex past a single level depth.
+        // Maybe [Split] if one level depth, otherwise default to before/after block
+        // Should work for the vast majority of cases, and not for those which would
+        // technically be invalid in-editor anyway.
+
+        // [Split]
+        // Copy original top-block node type and attrs (apart from ID)
+        // Move nodes after promoted tag-node into copy
+        // Insert copy after original (after promoted top-block eventually)
+
+        // Notes: May want to eventually parse through backwards, which should avoid issues
+        // in changes affecting the next tag, where tags may be in the same/adjacent nodes.
+
+
+        return $html->getBodyInnerHtml();
+    }
+}

--- a/app/Entities/Tools/PageIncludeParser.php
+++ b/app/Entities/Tools/PageIncludeParser.php
@@ -145,6 +145,7 @@ class PageIncludeParser
         $parentText = $parent->textContent;
         $tagPos = strpos($parentText, $tag->tagContent);
         $before = $tagPos < (strlen($parentText) / 2);
+        $this->toCleanup[] = $tag->domNode->parentNode;
 
         if ($before) {
             $parent->parentNode->insertBefore($tag->domNode, $parent);
@@ -206,8 +207,10 @@ class PageIncludeParser
     {
         foreach ($this->toCleanup as $element) {
             $element->normalize();
-            if ($element->parentNode && !$element->hasChildNodes()) {
-                $element->parentNode->removeChild($element);
+            while ($element->parentNode && !$element->hasChildNodes()) {
+                $parent = $element->parentNode;
+                $parent->removeChild($element);
+                $element = $parent;
             }
         }
     }

--- a/app/Entities/Tools/PageIncludeTag.php
+++ b/app/Entities/Tools/PageIncludeTag.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace BookStack\Entities\Tools;
+
+use DOMNode;
+
+class PageIncludeTag
+{
+    public function __construct(
+        public string $tagContent,
+        public DOMNode $domNode,
+    ) {
+    }
+
+    /**
+     * Get the page ID that this tag references.
+     */
+    public function getPageId(): int
+    {
+        return intval(trim(explode('#', $this->tagContent, 2)[0]));
+    }
+
+    /**
+     * Get the section ID that this tag references (if any)
+     */
+    public function getSectionId(): string
+    {
+        return trim(explode('#', $this->tagContent, 2)[1] ?? '');
+    }
+}

--- a/app/Theming/CustomHtmlHeadContentProvider.php
+++ b/app/Theming/CustomHtmlHeadContentProvider.php
@@ -50,7 +50,7 @@ class CustomHtmlHeadContentProvider
         $hash = md5($content);
 
         return $this->cache->remember('custom-head-export:' . $hash, 86400, function () use ($content) {
-            return HtmlContentFilter::removeScripts($content);
+            return HtmlContentFilter::removeScriptsFromHtmlString($content);
         });
     }
 

--- a/app/Theming/ThemeEvents.php
+++ b/app/Theming/ThemeEvents.php
@@ -2,8 +2,6 @@
 
 namespace BookStack\Theming;
 
-use BookStack\Entities\Models\Page;
-
 /**
  * The ThemeEvents used within BookStack.
  *
@@ -93,8 +91,8 @@ class ThemeEvents
      *
      * @param string $tagReference
      * @param string $replacementHTML
-     * @param Page   $currentPage
-     * @param ?Page  $referencedPage
+     * @param \BookStack\Entities\Models\Page   $currentPage
+     * @param ?\BookStack\Entities\Models\Page  $referencedPage
      */
     const PAGE_INCLUDE_PARSE = 'page_include_parse';
 

--- a/app/Theming/ThemeService.php
+++ b/app/Theming/ThemeService.php
@@ -49,6 +49,14 @@ class ThemeService
     }
 
     /**
+     * Check if there are listeners registered for the given event name.
+     */
+    public function hasListeners(string $event): bool
+    {
+        return count($this->listeners[$event] ?? []) > 0;
+    }
+
+    /**
      * Register a new custom artisan command to be available.
      */
     public function registerCommand(Command $command): void

--- a/app/Util/HtmlContentFilter.php
+++ b/app/Util/HtmlContentFilter.php
@@ -9,16 +9,10 @@ use DOMNodeList;
 class HtmlContentFilter
 {
     /**
-     * Remove all the script elements from the given HTML.
+     * Remove all the script elements from the given HTML document.
      */
-    public static function removeScripts(string $html): string
+    public static function removeScriptsFromDocument(HtmlDocument $doc)
     {
-        if (empty($html)) {
-            return $html;
-        }
-
-        $doc = new HtmlDocument($html);
-
         // Remove standard script tags
         $scriptElems = $doc->queryXPath('//script');
         static::removeNodes($scriptElems);
@@ -53,6 +47,19 @@ class HtmlContentFilter
         // Remove 'on*' attributes
         $onAttributes = $doc->queryXPath('//@*[starts-with(name(), \'on\')]');
         static::removeAttributes($onAttributes);
+    }
+
+    /**
+     * Remove scripts from the given HTML string.
+     */
+    public static function removeScriptsFromHtmlString(string $html): string
+    {
+        if (empty($html)) {
+            return $html;
+        }
+
+        $doc = new HtmlDocument($html);
+        static::removeScriptsFromDocument($doc);
 
         return $doc->getBodyInnerHtml();
     }

--- a/app/Util/HtmlDocument.php
+++ b/app/Util/HtmlDocument.php
@@ -149,4 +149,19 @@ class HtmlDocument
     {
         return $this->document->saveHTML($node);
     }
+
+    /**
+     * Adopt the given nodes into this document.
+     * @param DOMNode[] $nodes
+     * @return DOMNode[]
+     */
+    public function adoptNodes(array $nodes): array
+    {
+        $adopted = [];
+        foreach ($nodes as $node) {
+            $adopted[] = $this->document->importNode($node, true);
+        }
+
+        return $adopted;
+    }
 }

--- a/app/Util/HtmlDocument.php
+++ b/app/Util/HtmlDocument.php
@@ -149,19 +149,4 @@ class HtmlDocument
     {
         return $this->document->saveHTML($node);
     }
-
-    /**
-     * Adopt the given nodes into this document.
-     * @param DOMNode[] $nodes
-     * @return DOMNode[]
-     */
-    public function adoptNodes(array $nodes): array
-    {
-        $adopted = [];
-        foreach ($nodes as $node) {
-            $adopted[] = $this->document->importNode($node, true);
-        }
-
-        return $adopted;
-    }
 }

--- a/tests/Entity/PageContentTest.php
+++ b/tests/Entity/PageContentTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase;
 
 class PageContentTest extends TestCase
 {
-    protected $base64Jpeg = '/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=';
+    protected string $base64Jpeg = '/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=';
 
     public function test_page_includes()
     {
@@ -55,38 +55,6 @@ class PageContentTest extends TestCase
         $page = Page::find($page->id);
         $this->assertStringContainsString($includeTag, $page->html);
         $this->assertEquals('', $page->text);
-    }
-
-    public function test_page_includes_do_not_break_tables()
-    {
-        $page = $this->entities->page();
-        $secondPage = $this->entities->page();
-
-        $content = '<table id="table"><tbody><tr><td>test</td></tr></tbody></table>';
-        $secondPage->html = $content;
-        $secondPage->save();
-
-        $page->html = "{{@{$secondPage->id}#table}}";
-        $page->save();
-
-        $pageResp = $this->asEditor()->get($page->getUrl());
-        $pageResp->assertSee($content, false);
-    }
-
-    public function test_page_includes_do_not_break_code()
-    {
-        $page = $this->entities->page();
-        $secondPage = $this->entities->page();
-
-        $content = '<pre id="bkmrk-code"><code>var cat = null;</code></pre>';
-        $secondPage->html = $content;
-        $secondPage->save();
-
-        $page->html = "{{@{$secondPage->id}#bkmrk-code}}";
-        $page->save();
-
-        $pageResp = $this->asEditor()->get($page->getUrl());
-        $pageResp->assertSee($content, false);
     }
 
     public function test_page_includes_rendered_on_book_export()

--- a/tests/Entity/PageContentTest.php
+++ b/tests/Entity/PageContentTest.php
@@ -88,6 +88,19 @@ class PageContentTest extends TestCase
         $this->withHtml($pageResp)->assertElementNotContains('#bkmrk-test', 'Hello Barry Hello Barry Hello Barry Hello Barry Hello Barry ' . $tag);
     }
 
+    public function test_page_includes_to_nonexisting_pages_does_not_error()
+    {
+        $page = $this->entities->page();
+        $missingId = Page::query()->max('id') + 1;
+        $tag = "{{@{$missingId}}}";
+        $page->html = '<p id="bkmrk-test">Hello Barry ' . $tag . '</p>';
+        $page->save();
+
+        $pageResp = $this->asEditor()->get($page->getUrl());
+        $pageResp->assertOk();
+        $pageResp->assertSee('Hello Barry');
+    }
+
     public function test_page_content_scripts_removed_by_default()
     {
         $this->asEditor();

--- a/tests/Unit/PageIncludeParserTest.php
+++ b/tests/Unit/PageIncludeParserTest.php
@@ -7,7 +7,7 @@ use Tests\TestCase;
 
 class PageIncludeParserTest extends TestCase
 {
-    public function test_include_simple_inline_text()
+    public function test_simple_inline_text()
     {
         $this->runParserTest(
             '<p>{{@45#content}}</p>',
@@ -16,7 +16,7 @@ class PageIncludeParserTest extends TestCase
         );
     }
 
-    public function test_include_simple_inline_text_with_existing_siblings()
+    public function test_simple_inline_text_with_existing_siblings()
     {
         $this->runParserTest(
             '<p>{{@45#content}} <strong>Hi</strong>there!</p>',
@@ -25,12 +25,102 @@ class PageIncludeParserTest extends TestCase
         );
     }
 
-    public function test_include_simple_inline_text_within_other_text()
+    public function test_simple_inline_text_within_other_text()
     {
         $this->runParserTest(
             '<p>Hello {{@45#content}}there!</p>',
             ['45' => '<p id="content">Testing</p>'],
             '<p>Hello Testingthere!</p>',
+        );
+    }
+
+    public function test_block_content_types()
+    {
+        $inputs = [
+            '<table id="content"><td>Text</td></table>',
+            '<ul id="content"><li>Item A</li></ul>',
+            '<ol id="content"><li>Item A</li></ol>',
+            '<pre id="content">Code</pre>',
+        ];
+
+        foreach ($inputs as $input) {
+            $this->runParserTest(
+                '<p>A{{@45#content}}B</p>',
+                ['45' => $input],
+                '<p>A</p>' . $input . '<p>B</p>',
+            );
+        }
+    }
+
+    public function test_block_content_nested_origin_gets_placed_before()
+    {
+        $this->runParserTest(
+            '<p><strong>A {{@45#content}} there!</strong></p>',
+            ['45' => '<pre id="content">Testing</pre>'],
+            '<pre id="content">Testing</pre><p><strong>A  there!</strong></p>',
+        );
+    }
+
+    public function test_block_content_nested_origin_gets_placed_after()
+    {
+        $this->runParserTest(
+            '<p><strong>Some really good {{@45#content}} there!</strong></p>',
+            ['45' => '<pre id="content">Testing</pre>'],
+            '<p><strong>Some really good  there!</strong></p><pre id="content">Testing</pre>',
+        );
+    }
+
+    public function test_block_content_in_shallow_origin_gets_split()
+    {
+        $this->runParserTest(
+            '<p>Some really good {{@45#content}} there!</p>',
+            ['45' => '<pre id="content">doggos</pre>'],
+            '<p>Some really good </p><pre id="content">doggos</pre><p> there!</p>',
+        );
+    }
+
+    public function test_block_content_in_shallow_origin_split_does_not_duplicate_id()
+    {
+        $this->runParserTest(
+            '<p id="test" title="Hi">Some really good {{@45#content}} there!</p>',
+            ['45' => '<pre id="content">doggos</pre>'],
+            '<p title="Hi">Some really good </p><pre id="content">doggos</pre><p id="test" title="Hi"> there!</p>',
+        );
+    }
+
+    public function test_block_content_in_shallow_origin_does_not_leave_empty_nodes()
+    {
+        $this->runParserTest(
+            '<p>{{@45#content}}</p>',
+            ['45' => '<pre id="content">doggos</pre>'],
+            '<pre id="content">doggos</pre>',
+        );
+    }
+
+    public function test_simple_whole_document()
+    {
+        $this->runParserTest(
+            '<p>{{@45}}</p>',
+            ['45' => '<p id="content">Testing</p>'],
+            '<p id="content">Testing</p>',
+        );
+    }
+
+    public function test_multi_source_elem_whole_document()
+    {
+        $this->runParserTest(
+            '<p>{{@45}}</p>',
+            ['45' => '<p>Testing</p><blockquote>This</blockquote>'],
+            '<p>Testing</p><blockquote>This</blockquote>',
+        );
+    }
+
+    public function test_multi_source_elem_whole_document_with_shared_content_origin()
+    {
+        $this->runParserTest(
+            '<p>This is {{@45}} some text</p>',
+            ['45' => '<p>Testing</p><blockquote>This</blockquote>'],
+            '<p>This is </p><p>Testing</p><blockquote>This</blockquote><p> some text</p>',
         );
     }
 

--- a/tests/Unit/PageIncludeParserTest.php
+++ b/tests/Unit/PageIncludeParserTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Unit;
 
+use BookStack\Entities\Tools\PageIncludeContent;
 use BookStack\Entities\Tools\PageIncludeParser;
+use BookStack\Entities\Tools\PageIncludeTag;
 use BookStack\Util\HtmlDocument;
 use Tests\TestCase;
 
@@ -227,8 +229,9 @@ class PageIncludeParserTest extends TestCase
     protected function runParserTest(string $html, array $contentById, string $expected): void
     {
         $doc = new HtmlDocument($html);
-        $parser = new PageIncludeParser($doc, function (int $id) use ($contentById) {
-            return $contentById[strval($id)] ?? '';
+        $parser = new PageIncludeParser($doc, function (PageIncludeTag $tag) use ($contentById): PageIncludeContent {
+            $html = $contentById[strval($tag->getPageId())] ?? '';
+            return PageIncludeContent::fromHtmlAndTag($html, $tag);
         });
 
         $parser->parse();

--- a/tests/Unit/PageIncludeParserTest.php
+++ b/tests/Unit/PageIncludeParserTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use BookStack\Entities\Tools\PageIncludeParser;
+use BookStack\Util\HtmlDocument;
 use Tests\TestCase;
 
 class PageIncludeParserTest extends TestCase
@@ -214,13 +215,14 @@ class PageIncludeParserTest extends TestCase
         );
     }
 
-    protected function runParserTest(string $html, array $contentById, string $expected)
+    protected function runParserTest(string $html, array $contentById, string $expected): void
     {
-        $parser = new PageIncludeParser($html, function (int $id) use ($contentById) {
+        $doc = new HtmlDocument($html);
+        $parser = new PageIncludeParser($doc, function (int $id) use ($contentById) {
             return $contentById[strval($id)] ?? '';
         });
 
-        $result = $parser->parse();
-        $this->assertEquals($expected, $result);
+        $parser->parse();
+        $this->assertEquals($expected, $doc->getBodyInnerHtml());
     }
 }

--- a/tests/Unit/PageIncludeParserTest.php
+++ b/tests/Unit/PageIncludeParserTest.php
@@ -37,7 +37,7 @@ class PageIncludeParserTest extends TestCase
     protected function runParserTest(string $html, array $contentById, string $expected)
     {
         $parser = new PageIncludeParser($html, function (int $id) use ($contentById) {
-            return $contentById[strval($id)] ?? null;
+            return $contentById[strval($id)] ?? '';
         });
 
         $result = $parser->parse();

--- a/tests/Unit/PageIncludeParserTest.php
+++ b/tests/Unit/PageIncludeParserTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit;
+
+use BookStack\Entities\Tools\PageIncludeParser;
+use Tests\TestCase;
+
+class PageIncludeParserTest extends TestCase
+{
+    public function test_include_simple_inline_text()
+    {
+        $this->runParserTest(
+            '<p>{{@45#content}}</p>',
+            ['45' => '<p id="content">Testing</p>'],
+            '<p>Testing</p>',
+        );
+    }
+
+    public function test_include_simple_inline_text_with_existing_siblings()
+    {
+        $this->runParserTest(
+            '<p>{{@45#content}} <strong>Hi</strong>there!</p>',
+            ['45' => '<p id="content">Testing</p>'],
+            '<p>Testing <strong>Hi</strong>there!</p>',
+        );
+    }
+
+    public function test_include_simple_inline_text_within_other_text()
+    {
+        $this->runParserTest(
+            '<p>Hello {{@45#content}}there!</p>',
+            ['45' => '<p id="content">Testing</p>'],
+            '<p>Hello Testingthere!</p>',
+        );
+    }
+
+    protected function runParserTest(string $html, array $contentById, string $expected)
+    {
+        $parser = new PageIncludeParser($html, function (int $id) use ($contentById) {
+            return $contentById[strval($id)] ?? null;
+        });
+
+        $result = $parser->parse();
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/Unit/PageIncludeParserTest.php
+++ b/tests/Unit/PageIncludeParserTest.php
@@ -179,6 +179,15 @@ class PageIncludeParserTest extends TestCase
         );
     }
 
+    public function test_multi_source_elem_whole_document_with_nested_content_origin()
+    {
+        $this->runParserTest(
+            '<p><strong>{{@45}}</strong></p>',
+            ['45' => '<p>Testing</p><blockquote>This</blockquote>'],
+            '<p>Testing</p><blockquote>This</blockquote>',
+        );
+    }
+
     public function test_multiple_tags_in_same_origin_with_inline_content()
     {
         $this->runParserTest(
@@ -202,7 +211,7 @@ class PageIncludeParserTest extends TestCase
         $this->runParserTest(
             '<div><p>This <strong>{{@45#content}}</strong> content is {{@45#content}}</p>{{@45#content}}</div>',
             ['45' => '<pre id="content">block</pre>'],
-            '<div><pre id="content">block</pre><p>This <strong></strong> content is </p><pre id="content">block</pre><pre id="content">block</pre></div>',
+            '<div><pre id="content">block</pre><p>This  content is </p><pre id="content">block</pre><pre id="content">block</pre></div>',
         );
     }
 

--- a/tests/Unit/PageIncludeParserTest.php
+++ b/tests/Unit/PageIncludeParserTest.php
@@ -34,6 +34,15 @@ class PageIncludeParserTest extends TestCase
         );
     }
 
+    public function test_complex_inline_text_within_other_text()
+    {
+        $this->runParserTest(
+            '<p>Hello {{@45#content}}there!</p>',
+            ['45' => '<p id="content"><strong>Testing</strong> with<em>some</em><i>extra</i>tags</p>'],
+            '<p>Hello <strong>Testing</strong> with<em>some</em><i>extra</i>tagsthere!</p>',
+        );
+    }
+
     public function test_block_content_types()
     {
         $inputs = [
@@ -97,6 +106,51 @@ class PageIncludeParserTest extends TestCase
         );
     }
 
+    public function test_block_content_in_allowable_parent_element()
+    {
+        $this->runParserTest(
+            '<div>{{@45#content}}</div>',
+            ['45' => '<pre id="content">doggos</pre>'],
+            '<div><pre id="content">doggos</pre></div>',
+        );
+    }
+
+    public function test_block_content_in_paragraph_origin_with_allowable_grandparent()
+    {
+        $this->runParserTest(
+            '<div><p>{{@45#content}}</p></div>',
+            ['45' => '<pre id="content">doggos</pre>'],
+            '<div><pre id="content">doggos</pre></div>',
+        );
+    }
+
+    public function test_block_content_in_paragraph_origin_with_allowable_grandparent_with_adjacent_content()
+    {
+        $this->runParserTest(
+            '<div><p>Cute {{@45#content}} over there!</p></div>',
+            ['45' => '<pre id="content">doggos</pre>'],
+            '<div><p>Cute </p><pre id="content">doggos</pre><p> over there!</p></div>',
+        );
+    }
+
+    public function test_block_content_in_child_within_paragraph_origin_with_allowable_grandparent_with_adjacent_content()
+    {
+        $this->runParserTest(
+            '<div><p><strong>Cute {{@45#content}} over there!</strong></p></div>',
+            ['45' => '<pre id="content">doggos</pre>'],
+            '<div><pre id="content">doggos</pre><p><strong>Cute  over there!</strong></p></div>',
+        );
+    }
+
+    public function test_block_content_in_paragraph_origin_within_details()
+    {
+        $this->runParserTest(
+            '<details><p>{{@45#content}}</p></details>',
+            ['45' => '<pre id="content">doggos</pre>'],
+            '<details><pre id="content">doggos</pre></details>',
+        );
+    }
+
     public function test_simple_whole_document()
     {
         $this->runParserTest(
@@ -121,6 +175,42 @@ class PageIncludeParserTest extends TestCase
             '<p>This is {{@45}} some text</p>',
             ['45' => '<p>Testing</p><blockquote>This</blockquote>'],
             '<p>This is </p><p>Testing</p><blockquote>This</blockquote><p> some text</p>',
+        );
+    }
+
+    public function test_multiple_tags_in_same_origin_with_inline_content()
+    {
+        $this->runParserTest(
+            '<p>This {{@45#content}}{{@45#content}} content is {{@45#content}}</p>',
+            ['45' => '<p id="content">inline</p>'],
+            '<p>This inlineinline content is inline</p>',
+        );
+    }
+
+    public function test_multiple_tags_in_same_origin_with_block_content()
+    {
+        $this->runParserTest(
+            '<p>This {{@45#content}}{{@45#content}} content is {{@45#content}}</p>',
+            ['45' => '<pre id="content">block</pre>'],
+            '<p>This </p><pre id="content">block</pre><pre id="content">block</pre><p> content is </p><pre id="content">block</pre>',
+        );
+    }
+
+    public function test_multiple_tags_in_differing_origin_levels_with_block_content()
+    {
+        $this->runParserTest(
+            '<div><p>This <strong>{{@45#content}}</strong> content is {{@45#content}}</p>{{@45#content}}</div>',
+            ['45' => '<pre id="content">block</pre>'],
+            '<div><pre id="content">block</pre><p>This <strong></strong> content is </p><pre id="content">block</pre><pre id="content">block</pre></div>',
+        );
+    }
+
+    public function test_multiple_tags_in_shallow_origin_with_multi_block_content()
+    {
+        $this->runParserTest(
+            '<p>{{@45}}C{{@45}}</p><div>{{@45}}{{@45}}</div>',
+            ['45' => '<p>A</p><p>B</p>'],
+            '<p>A</p><p>B</p><p>C</p><p>A</p><p>B</p><div><p>A</p><p>B</p><p>A</p><p>B</p></div>',
         );
     }
 


### PR DESCRIPTION
### Todo

- [x] Consider usage with details blocks (Maybe other acceptable top levels? Could be worth inverting to handle blocks that don't allow this.
  - [This page has a list](https://blog.teamtreehouse.com/to-close-or-not-to-close-tags-in-html5): html, head, body, p, dt, dd, li, ption, thead, th, tbody, tr, td, tfoot, colgroup.
  - In the end, I made this specific to `p` tags since that's the large case to target, otherwise most existing parents should be fine. Will be edge-cases (header in other headers etc...) but are much more likely to be user-driven and solvable, and harder to fall into.
- [x] Add multi-depth support (3 levels as per production)
- [x] Look to update/handle the logical theme system event somehow.
- [x] Handle duplicate IDs?
- [x] Expand test cases
  - [x] Multiple tags in same elem.

### Doc Updates

- Note (potentially) breaking change of include behaviour as update advisory.
- ~~Note break/change in include event~~.
- Maybe update page include docs with some technical info regarding it's behaviour?