### PR TITLE
OIDC RP-Initiated logout

### DIFF
--- a/.env.example.complete
+++ b/.env.example.complete
@@ -273,7 +273,7 @@ OIDC_USER_TO_GROUPS=false
 OIDC_GROUPS_CLAIM=groups
 OIDC_REMOVE_FROM_GROUPS=false
 OIDC_EXTERNAL_ID_CLAIM=sub
-OIDC_END_SESSION_ENDPOINT=null
+OIDC_END_SESSION_ENDPOINT=false
 
 # Disable default third-party services such as Gravatar and Draw.IO
 # Service-specific options will override this option

--- a/.env.example.complete
+++ b/.env.example.complete
@@ -274,6 +274,10 @@ OIDC_GROUPS_CLAIM=groups
 OIDC_REMOVE_FROM_GROUPS=false
 OIDC_EXTERNAL_ID_CLAIM=sub
 
+# OIDC Logout Feature: Its value should be value of end_session_endpoint from <issuer>/.well-known/openid-configuration 
+OIDC_END_SESSION_ENDPOINT=null
+
+
 # Disable default third-party services such as Gravatar and Draw.IO
 # Service-specific options will override this option
 DISABLE_EXTERNAL_SERVICES=false

--- a/.env.example.complete
+++ b/.env.example.complete
@@ -273,10 +273,7 @@ OIDC_USER_TO_GROUPS=false
 OIDC_GROUPS_CLAIM=groups
 OIDC_REMOVE_FROM_GROUPS=false
 OIDC_EXTERNAL_ID_CLAIM=sub
-
-# OIDC Logout Feature: Its value should be value of end_session_endpoint from <issuer>/.well-known/openid-configuration 
 OIDC_END_SESSION_ENDPOINT=null
-
 
 # Disable default third-party services such as Gravatar and Draw.IO
 # Service-specific options will override this option

--- a/app/Access/Controllers/OidcController.php
+++ b/app/Access/Controllers/OidcController.php
@@ -11,9 +11,6 @@ class OidcController extends Controller
 {
     protected OidcService $oidcService;
 
-    /**
-     * OpenIdController constructor.
-     */
     public function __construct(OidcService $oidcService)
     {
         $this->oidcService = $oidcService;
@@ -65,16 +62,10 @@ class OidcController extends Controller
     }
 
     /**
-     * OIDC Logout Feature: Start the authorization logout flow via OIDC.
+     * Log the user out then start the OIDC RP-initiated logout process.
      */
     public function logout()
     {
-        try {
-            return $this->oidcService->logout();
-        } catch (OidcException $exception) {
-            $this->showErrorNotification($exception->getMessage());
-            return redirect('/logout');
-        }
+        return redirect($this->oidcService->logout());
     }
-
 }

--- a/app/Access/Controllers/OidcController.php
+++ b/app/Access/Controllers/OidcController.php
@@ -63,4 +63,18 @@ class OidcController extends Controller
 
         return redirect()->intended();
     }
+
+    /**
+     * OIDC Logout Feature: Start the authorization logout flow via OIDC.
+     */
+    public function logout()
+    {
+        try {
+            return $this->oidcService->logout();
+        } catch (OidcException $exception) {
+            $this->showErrorNotification($exception->getMessage());
+            return redirect('/logout');
+        }
+    }
+
 }

--- a/app/Access/Controllers/RegisterController.php
+++ b/app/Access/Controllers/RegisterController.php
@@ -4,7 +4,7 @@ namespace BookStack\Access\Controllers;
 
 use BookStack\Access\LoginService;
 use BookStack\Access\RegistrationService;
-use BookStack\Access\SocialAuthService;
+use BookStack\Access\SocialDriverManager;
 use BookStack\Exceptions\StoppedAuthenticationException;
 use BookStack\Exceptions\UserRegistrationException;
 use BookStack\Http\Controller;
@@ -15,7 +15,7 @@ use Illuminate\Validation\Rules\Password;
 
 class RegisterController extends Controller
 {
-    protected SocialAuthService $socialAuthService;
+    protected SocialDriverManager $socialDriverManager;
     protected RegistrationService $registrationService;
     protected LoginService $loginService;
 
@@ -23,14 +23,14 @@ class RegisterController extends Controller
      * Create a new controller instance.
      */
     public function __construct(
-        SocialAuthService $socialAuthService,
+        SocialDriverManager $socialDriverManager,
         RegistrationService $registrationService,
         LoginService $loginService
     ) {
         $this->middleware('guest');
         $this->middleware('guard:standard');
 
-        $this->socialAuthService = $socialAuthService;
+        $this->socialDriverManager = $socialDriverManager;
         $this->registrationService = $registrationService;
         $this->loginService = $loginService;
     }
@@ -43,7 +43,7 @@ class RegisterController extends Controller
     public function getRegister()
     {
         $this->registrationService->ensureRegistrationAllowed();
-        $socialDrivers = $this->socialAuthService->getActiveDrivers();
+        $socialDrivers = $this->socialDriverManager->getActive();
 
         return view('auth.register', [
             'socialDrivers' => $socialDrivers,

--- a/app/Access/Controllers/SocialController.php
+++ b/app/Access/Controllers/SocialController.php
@@ -79,7 +79,7 @@ class SocialController extends Controller
             try {
                 return $this->socialAuthService->handleLoginCallback($socialDriver, $socialUser);
             } catch (SocialSignInAccountNotUsed $exception) {
-                if ($this->socialAuthService->driverAutoRegisterEnabled($socialDriver)) {
+                if ($this->socialAuthService->drivers()->isAutoRegisterEnabled($socialDriver)) {
                     return $this->socialRegisterCallback($socialDriver, $socialUser);
                 }
 
@@ -114,7 +114,7 @@ class SocialController extends Controller
     {
         $socialUser = $this->socialAuthService->handleRegistrationCallback($socialDriver, $socialUser);
         $socialAccount = $this->socialAuthService->newSocialAccount($socialDriver, $socialUser);
-        $emailVerified = $this->socialAuthService->driverAutoConfirmEmailEnabled($socialDriver);
+        $emailVerified = $this->socialAuthService->drivers()->isAutoConfirmEmailEnabled($socialDriver);
 
         // Create an array of the user data to create a new user instance
         $userData = [

--- a/app/Access/LoginService.php
+++ b/app/Access/LoginService.php
@@ -16,13 +16,11 @@ class LoginService
 {
     protected const LAST_LOGIN_ATTEMPTED_SESSION_KEY = 'auth-login-last-attempted';
 
-    protected $mfaSession;
-    protected $emailConfirmationService;
-
-    public function __construct(MfaSession $mfaSession, EmailConfirmationService $emailConfirmationService)
-    {
-        $this->mfaSession = $mfaSession;
-        $this->emailConfirmationService = $emailConfirmationService;
+    public function __construct(
+        protected MfaSession $mfaSession,
+        protected EmailConfirmationService $emailConfirmationService,
+        protected SocialDriverManager $socialDriverManager,
+    ) {
     }
 
     /**
@@ -162,5 +160,30 @@ class LoginService
         }
 
         return $result;
+    }
+
+    /**
+     * Logs the current user out of the application.
+     * Returns an app post-redirect path.
+     */
+    public function logout(): string
+    {
+        auth()->logout();
+        session()->invalidate();
+        session()->regenerateToken();
+
+        return $this->shouldAutoInitiate() ? '/login?prevent_auto_init=true' : '/';
+    }
+
+    /**
+     * Check if login auto-initiate should be valid based upon authentication config.
+     */
+    protected function shouldAutoInitiate(): bool
+    {
+        $socialDrivers = $this->socialDriverManager->getActive();
+        $authMethod = config('auth.method');
+        $autoRedirect = config('auth.auto_initiate');
+
+        return $autoRedirect && count($socialDrivers) === 0 && in_array($authMethod, ['oidc', 'saml2']);
     }
 }

--- a/app/Access/LoginService.php
+++ b/app/Access/LoginService.php
@@ -176,14 +176,18 @@ class LoginService
     }
 
     /**
-     * Check if login auto-initiate should be valid based upon authentication config.
+     * Check if login auto-initiate should be active based upon authentication config.
      */
-    protected function shouldAutoInitiate(): bool
+    public function shouldAutoInitiate(): bool
     {
+        $autoRedirect = config('auth.auto_initiate');
+        if (!$autoRedirect) {
+            return false;
+        }
+
         $socialDrivers = $this->socialDriverManager->getActive();
         $authMethod = config('auth.method');
-        $autoRedirect = config('auth.auto_initiate');
 
-        return $autoRedirect && count($socialDrivers) === 0 && in_array($authMethod, ['oidc', 'saml2']);
+        return count($socialDrivers) === 0 && in_array($authMethod, ['oidc', 'saml2']);
     }
 }

--- a/app/Access/Oidc/OidcProviderSettings.php
+++ b/app/Access/Oidc/OidcProviderSettings.php
@@ -21,6 +21,7 @@ class OidcProviderSettings
     public ?string $redirectUri;
     public ?string $authorizationEndpoint;
     public ?string $tokenEndpoint;
+    public ?string $endSessionEndpoint;
 
     /**
      * @var string[]|array[]
@@ -130,6 +131,10 @@ class OidcProviderSettings
         if (!empty($result['jwks_uri'])) {
             $keys = $this->loadKeysFromUri($result['jwks_uri'], $httpClient);
             $discoveredSettings['keys'] = $this->filterKeys($keys);
+        }
+
+        if (!empty($result['end_session_endpoint'])) {
+            $discoveredSettings['endSessionEndpoint'] = $result['end_session_endpoint'];
         }
 
         return $discoveredSettings;

--- a/app/Access/Oidc/OidcService.php
+++ b/app/Access/Oidc/OidcService.php
@@ -301,7 +301,7 @@ class OidcService
     public function logout() {
 
         $config = $this->config();
-        $app_url = env('APP_URL', null);
+        $app_url = env('APP_URL', '');
         $end_session_endpoint = $config["end_session_endpoint"];
 
         $oidctoken = session()->get("oidctoken");

--- a/app/Access/Oidc/OidcService.php
+++ b/app/Access/Oidc/OidcService.php
@@ -84,7 +84,7 @@ class OidcService
             'redirectUri'           => url('/oidc/callback'),
             'authorizationEndpoint' => $config['authorization_endpoint'],
             'tokenEndpoint'         => $config['token_endpoint'],
-            'endSessionEndpoint'    => $config['end_session_endpoint'],
+            'endSessionEndpoint'    => is_string($config['end_session_endpoint']) ? $config['end_session_endpoint'] : null,
         ]);
 
         // Use keys if configured
@@ -102,8 +102,11 @@ class OidcService
         }
 
         // Prevent use of RP-initiated logout if specifically disabled
+        // Or force use of a URL if specifically set.
         if ($config['end_session_endpoint'] === false) {
             $settings->endSessionEndpoint = null;
+        } else if (is_string($config['end_session_endpoint'])) {
+            $settings->endSessionEndpoint = $config['end_session_endpoint'];
         }
 
         $settings->validate();
@@ -314,6 +317,8 @@ class OidcService
             'post_logout_redirect_uri' => $defaultLogoutUrl,
         ];
 
-        return $oidcSettings->endSessionEndpoint . '?' . http_build_query($endpointParams);
+        $joiner = str_contains($oidcSettings->endSessionEndpoint, '?') ? '&' : '?';
+
+        return $oidcSettings->endSessionEndpoint . $joiner . http_build_query($endpointParams);
     }
 }

--- a/app/Access/Saml2Service.php
+++ b/app/Access/Saml2Service.php
@@ -71,8 +71,7 @@ class Saml2Service
                 throw $error;
             }
 
-            $this->actionLogout();
-            $url = '/';
+            $url = $this->loginService->logout();
             $id = null;
         }
 
@@ -140,18 +139,9 @@ class Saml2Service
             );
         }
 
-        $this->actionLogout();
+        $this->loginService->logout();
 
         return $redirect;
-    }
-
-    /**
-     * Do the required actions to log a user out.
-     */
-    protected function actionLogout()
-    {
-        auth()->logout();
-        session()->invalidate();
     }
 
     /**

--- a/app/Access/SocialDriverManager.php
+++ b/app/Access/SocialDriverManager.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace BookStack\Access;
+
+use BookStack\Exceptions\SocialDriverNotConfigured;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+class SocialDriverManager
+{
+    /**
+     * The default built-in social drivers we support.
+     *
+     * @var string[]
+     */
+    protected array $validDrivers = [
+        'google',
+        'github',
+        'facebook',
+        'slack',
+        'twitter',
+        'azure',
+        'okta',
+        'gitlab',
+        'twitch',
+        'discord',
+    ];
+
+    /**
+     * Callbacks to run when configuring a social driver
+     * for an initial redirect action.
+     * Array is keyed by social driver name.
+     * Callbacks are passed an instance of the driver.
+     *
+     * @var array<string, callable>
+     */
+    protected array $configureForRedirectCallbacks = [];
+
+    /**
+     * Check if the current config for the given driver allows auto-registration.
+     */
+    public function isAutoRegisterEnabled(string $driver): bool
+    {
+        return $this->getDriverConfigProperty($driver, 'auto_register') === true;
+    }
+
+    /**
+     * Check if the current config for the given driver allow email address auto-confirmation.
+     */
+    public function isAutoConfirmEmailEnabled(string $driver): bool
+    {
+        return $this->getDriverConfigProperty($driver, 'auto_confirm') === true;
+    }
+
+    /**
+     * Gets the names of the active social drivers, keyed by driver id.
+     * @returns array<string, string>
+     */
+    public function getActive(): array
+    {
+        $activeDrivers = [];
+
+        foreach ($this->validDrivers as $driverKey) {
+            if ($this->checkDriverConfigured($driverKey)) {
+                $activeDrivers[$driverKey] = $this->getName($driverKey);
+            }
+        }
+
+        return $activeDrivers;
+    }
+
+    /**
+     * Get the configure-for-redirect callback for the given driver.
+     * This is a callable that allows modification of the driver at redirect time.
+     * Commonly used to perform custom dynamic configuration where required.
+     * The callback is passed a \Laravel\Socialite\Contracts\Provider instance.
+     */
+    public function getConfigureForRedirectCallback(string $driver): callable
+    {
+        return $this->configureForRedirectCallbacks[$driver] ?? (fn() => true);
+    }
+
+    /**
+     * Add a custom socialite driver to be used.
+     * Driver name should be lower_snake_case.
+     * Config array should mirror the structure of a service
+     * within the `Config/services.php` file.
+     * Handler should be a Class@method handler to the SocialiteWasCalled event.
+     */
+    public function addSocialDriver(
+        string $driverName,
+        array $config,
+        string $socialiteHandler,
+        callable $configureForRedirect = null
+    ) {
+        $this->validDrivers[] = $driverName;
+        config()->set('services.' . $driverName, $config);
+        config()->set('services.' . $driverName . '.redirect', url('/login/service/' . $driverName . '/callback'));
+        config()->set('services.' . $driverName . '.name', $config['name'] ?? $driverName);
+        Event::listen(SocialiteWasCalled::class, $socialiteHandler);
+        if (!is_null($configureForRedirect)) {
+            $this->configureForRedirectCallbacks[$driverName] = $configureForRedirect;
+        }
+    }
+
+    /**
+     * Get the presentational name for a driver.
+     */
+    protected function getName(string $driver): string
+    {
+        return $this->getDriverConfigProperty($driver, 'name') ?? '';
+    }
+
+    protected function getDriverConfigProperty(string $driver, string $property): mixed
+    {
+        return config("services.{$driver}.{$property}");
+    }
+
+    /**
+     * Ensure the social driver is correct and supported.
+     *
+     * @throws SocialDriverNotConfigured
+     */
+    public function ensureDriverActive(string $driverName): void
+    {
+        if (!in_array($driverName, $this->validDrivers)) {
+            abort(404, trans('errors.social_driver_not_found'));
+        }
+
+        if (!$this->checkDriverConfigured($driverName)) {
+            throw new SocialDriverNotConfigured(trans('errors.social_driver_not_configured', ['socialAccount' => Str::title($driverName)]));
+        }
+    }
+
+    /**
+     * Check a social driver has been configured correctly.
+     */
+    protected function checkDriverConfigured(string $driver): bool
+    {
+        $lowerName = strtolower($driver);
+        $configPrefix = 'services.' . $lowerName . '.';
+        $config = [config($configPrefix . 'client_id'), config($configPrefix . 'client_secret'), config('services.callback_url')];
+
+        return !in_array(false, $config) && !in_array(null, $config);
+    }
+}

--- a/app/App/Providers/AppServiceProvider.php
+++ b/app/App/Providers/AppServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace BookStack\App\Providers;
 
-use BookStack\Access\SocialAuthService;
+use BookStack\Access\SocialDriverManager;
 use BookStack\Activity\Tools\ActivityLogger;
 use BookStack\Entities\Models\Book;
 use BookStack\Entities\Models\Bookshelf;
@@ -36,7 +36,7 @@ class AppServiceProvider extends ServiceProvider
     public $singletons = [
         'activity' => ActivityLogger::class,
         SettingService::class => SettingService::class,
-        SocialAuthService::class => SocialAuthService::class,
+        SocialDriverManager::class => SocialDriverManager::class,
         CspService::class => CspService::class,
         HttpRequestService::class => HttpRequestService::class,
     ];

--- a/app/Config/oidc.php
+++ b/app/Config/oidc.php
@@ -37,9 +37,10 @@ return [
     'token_endpoint'         => env('OIDC_TOKEN_ENDPOINT', null),
 
     // OIDC RP-Initiated Logout endpoint URL.
-    // A null value gets the URL from discovery, if active.
     // A false value force-disables RP-Initiated Logout.
-    'end_session_endpoint' => env('OIDC_END_SESSION_ENDPOINT', null),
+    // A true value gets the URL from discovery, if active.
+    // A string value is used as the URL.
+    'end_session_endpoint' => env('OIDC_END_SESSION_ENDPOINT', false),
 
     // Add extra scopes, upon those required, to the OIDC authentication request
     // Multiple values can be provided comma seperated.

--- a/app/Config/oidc.php
+++ b/app/Config/oidc.php
@@ -36,10 +36,9 @@ return [
     'authorization_endpoint' => env('OIDC_AUTH_ENDPOINT', null),
     'token_endpoint'         => env('OIDC_TOKEN_ENDPOINT', null),
 
-    // OIDC RP-Initiated Logout endpoint
+    // OIDC RP-Initiated Logout endpoint URL.
     // A null value gets the URL from discovery, if active.
     // A false value force-disables RP-Initiated Logout.
-    // A string value forces the given URL to be used.
     'end_session_endpoint' => env('OIDC_END_SESSION_ENDPOINT', null),
 
     // Add extra scopes, upon those required, to the OIDC authentication request

--- a/app/Config/oidc.php
+++ b/app/Config/oidc.php
@@ -47,4 +47,9 @@ return [
     'groups_claim' => env('OIDC_GROUPS_CLAIM', 'groups'),
     // When syncing groups, remove any groups that no longer match. Otherwise sync only adds new groups.
     'remove_from_groups' => env('OIDC_REMOVE_FROM_GROUPS', false),
+
+    // OIDC Logout Feature: OAuth2 end_session_endpoint
+    'end_session_endpoint' => env('OIDC_END_SESSION_ENDPOINT', null),
+
 ];
+

--- a/app/Config/oidc.php
+++ b/app/Config/oidc.php
@@ -36,6 +36,12 @@ return [
     'authorization_endpoint' => env('OIDC_AUTH_ENDPOINT', null),
     'token_endpoint'         => env('OIDC_TOKEN_ENDPOINT', null),
 
+    // OIDC RP-Initiated Logout endpoint
+    // A null value gets the URL from discovery, if active.
+    // A false value force-disables RP-Initiated Logout.
+    // A string value forces the given URL to be used.
+    'end_session_endpoint' => env('OIDC_END_SESSION_ENDPOINT', null),
+
     // Add extra scopes, upon those required, to the OIDC authentication request
     // Multiple values can be provided comma seperated.
     'additional_scopes' => env('OIDC_ADDITIONAL_SCOPES', null),
@@ -45,11 +51,6 @@ return [
     'user_to_groups' => env('OIDC_USER_TO_GROUPS', false),
     // Attribute, within a OIDC ID token, to find group names within
     'groups_claim' => env('OIDC_GROUPS_CLAIM', 'groups'),
-    // When syncing groups, remove any groups that no longer match. Otherwise sync only adds new groups.
+    // When syncing groups, remove any groups that no longer match. Otherwise, sync only adds new groups.
     'remove_from_groups' => env('OIDC_REMOVE_FROM_GROUPS', false),
-
-    // OIDC Logout Feature: OAuth2 end_session_endpoint
-    'end_session_endpoint' => env('OIDC_END_SESSION_ENDPOINT', null),
-
 ];
-

--- a/app/Theming/ThemeService.php
+++ b/app/Theming/ThemeService.php
@@ -2,7 +2,7 @@
 
 namespace BookStack\Theming;
 
-use BookStack\Access\SocialAuthService;
+use BookStack\Access\SocialDriverManager;
 use BookStack\Exceptions\ThemeException;
 use Illuminate\Console\Application;
 use Illuminate\Console\Application as Artisan;
@@ -82,11 +82,11 @@ class ThemeService
     }
 
     /**
-     * @see SocialAuthService::addSocialDriver
+     * @see SocialDriverManager::addSocialDriver
      */
     public function addSocialDriver(string $driverName, array $config, string $socialiteHandler, callable $configureForRedirect = null): void
     {
-        $socialAuthService = app()->make(SocialAuthService::class);
-        $socialAuthService->addSocialDriver($driverName, $config, $socialiteHandler, $configureForRedirect);
+        $driverManager = app()->make(SocialDriverManager::class);
+        $driverManager->addSocialDriver($driverName, $config, $socialiteHandler, $configureForRedirect);
     }
 }

--- a/app/Users/Controllers/UserAccountController.php
+++ b/app/Users/Controllers/UserAccountController.php
@@ -2,7 +2,7 @@
 
 namespace BookStack\Users\Controllers;
 
-use BookStack\Access\SocialAuthService;
+use BookStack\Access\SocialDriverManager;
 use BookStack\Http\Controller;
 use BookStack\Permissions\PermissionApplicator;
 use BookStack\Settings\UserNotificationPreferences;
@@ -161,7 +161,7 @@ class UserAccountController extends Controller
     /**
      * Show the view for the "Access & Security" account options.
      */
-    public function showAuth(SocialAuthService $socialAuthService)
+    public function showAuth(SocialDriverManager $socialDriverManager)
     {
         $mfaMethods = user()->mfaValues()->get()->groupBy('method');
 
@@ -171,7 +171,7 @@ class UserAccountController extends Controller
             'category' => 'auth',
             'mfaMethods' => $mfaMethods,
             'authMethod' => config('auth.method'),
-            'activeSocialDrivers' => $socialAuthService->getActiveDrivers(),
+            'activeSocialDrivers' => $socialDriverManager->getActive(),
         ]);
     }
 

--- a/app/Users/Controllers/UserController.php
+++ b/app/Users/Controllers/UserController.php
@@ -2,7 +2,7 @@
 
 namespace BookStack\Users\Controllers;
 
-use BookStack\Access\SocialAuthService;
+use BookStack\Access\SocialDriverManager;
 use BookStack\Exceptions\ImageUploadException;
 use BookStack\Exceptions\UserUpdateException;
 use BookStack\Http\Controller;
@@ -101,7 +101,7 @@ class UserController extends Controller
     /**
      * Show the form for editing the specified user.
      */
-    public function edit(int $id, SocialAuthService $socialAuthService)
+    public function edit(int $id, SocialDriverManager $socialDriverManager)
     {
         $this->checkPermission('users-manage');
 
@@ -109,7 +109,7 @@ class UserController extends Controller
         $user->load(['apiTokens', 'mfaValues']);
         $authMethod = ($user->system_name) ? 'system' : config('auth.method');
 
-        $activeSocialDrivers = $socialAuthService->getActiveDrivers();
+        $activeSocialDrivers = $socialDriverManager->getActive();
         $mfaMethods = $user->mfaValues->groupBy('method');
         $this->setPageTitle(trans('settings.user_profile'));
         $roles = Role::query()->orderBy('display_name', 'asc')->get();

--- a/resources/views/common/header.blade.php
+++ b/resources/views/common/header.blade.php
@@ -93,8 +93,22 @@
                             </a>
                         </li>
                         <li>
+<?php
+// OIDC Logout Feature: Use /oidc/logout if authentication method is oidc.
+if (config('auth.method') === 'oidc')  {
+?>
+                            <form action="/oidc/logout"
+                                  method="get">
+<?php
+// OIDC Logout Feature: Use /oidc/logout if authentication method is oidc.
+} else {
+?>
                             <form action="{{ url(config('auth.method') === 'saml2' ? '/saml2/logout' : '/logout') }}"
                                   method="post">
+<?php
+// OIDC Logout Feature: Use /oidc/logout if authentication method is oidc.
+}
+?>
                                 {{ csrf_field() }}
                                 <button class="icon-item" data-shortcut="logout">
                                     @icon('logout')

--- a/resources/views/layouts/parts/header-user-menu.blade.php
+++ b/resources/views/layouts/parts/header-user-menu.blade.php
@@ -29,28 +29,20 @@
         </li>
         <li><hr></li>
         <li>
-            <?php
-// OIDC Logout Feature: Use /oidc/logout if authentication method is oidc.
-            if (config('auth.method') === 'oidc')  {
-                ?>
-                <form action="/oidc/logout"
-                    method="get">
-                    <?php
-// OIDC Logout Feature: Use /oidc/logout if authentication method is oidc.
-                } else {
-                    ?>
-                <form action="{{ url(config('auth.method') === 'saml2' ? '/saml2/logout' : '/logout') }}"
-                      method="post">
-                        <?php
-// OIDC Logout Feature: Use /oidc/logout if authentication method is oidc.
-                    }
-                    ?>
-                    {{ csrf_field() }}
-                    <button class="icon-item" data-shortcut="logout">
-                        @icon('logout')
-                        <div>{{ trans('auth.logout') }}</div>
-                    </button>
-                </form>
+            @php
+                $logoutPath = match (config('auth.method')) {
+                    'saml2' => '/saml2/logout',
+                    'oidc' => '/oidc/logout',
+                    default => '/logout',
+                }
+            @endphp
+            <form action="{{ url($logoutPath) }}" method="post">
+                {{ csrf_field() }}
+                <button class="icon-item" data-shortcut="logout">
+                    @icon('logout')
+                    <div>{{ trans('auth.logout') }}</div>
+                </button>
+            </form>
         </li>
     </ul>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -323,6 +323,8 @@ Route::get('/saml2/acs', [AccessControllers\Saml2Controller::class, 'processAcs'
 // OIDC routes
 Route::post('/oidc/login', [AccessControllers\OidcController::class, 'login']);
 Route::get('/oidc/callback', [AccessControllers\OidcController::class, 'callback']);
+// OIDC Logout Feature: Added to cater OIDC logout
+Route::get('/oidc/logout', [AccessControllers\OidcController::class, 'logout']);
 
 // User invitation routes
 Route::get('/register/invite/{token}', [AccessControllers\UserInviteController::class, 'showSetPassword']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -332,8 +332,7 @@ Route::get('/saml2/acs', [AccessControllers\Saml2Controller::class, 'processAcs'
 // OIDC routes
 Route::post('/oidc/login', [AccessControllers\OidcController::class, 'login']);
 Route::get('/oidc/callback', [AccessControllers\OidcController::class, 'callback']);
-// OIDC Logout Feature: Added to cater OIDC logout
-Route::get('/oidc/logout', [AccessControllers\OidcController::class, 'logout']);
+Route::post('/oidc/logout', [AccessControllers\OidcController::class, 'logout']);
 
 // User invitation routes
 Route::get('/register/invite/{token}', [AccessControllers\UserInviteController::class, 'showSetPassword']);

--- a/tests/Auth/OidcTest.php
+++ b/tests/Auth/OidcTest.php
@@ -44,6 +44,7 @@ class OidcTest extends TestCase
             'oidc.groups_claim'           => 'group',
             'oidc.remove_from_groups'     => false,
             'oidc.external_id_claim'      => 'sub',
+            'oidc.end_session_endpoint'   => null,
         ]);
     }
 
@@ -478,6 +479,81 @@ class OidcTest extends TestCase
         $this->assertTrue($user->hasRole($roleA->id));
     }
 
+    public function test_oidc_logout_form_active_when_oidc_active()
+    {
+        $this->runLogin();
+
+        $resp = $this->get('/');
+        $this->withHtml($resp)->assertElementExists('header form[action$="/oidc/logout"] button');
+    }
+    public function test_logout_with_autodiscovery()
+    {
+        $this->withAutodiscovery();
+
+        $transactions = $this->mockHttpClient([
+            $this->getAutoDiscoveryResponse(),
+            $this->getJwksResponse(),
+        ]);
+
+        $resp = $this->asEditor()->post('/oidc/logout');
+        $resp->assertRedirect('https://auth.example.com/oidc/logout?post_logout_redirect_uri=' . urlencode(url('/')));
+
+        $this->assertEquals(2, $transactions->requestCount());
+    }
+
+    public function test_logout_with_autodiscovery_but_oidc_logout_disabled()
+    {
+        $this->withAutodiscovery();
+        config()->set(['oidc.end_session_endpoint' => false]);
+
+        $this->mockHttpClient([
+            $this->getAutoDiscoveryResponse(),
+            $this->getJwksResponse(),
+        ]);
+
+        $resp = $this->asEditor()->post('/oidc/logout');
+        $resp->assertRedirect('/');
+    }
+
+    public function test_logout_without_autodiscovery_but_with_endpoint_configured()
+    {
+        config()->set(['oidc.end_session_endpoint' => 'https://example.com/logout']);
+
+        $resp = $this->asEditor()->post('/oidc/logout');
+        $resp->assertRedirect('https://example.com/logout?post_logout_redirect_uri=' . urlencode(url('/')));
+    }
+
+    public function test_logout_with_autodiscovery_and_auto_initiate_returns_to_auto_prevented_login()
+    {
+        $this->withAutodiscovery();
+        config()->set([
+            'auth.auto_initiate' => true,
+            'services.google.client_id' => false,
+            'services.github.client_id' => false,
+        ]);
+
+        $this->mockHttpClient([
+            $this->getAutoDiscoveryResponse(),
+            $this->getJwksResponse(),
+        ]);
+
+        $resp = $this->asEditor()->post('/oidc/logout');
+
+        $redirectUrl = url('/login?prevent_auto_init=true');
+        $resp->assertRedirect('https://auth.example.com/oidc/logout?post_logout_redirect_uri=' . urlencode($redirectUrl));
+    }
+
+    public function test_logout_redirect_contains_id_token_hint_if_existing()
+    {
+        config()->set(['oidc.end_session_endpoint' => 'https://example.com/logout']);
+
+        $this->runLogin();
+
+        $resp = $this->asEditor()->post('/oidc/logout');
+        $query = 'id_token_hint=' . urlencode(OidcJwtHelper::idToken()) .  '&post_logout_redirect_uri=' . urlencode(url('/'));
+        $resp->assertRedirect('https://example.com/logout?' . $query);
+    }
+
     public function test_oidc_id_token_pre_validate_theme_event_without_return()
     {
         $args = [];
@@ -563,6 +639,7 @@ class OidcTest extends TestCase
             'authorization_endpoint' => OidcJwtHelper::defaultIssuer() . '/oidc/authorize',
             'jwks_uri'               => OidcJwtHelper::defaultIssuer() . '/oidc/keys',
             'issuer'                 => OidcJwtHelper::defaultIssuer(),
+            'end_session_endpoint'   => OidcJwtHelper::defaultIssuer() . '/oidc/logout',
         ], $responseOverrides)));
     }
 

--- a/tests/DebugViewTest.php
+++ b/tests/DebugViewTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use BookStack\Access\SocialAuthService;
+use BookStack\Access\SocialDriverManager;
 use Illuminate\Testing\TestResponse;
 
 class DebugViewTest extends TestCase
@@ -46,8 +46,8 @@ class DebugViewTest extends TestCase
     protected function getDebugViewForException(\Exception $exception): TestResponse
     {
         // Fake an error via social auth service used on login page
-        $mockService = $this->mock(SocialAuthService::class);
-        $mockService->shouldReceive('getActiveDrivers')->andThrow($exception);
+        $mockService = $this->mock(SocialDriverManager::class);
+        $mockService->shouldReceive('getActive')->andThrow($exception);
 
         return $this->get('/login');
     }


### PR DESCRIPTION
Continuation of #4467.

https://openid.net/specs/openid-connect-rpinitiated-1_0.html

### Todo

- [x] Add auto-discovery support.
- [x] Allow disabling via config option.
- [x] Testing
  - [x] PHP Unit Coverage
  - [x] Manual test on providers:
    - [x] Okta
    - [x] KeyCloak
    - [x] Azure
    - [x] Authentik
    - [x] Auth0 (If supports)
  - [x] Manual re-test of SAML2 logout with auto-initate on/off.
  - [x] Manual re-test of OIDC logout with auto-initate on/off, with RP-initated logout on/off.
  - [x] Manual re-test of custom social driver usage (specifically appearance/use in multiple parts of the app).
  - [x] Test of auto-initate login and logout handling when lone custom social driver active.

### Questionables

- Can an OP error if a `post_logout_redirect_uri` is provided that doesn't meet spec (which we cannot check dynamically as config is OP side).
  - **Answer**:  From testing, an OP will reject the request if an non-expected redirect URI is provided. Without a redirect URI you can be left at the OP system sign-in page, so don't think sending without a redirect URI by default is sensible.

### Notes

- Okta is really strict when it comes to redirect URIs, they had to match exactly, including query params (`?prevent_auto_init=true`) otherwise an error would be thrown pre-okta-signout. Might need to specify the adding of all URL possibilities. Also makes it more important that we never (or very rarely) change these.
- Azure didn't require any logout redirect URLs to be provided, just returned as desired.
- Looks like Auth0 [do support RP-initiated logout](https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0) but the endpoint via autodiscovery wasn't active for me, maybe have to talk to support or something.
  - Manually using a `<ISSUER>/oidc/logout` worked okay for me.
  - Auth0 also strict on return URL like okta.
- Keycloak strict on logout return URLs, although allow wildcards which is nice.
- Authentik never redirects back, and provides the option to user to logout of all, or go back to BookStack. Not an issue, but a little different to others.

### Docs updates

- ~~Update advisory to advise RP-initiated logout will be active if supported via discovery.~~
  - Changed plans to make non-enabled by default.
- Update docs with logout info.
  - Specifically mention the requirement to configure the "Sign-out redirect URI" (or similar) on the identity provider.
  - Might need to detail specifics, including return URLs and the http/https caveat from the spec.