### PR TITLE
Added Default Templates for Chapters

### DIFF
--- a/app/Entities/Controllers/ChapterApiController.php
+++ b/app/Entities/Controllers/ChapterApiController.php
@@ -15,20 +15,22 @@ class ChapterApiController extends ApiController
 {
     protected $rules = [
         'create' => [
-            'book_id'          => ['required', 'integer'],
-            'name'             => ['required', 'string', 'max:255'],
-            'description'      => ['string', 'max:1900'],
-            'description_html' => ['string', 'max:2000'],
-            'tags'             => ['array'],
-            'priority'         => ['integer'],
+            'book_id'             => ['required', 'integer'],
+            'name'                => ['required', 'string', 'max:255'],
+            'description'         => ['string', 'max:1900'],
+            'description_html'    => ['string', 'max:2000'],
+            'tags'                => ['array'],
+            'priority'            => ['integer'],
+            'default_template_id' => ['nullable', 'integer'],
         ],
         'update' => [
-            'book_id'          => ['integer'],
-            'name'             => ['string', 'min:1', 'max:255'],
-            'description'      => ['string', 'max:1900'],
-            'description_html' => ['string', 'max:2000'],
-            'tags'             => ['array'],
-            'priority'         => ['integer'],
+            'book_id'             => ['integer'],
+            'name'                => ['string', 'min:1', 'max:255'],
+            'description'         => ['string', 'max:1900'],
+            'description_html'    => ['string', 'max:2000'],
+            'tags'                => ['array'],
+            'priority'            => ['integer'],
+            'default_template_id' => ['nullable', 'integer'],
         ],
     ];
 

--- a/app/Entities/Controllers/ChapterController.php
+++ b/app/Entities/Controllers/ChapterController.php
@@ -49,9 +49,10 @@ class ChapterController extends Controller
     public function store(Request $request, string $bookSlug)
     {
         $validated = $this->validate($request, [
-            'name'             => ['required', 'string', 'max:255'],
-            'description_html' => ['string', 'max:2000'],
-            'tags'             => ['array'],
+            'name'                => ['required', 'string', 'max:255'],
+            'description_html'    => ['string', 'max:2000'],
+            'tags'                => ['array'],
+            'default_template_id' => ['nullable', 'integer'],
         ]);
 
         $book = Book::visible()->where('slug', '=', $bookSlug)->firstOrFail();
@@ -111,9 +112,10 @@ class ChapterController extends Controller
     public function update(Request $request, string $bookSlug, string $chapterSlug)
     {
         $validated = $this->validate($request, [
-            'name'             => ['required', 'string', 'max:255'],
-            'description_html' => ['string', 'max:2000'],
-            'tags'             => ['array'],
+            'name'                => ['required', 'string', 'max:255'],
+            'description_html'    => ['string', 'max:2000'],
+            'tags'                => ['array'],
+            'default_template_id' => ['nullable', 'integer'],
         ]);
 
         $chapter = $this->chapterRepo->getBySlug($bookSlug, $chapterSlug);

--- a/app/Entities/Controllers/PageController.php
+++ b/app/Entities/Controllers/PageController.php
@@ -6,6 +6,7 @@ use BookStack\Activity\Models\View;
 use BookStack\Activity\Tools\CommentTree;
 use BookStack\Activity\Tools\UserEntityWatchOptions;
 use BookStack\Entities\Models\Book;
+use BookStack\Entities\Models\Chapter;
 use BookStack\Entities\Models\Page;
 use BookStack\Entities\Repos\PageRepo;
 use BookStack\Entities\Tools\BookContents;
@@ -259,7 +260,9 @@ class PageController extends Controller
         $page = $this->pageRepo->getBySlug($bookSlug, $pageSlug);
         $this->checkOwnablePermission('page-delete', $page);
         $this->setPageTitle(trans('entities.pages_delete_named', ['pageName' => $page->getShortName()]));
-        $usedAsTemplate = Book::query()->where('default_template_id', '=', $page->id)->count() > 0;
+        $usedAsTemplate = 
+            Book::query()->where('default_template_id', '=', $page->id)->count() > 0 ||
+            Chapter::query()->where('default_template_id', '=', $page->id)->count() > 0;
 
         return view('pages.delete', [
             'book'    => $page->book,
@@ -279,7 +282,9 @@ class PageController extends Controller
         $page = $this->pageRepo->getById($pageId);
         $this->checkOwnablePermission('page-update', $page);
         $this->setPageTitle(trans('entities.pages_delete_draft_named', ['pageName' => $page->getShortName()]));
-        $usedAsTemplate = Book::query()->where('default_template_id', '=', $page->id)->count() > 0;
+        $usedAsTemplate = 
+            Book::query()->where('default_template_id', '=', $page->id)->count() > 0 ||
+            Chapter::query()->where('default_template_id', '=', $page->id)->count() > 0;
 
         return view('pages.delete', [
             'book'    => $page->book,

--- a/app/Entities/Controllers/PageController.php
+++ b/app/Entities/Controllers/PageController.php
@@ -260,7 +260,7 @@ class PageController extends Controller
         $page = $this->pageRepo->getBySlug($bookSlug, $pageSlug);
         $this->checkOwnablePermission('page-delete', $page);
         $this->setPageTitle(trans('entities.pages_delete_named', ['pageName' => $page->getShortName()]));
-        $usedAsTemplate = 
+        $usedAsTemplate =
             Book::query()->where('default_template_id', '=', $page->id)->count() > 0 ||
             Chapter::query()->where('default_template_id', '=', $page->id)->count() > 0;
 
@@ -282,7 +282,7 @@ class PageController extends Controller
         $page = $this->pageRepo->getById($pageId);
         $this->checkOwnablePermission('page-update', $page);
         $this->setPageTitle(trans('entities.pages_delete_draft_named', ['pageName' => $page->getShortName()]));
-        $usedAsTemplate = 
+        $usedAsTemplate =
             Book::query()->where('default_template_id', '=', $page->id)->count() > 0 ||
             Chapter::query()->where('default_template_id', '=', $page->id)->count() > 0;
 

--- a/app/Entities/Models/Chapter.php
+++ b/app/Entities/Models/Chapter.php
@@ -2,6 +2,7 @@
 
 namespace BookStack\Entities\Models;
 
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
@@ -11,6 +12,8 @@ use Illuminate\Support\Collection;
  *
  * @property Collection<Page> $pages
  * @property string           $description
+ * @property ?int             $default_template_id
+ * @property ?Page            $defaultTemplate
  */
 class Chapter extends BookChild
 {
@@ -46,6 +49,14 @@ class Chapter extends BookChild
         ];
 
         return url('/' . implode('/', $parts));
+    }
+
+    /**
+     * Get the Page that is used as default template for newly created pages within this Chapter.
+     */
+    public function defaultTemplate(): BelongsTo
+    {
+        return $this->belongsTo(Page::class, 'default_template_id');
     }
 
     /**

--- a/app/Entities/Repos/ChapterRepo.php
+++ b/app/Entities/Repos/ChapterRepo.php
@@ -4,6 +4,7 @@ namespace BookStack\Entities\Repos;
 
 use BookStack\Activity\ActivityType;
 use BookStack\Entities\Models\Book;
+use BookStack\Entities\Models\Page;
 use BookStack\Entities\Models\Chapter;
 use BookStack\Entities\Models\Entity;
 use BookStack\Entities\Tools\BookContents;
@@ -46,6 +47,7 @@ class ChapterRepo
         $chapter->book_id = $parentBook->id;
         $chapter->priority = (new BookContents($parentBook))->getLastPriority() + 1;
         $this->baseRepo->create($chapter, $input);
+        $this->updateChapterDefaultTemplate($chapter, intval($input['default_template_id'] ?? null));
         Activity::add(ActivityType::CHAPTER_CREATE, $chapter);
 
         return $chapter;
@@ -57,6 +59,11 @@ class ChapterRepo
     public function update(Chapter $chapter, array $input): Chapter
     {
         $this->baseRepo->update($chapter, $input);
+
+        if (array_key_exists('default_template_id', $input)) {
+            $this->updateChapterDefaultTemplate($chapter, intval($input['default_template_id']));
+        }
+
         Activity::add(ActivityType::CHAPTER_UPDATE, $chapter);
 
         return $chapter;
@@ -99,6 +106,33 @@ class ChapterRepo
         Activity::add(ActivityType::CHAPTER_MOVE, $chapter);
 
         return $parent;
+    }
+
+    /**
+     * Update the default page template used for this chapter.
+     * Checks that, if changing, the provided value is a valid template and the user
+     * has visibility of the provided page template id.
+     */
+    protected function updateChapterDefaultTemplate(Chapter $chapter, int $templateId): void
+    {
+        $changing = $templateId !== intval($chapter->default_template_id);
+        if (!$changing) {
+            return;
+        }
+
+        if ($templateId === 0) {
+            $chapter->default_template_id = null;
+            $chapter->save();
+            return;
+        }
+
+        $templateExists = Page::query()->visible()
+            ->where('template', '=', true)
+            ->where('id', '=', $templateId)
+            ->exists();
+
+        $chapter->default_template_id = $templateExists ? $templateId : null;
+        $chapter->save();
     }
 
     /**

--- a/app/Entities/Repos/PageRepo.php
+++ b/app/Entities/Repos/PageRepo.php
@@ -142,7 +142,7 @@ class PageRepo
         } else {
             $defaultTemplate = $page->book->defaultTemplate;
         }
-        
+
         if ($defaultTemplate && userCan('view', $defaultTemplate)) {
             $page->forceFill([
                 'html'  => $defaultTemplate->html,

--- a/app/Entities/Repos/PageRepo.php
+++ b/app/Entities/Repos/PageRepo.php
@@ -136,7 +136,13 @@ class PageRepo
             $page->book_id = $parent->id;
         }
 
-        $defaultTemplate = $page->book->defaultTemplate;
+        // check for chapter
+        if ($page->chapter_id) {
+            $defaultTemplate = $page->chapter->defaultTemplate;
+        } else {
+            $defaultTemplate = $page->book->defaultTemplate;
+        }
+        
         if ($defaultTemplate && userCan('view', $defaultTemplate)) {
             $page->forceFill([
                 'html'  => $defaultTemplate->html,

--- a/app/Entities/Tools/TrashCan.php
+++ b/app/Entities/Tools/TrashCan.php
@@ -208,6 +208,12 @@ class TrashCan
 
         $page->forceDelete();
 
+        // Remove chapter template usages
+        Chapter::query()->where('default_template_id', '=', $page->id)
+            ->update(['default_template_id' => null]);
+
+        $page->forceDelete();
+
         return 1;
     }
 

--- a/app/Entities/Tools/TrashCan.php
+++ b/app/Entities/Tools/TrashCan.php
@@ -206,8 +206,6 @@ class TrashCan
         Book::query()->where('default_template_id', '=', $page->id)
             ->update(['default_template_id' => null]);
 
-        $page->forceDelete();
-
         // Remove chapter template usages
         Chapter::query()->where('default_template_id', '=', $page->id)
             ->update(['default_template_id' => null]);

--- a/database/migrations/2024_01_01_104542_add_default_template_to_chapters.php
+++ b/database/migrations/2024_01_01_104542_add_default_template_to_chapters.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDefaultTemplateToChapters extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('chapters', function (Blueprint $table) {
+            $table->integer('default_template_id')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('chapters', function (Blueprint $table) {
+            $table->dropColumn('default_template_id');
+        });
+    }
+}

--- a/lang/en/entities.php
+++ b/lang/en/entities.php
@@ -39,6 +39,9 @@ return [
     'export_pdf' => 'PDF File',
     'export_text' => 'Plain Text File',
     'export_md' => 'Markdown File',
+    'default_template' => 'Default Page Template',
+    'default_template_explain' => 'Assign a page template that will be used as the default content for all new pages in this book/chapter. Keep in mind this will only be used if the page creator has view access to those chosen template page.',
+    'default_template_select' => 'Select a template page',
 
     // Permissions and restrictions
     'permissions' => 'Permissions',
@@ -132,9 +135,6 @@ return [
     'books_edit_named' => 'Edit Book :bookName',
     'books_form_book_name' => 'Book Name',
     'books_save' => 'Save Book',
-    'books_default_template' => 'Default Page Template',
-    'books_default_template_explain' => 'Assign a page template that will be used as the default content for all new pages in this book. Keep in mind this will only be used if the page creator has view access to those chosen template page.',
-    'books_default_template_select' => 'Select a template page',
     'books_permissions' => 'Book Permissions',
     'books_permissions_updated' => 'Book Permissions Updated',
     'books_empty_contents' => 'No pages or chapters have been created for this book.',
@@ -192,9 +192,6 @@ return [
     'chapters_permissions_success' => 'Chapter Permissions Updated',
     'chapters_search_this' => 'Search this chapter',
     'chapter_sort_book' => 'Sort Book',
-    'chapter_default_template' => 'Default Page Template',
-    'chapter_default_template_explain' => 'Assign a page template that will be used as the default content for all new pages in this chapter. Keep in mind this will only be used if the page creator has view access to those chosen template page.',
-    'chapter_default_template_select' => 'Select a template page',
 
     // Pages
     'page' => 'Page',

--- a/lang/en/entities.php
+++ b/lang/en/entities.php
@@ -192,6 +192,9 @@ return [
     'chapters_permissions_success' => 'Chapter Permissions Updated',
     'chapters_search_this' => 'Search this chapter',
     'chapter_sort_book' => 'Sort Book',
+    'chapter_default_template' => 'Default Page Template',
+    'chapter_default_template_explain' => 'Assign a page template that will be used as the default content for all new pages in this chapter. Keep in mind this will only be used if the page creator has view access to those chosen template page.',
+    'chapter_default_template_select' => 'Select a template page',
 
     // Pages
     'page' => 'Page',

--- a/lang/en/entities.php
+++ b/lang/en/entities.php
@@ -210,7 +210,7 @@ return [
     'pages_delete_draft' => 'Delete Draft Page',
     'pages_delete_success' => 'Page deleted',
     'pages_delete_draft_success' => 'Draft page deleted',
-    'pages_delete_warning_template' => 'This page is in active use as a book default page template. These books will no longer have a default page template assigned after this page is deleted.',
+    'pages_delete_warning_template' => 'This page is in active use as a book or chapter default page template. These books or chapters will no longer have a default page template assigned after this page is deleted.',
     'pages_delete_confirm' => 'Are you sure you want to delete this page?',
     'pages_delete_draft_confirm' => 'Are you sure you want to delete this draft page?',
     'pages_editing_named' => 'Editing Page :pageName',

--- a/resources/views/books/parts/form.blade.php
+++ b/resources/views/books/parts/form.blade.php
@@ -40,24 +40,10 @@
 
 <div class="form-group collapsible" component="collapsible" id="template-control">
     <button refs="collapsible@trigger" type="button" class="collapse-title text-link" aria-expanded="false">
-        <label for="template-manager">{{ trans('entities.books_default_template') }}</label>
+        <label for="template-manager">{{ trans('entities.default_template') }}</label>
     </button>
     <div refs="collapsible@content" class="collapse-content">
-        <div class="flex-container-row gap-l justify-space-between pb-xs wrap">
-            <p class="text-muted small my-none min-width-xs flex">
-                {{ trans('entities.books_default_template_explain') }}
-            </p>
-
-            <div class="min-width-m">
-                @include('form.page-picker', [
-                    'name' => 'default_template_id',
-                    'placeholder' => trans('entities.books_default_template_select'),
-                    'value' => $book->default_template_id ?? null,
-                    'selectorEndpoint' => '/search/entity-selector-templates',
-                ])
-            </div>
-        </div>
-
+        @include('entities.template-selector', ['entity' => $book ?? null])
     </div>
 </div>
 

--- a/resources/views/chapters/parts/form.blade.php
+++ b/resources/views/chapters/parts/form.blade.php
@@ -24,24 +24,10 @@
 
 <div class="form-group collapsible" component="collapsible" id="template-control">
     <button refs="collapsible@trigger" type="button" class="collapse-title text-link" aria-expanded="false">
-        <label for="template-manager">{{ trans('entities.chapter_default_template') }}</label>
+        <label for="template-manager">{{ trans('entities.default_template') }}</label>
     </button>
     <div refs="collapsible@content" class="collapse-content">
-        <div class="flex-container-row gap-l justify-space-between pb-xs wrap">
-            <p class="text-muted small my-none min-width-xs flex">
-                {{ trans('entities.chapter_default_template_explain') }}
-            </p>
-
-            <div class="min-width-m">
-                @include('form.page-picker', [
-                    'name' => 'default_template_id',
-                    'placeholder' => trans('entities.chapter_default_template_select'),
-                    'value' => $chapter->default_template_id ?? null,
-                    'selectorEndpoint' => '/search/entity-selector-templates',
-                ])
-            </div>
-        </div>
-
+        @include('entities.template-selector', ['entity' => $chapter ?? null])
     </div>
 </div>
 

--- a/resources/views/chapters/parts/form.blade.php
+++ b/resources/views/chapters/parts/form.blade.php
@@ -22,6 +22,29 @@
     </div>
 </div>
 
+<div class="form-group collapsible" component="collapsible" id="template-control">
+    <button refs="collapsible@trigger" type="button" class="collapse-title text-link" aria-expanded="false">
+        <label for="template-manager">{{ trans('entities.chapter_default_template') }}</label>
+    </button>
+    <div refs="collapsible@content" class="collapse-content">
+        <div class="flex-container-row gap-l justify-space-between pb-xs wrap">
+            <p class="text-muted small my-none min-width-xs flex">
+                {{ trans('entities.chapter_default_template_explain') }}
+            </p>
+
+            <div class="min-width-m">
+                @include('form.page-picker', [
+                    'name' => 'default_template_id',
+                    'placeholder' => trans('entities.chapter_default_template_select'),
+                    'value' => $chapter->default_template_id ?? null,
+                    'selectorEndpoint' => '/search/entity-selector-templates',
+                ])
+            </div>
+        </div>
+
+    </div>
+</div>
+
 <div class="form-group text-right">
     <a href="{{ isset($chapter) ? $chapter->getUrl() : $book->getUrl() }}" class="button outline">{{ trans('common.cancel') }}</a>
     <button type="submit" class="button">{{ trans('entities.chapters_save') }}</button>

--- a/resources/views/entities/template-selector.blade.php
+++ b/resources/views/entities/template-selector.blade.php
@@ -1,0 +1,14 @@
+<div class="flex-container-row gap-l justify-space-between pb-xs wrap">
+    <p class="text-muted small my-none min-width-xs flex">
+        {{ trans('entities.default_template_explain') }}
+    </p>
+
+    <div class="min-width-m">
+        @include('form.page-picker', [
+            'name' => 'default_template_id',
+            'placeholder' => trans('entities.default_template_select'),
+            'value' => $entity->default_template_id ?? null,
+            'selectorEndpoint' => '/search/entity-selector-templates',
+        ])
+    </div>
+</div>


### PR DESCRIPTION
I have extended the new feature of default templates for books to chapters.
This makes it possible to specify default templates within individual chapters of a book so that they are automatically selected when a new page is created.
The functionality is exactly the same as with books.
Here is an excerpt from my bookstack (in german):
<img width="411" alt="image" src="https://github.com/BookStackApp/BookStack/assets/9048534/45c3054f-079c-45b8-aa89-57a64d5189a4">
Behind the scenes I've made changes to the controller, the repos, the models and the trash can.
There is also a migration file for the database to alter the table for the chapters so that you can set the default_template_id.