### PR TITLE
Range request support

### DIFF
--- a/app/Config/filesystems.php
+++ b/app/Config/filesystems.php
@@ -58,6 +58,7 @@ return [
             'endpoint'                => env('STORAGE_S3_ENDPOINT', null),
             'use_path_style_endpoint' => env('STORAGE_S3_ENDPOINT', null) !== null,
             'throw'                   => true,
+            'stream_reads'            => false,
         ],
 
     ],

--- a/app/Http/RangeSupportedStream.php
+++ b/app/Http/RangeSupportedStream.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BookStack\Http;
+
+use BookStack\Util\WebSafeMimeSniffer;
+use Symfony\Component\HttpFoundation\HeaderBag;
+
+class RangeSupportedStream
+{
+    protected string $sniffContent;
+
+    public function __construct(
+        protected $stream,
+        protected int $fileSize,
+        protected HeaderBag $requestHeaders,
+    ) {
+    }
+
+    /**
+     * Sniff a mime type from the stream.
+     */
+    public function sniffMime(): string
+    {
+        $offset = min(2000, $this->fileSize);
+        $this->sniffContent = fread($this->stream, $offset);
+
+        return (new WebSafeMimeSniffer())->sniff($this->sniffContent);
+    }
+
+    /**
+     * Output the current stream to stdout before closing out the stream.
+     */
+    public function outputAndClose(): void
+    {
+        // End & flush the output buffer, if we're in one, otherwise we still use memory.
+        // Output buffer may or may not exist depending on PHP `output_buffering` setting.
+        // Ignore in testing since output buffers are used to gather a response.
+        if (!empty(ob_get_status()) && !app()->runningUnitTests()) {
+            ob_end_clean();
+        }
+
+        $outStream = fopen('php://output', 'w');
+        $offset = 0;
+
+        if (!empty($this->sniffContent)) {
+            fwrite($outStream, $this->sniffContent);
+            $offset = strlen($this->sniffContent);
+        }
+
+        $toWrite = $this->fileSize - $offset;
+        stream_copy_to_stream($this->stream, $outStream, $toWrite);
+        fpassthru($this->stream);
+
+        fclose($this->stream);
+        fclose($outStream);
+    }
+}

--- a/app/Http/RangeSupportedStream.php
+++ b/app/Http/RangeSupportedStream.php
@@ -3,17 +3,30 @@
 namespace BookStack\Http;
 
 use BookStack\Util\WebSafeMimeSniffer;
-use Symfony\Component\HttpFoundation\HeaderBag;
+use Illuminate\Http\Request;
 
+/**
+ * Helper wrapper for range-based stream response handling.
+ * Much of this used symfony/http-foundation as a reference during build.
+ * URL: https://github.com/symfony/http-foundation/blob/v6.0.20/BinaryFileResponse.php
+ * License: MIT license, Copyright (c) Fabien Potencier.
+ */
 class RangeSupportedStream
 {
     protected string $sniffContent;
+    protected array $responseHeaders;
+    protected int $responseStatus = 200;
+
+    protected int $responseLength = 0;
+    protected int $responseOffset = 0;
 
     public function __construct(
         protected $stream,
         protected int $fileSize,
-        protected HeaderBag $requestHeaders,
+        Request $request,
     ) {
+        $this->responseLength = $this->fileSize;
+        $this->parseRequest($request);
     }
 
     /**
@@ -40,18 +53,82 @@ class RangeSupportedStream
         }
 
         $outStream = fopen('php://output', 'w');
-        $offset = 0;
+        $sniffOffset = strlen($this->sniffContent);
 
-        if (!empty($this->sniffContent)) {
-            fwrite($outStream, $this->sniffContent);
-            $offset = strlen($this->sniffContent);
+        if (!empty($this->sniffContent) && $this->responseOffset < $sniffOffset) {
+            $sniffOutput = substr($this->sniffContent, $this->responseOffset, min($sniffOffset, $this->responseLength));
+            fwrite($outStream, $sniffOutput);
+        } else if ($this->responseOffset !== 0) {
+            fseek($this->stream, $this->responseOffset);
         }
 
-        $toWrite = $this->fileSize - $offset;
-        stream_copy_to_stream($this->stream, $outStream, $toWrite);
-        fpassthru($this->stream);
+        stream_copy_to_stream($this->stream, $outStream, $this->responseLength);
 
         fclose($this->stream);
         fclose($outStream);
+    }
+
+    public function getResponseHeaders(): array
+    {
+        return $this->responseHeaders;
+    }
+
+    public function getResponseStatus(): int
+    {
+        return $this->responseStatus;
+    }
+
+    protected function parseRequest(Request $request): void
+    {
+        $this->responseHeaders['Accept-Ranges'] = $request->isMethodSafe() ? 'bytes' : 'none';
+
+        $range = $this->getRangeFromRequest($request);
+        if ($range) {
+            [$start, $end] = $range;
+            if ($start < 0 || $start > $end) {
+                $this->responseStatus = 416;
+                $this->responseHeaders['Content-Range'] = sprintf('bytes */%s', $this->fileSize);
+            } elseif ($end - $start < $this->fileSize - 1) {
+                $this->responseLength = $end < $this->fileSize ? $end - $start + 1 : -1;
+                $this->responseOffset = $start;
+                $this->responseStatus = 206;
+                $this->responseHeaders['Content-Range'] = sprintf('bytes %s-%s/%s', $start, $end, $this->fileSize);
+                $this->responseHeaders['Content-Length'] = $end - $start + 1;
+            }
+        }
+
+        if ($request->isMethod('HEAD')) {
+            $this->responseLength = 0;
+        }
+    }
+
+    protected function getRangeFromRequest(Request $request): ?array
+    {
+        $range = $request->headers->get('Range');
+        if (!$range || !$request->isMethod('GET') || !str_starts_with($range, 'bytes=')) {
+            return null;
+        }
+
+        if ($request->headers->has('If-Range')) {
+            return null;
+        }
+
+        [$start, $end] = explode('-', substr($range, 6), 2) + [0];
+
+        $end = ('' === $end) ? $this->fileSize - 1 : (int) $end;
+
+        if ('' === $start) {
+            $start = $this->fileSize - $end;
+            $end = $this->fileSize - 1;
+        } else {
+            $start = (int) $start;
+        }
+
+        if ($start > $end) {
+            return null;
+        }
+
+        $end = min($end, $this->fileSize - 1);
+        return [$start, $end];
     }
 }

--- a/app/Uploads/Attachment.php
+++ b/app/Uploads/Attachment.php
@@ -77,7 +77,22 @@ class Attachment extends Model
     }
 
     /**
-     * Generate a HTML link to this attachment.
+     * Get the representation of this attachment in a format suitable for the page editors.
+     * Detects and adapts video content to use an inline video embed.
+     */
+    public function editorContent(): array
+    {
+        $videoExtensions = ['mp4', 'webm', 'mkv', 'ogg', 'avi'];
+        if (in_array(strtolower($this->extension), $videoExtensions)) {
+            $html = '<video src="' . e($this->getUrl(true)) . '" controls width="480" height="270"></video>';
+            return ['text/html' => $html, 'text/plain' => $html];
+        }
+
+        return ['text/html' => $this->htmlLink(), 'text/plain' => $this->markdownLink()];
+    }
+
+    /**
+     * Generate the HTML link to this attachment.
      */
     public function htmlLink(): string
     {
@@ -85,7 +100,7 @@ class Attachment extends Model
     }
 
     /**
-     * Generate a markdown link to this attachment.
+     * Generate a MarkDown link to this attachment.
      */
     public function markdownLink(): string
     {

--- a/app/Uploads/AttachmentService.php
+++ b/app/Uploads/AttachmentService.php
@@ -66,13 +66,19 @@ class AttachmentService
     /**
      * Stream an attachment from storage.
      *
-     * @throws FileNotFoundException
-     *
      * @return resource|null
      */
     public function streamAttachmentFromStorage(Attachment $attachment)
     {
         return $this->getStorageDisk()->readStream($this->adjustPathForStorageDisk($attachment->path));
+    }
+
+    /**
+     * Read the file size of an attachment from storage, in bytes.
+     */
+    public function getAttachmentFileSize(Attachment $attachment): int
+    {
+        return $this->getStorageDisk()->size($this->adjustPathForStorageDisk($attachment->path));
     }
 
     /**

--- a/app/Uploads/Controllers/AttachmentController.php
+++ b/app/Uploads/Controllers/AttachmentController.php
@@ -226,12 +226,13 @@ class AttachmentController extends Controller
 
         $fileName = $attachment->getFileName();
         $attachmentStream = $this->attachmentService->streamAttachmentFromStorage($attachment);
+        $attachmentSize = $this->attachmentService->getAttachmentFileSize($attachment);
 
         if ($request->get('open') === 'true') {
-            return $this->download()->streamedInline($attachmentStream, $fileName);
+            return $this->download()->streamedInline($attachmentStream, $fileName, $attachmentSize);
         }
 
-        return $this->download()->streamedDirectly($attachmentStream, $fileName);
+        return $this->download()->streamedDirectly($attachmentStream, $fileName, $attachmentSize);
     }
 
     /**

--- a/resources/views/attachments/manager-list.blade.php
+++ b/resources/views/attachments/manager-list.blade.php
@@ -4,7 +4,7 @@
         <div component="ajax-delete-row"
              option:ajax-delete-row:url="{{ url('/attachments/' . $attachment->id) }}"
              data-id="{{ $attachment->id }}"
-             data-drag-content="{{ json_encode(['text/html' => $attachment->htmlLink(), 'text/plain' => $attachment->markdownLink()]) }}"
+             data-drag-content="{{ json_encode($attachment->editorContent()) }}"
              class="card drag-card">
             <div class="handle">@icon('grip')</div>
             <div class="py-s">

--- a/tests/Uploads/AttachmentTest.php
+++ b/tests/Uploads/AttachmentTest.php
@@ -316,4 +316,105 @@ class AttachmentTest extends TestCase
         $this->assertFileExists(storage_path($attachment->path));
         $this->files->deleteAllAttachmentFiles();
     }
+
+    public function test_file_get_range_access()
+    {
+        $page = $this->entities->page();
+        $this->asAdmin();
+        $attachment = $this->files->uploadAttachmentDataToPage($this, $page, 'my_text.txt', 'abc123456', 'text/plain');
+
+        // Download access
+        $resp = $this->get($attachment->getUrl(), ['Range' => 'bytes=3-5']);
+        $resp->assertStatus(206);
+        $resp->assertStreamedContent('123');
+        $resp->assertHeader('Content-Length', '3');
+        $resp->assertHeader('Content-Range', 'bytes 3-5/9');
+
+        // Inline access
+        $resp = $this->get($attachment->getUrl(true), ['Range' => 'bytes=5-7']);
+        $resp->assertStatus(206);
+        $resp->assertStreamedContent('345');
+        $resp->assertHeader('Content-Length', '3');
+        $resp->assertHeader('Content-Range', 'bytes 5-7/9');
+
+        $this->files->deleteAllAttachmentFiles();
+    }
+
+    public function test_file_head_range_returns_no_content()
+    {
+        $page = $this->entities->page();
+        $this->asAdmin();
+        $attachment = $this->files->uploadAttachmentDataToPage($this, $page, 'my_text.txt', 'abc123456', 'text/plain');
+
+        $resp = $this->head($attachment->getUrl(), ['Range' => 'bytes=0-9']);
+        $resp->assertStreamedContent('');
+        $resp->assertHeader('Content-Length', '9');
+        $resp->assertStatus(200);
+
+        $this->files->deleteAllAttachmentFiles();
+    }
+
+    public function test_file_head_range_edge_cases()
+    {
+        $page = $this->entities->page();
+        $this->asAdmin();
+
+        // Mime-type "sniffing" happens on first 2k bytes, hence this content (2005 bytes)
+        $content = '01234' . str_repeat('a', 1990) . '0123456789';
+        $attachment = $this->files->uploadAttachmentDataToPage($this, $page, 'my_text.txt', $content, 'text/plain');
+
+        // Test for both inline and download attachment serving
+        foreach ([true, false] as $isInline) {
+            // No end range
+            $resp = $this->get($attachment->getUrl($isInline), ['Range' => 'bytes=5-']);
+            $resp->assertStreamedContent(substr($content, 5));
+            $resp->assertHeader('Content-Length', '2000');
+            $resp->assertHeader('Content-Range', 'bytes 5-2004/2005');
+            $resp->assertStatus(206);
+
+            // End only range
+            $resp = $this->get($attachment->getUrl($isInline), ['Range' => 'bytes=-10']);
+            $resp->assertStreamedContent('0123456789');
+            $resp->assertHeader('Content-Length', '10');
+            $resp->assertHeader('Content-Range', 'bytes 1995-2004/2005');
+            $resp->assertStatus(206);
+
+            // Range across sniff point
+            $resp = $this->get($attachment->getUrl($isInline), ['Range' => 'bytes=1997-2002']);
+            $resp->assertStreamedContent('234567');
+            $resp->assertHeader('Content-Length', '6');
+            $resp->assertHeader('Content-Range', 'bytes 1997-2002/2005');
+            $resp->assertStatus(206);
+
+            // Range up to sniff point
+            $resp = $this->get($attachment->getUrl($isInline), ['Range' => 'bytes=0-1997']);
+            $resp->assertHeader('Content-Length', '1998');
+            $resp->assertHeader('Content-Range', 'bytes 0-1997/2005');
+            $resp->assertStreamedContent(substr($content, 0, 1998));
+            $resp->assertStatus(206);
+
+            // Range beyond sniff point
+            $resp = $this->get($attachment->getUrl($isInline), ['Range' => 'bytes=2001-2003']);
+            $resp->assertStreamedContent('678');
+            $resp->assertHeader('Content-Length', '3');
+            $resp->assertHeader('Content-Range', 'bytes 2001-2003/2005');
+            $resp->assertStatus(206);
+
+            // Range beyond content
+            $resp = $this->get($attachment->getUrl($isInline), ['Range' => 'bytes=0-2010']);
+            $resp->assertStreamedContent($content);
+            $resp->assertHeader('Content-Length', '2005');
+            $resp->assertHeaderMissing('Content-Range');
+            $resp->assertStatus(200);
+
+            // Range start before end
+            $resp = $this->get($attachment->getUrl($isInline), ['Range' => 'bytes=50-10']);
+            $resp->assertStreamedContent($content);
+            $resp->assertHeader('Content-Length', '2005');
+            $resp->assertHeader('Content-Range', 'bytes */2005');
+            $resp->assertStatus(416);
+        }
+
+        $this->files->deleteAllAttachmentFiles();
+    }
 }


### PR DESCRIPTION
**Ready for merge**

Primarily for video support.
This also:

- Sets content-length so attachment downloads can properly show progress.
- Adds drag and drop of video into editors to add as an embedded HTML video.

## Notes

In testing, all browsers handle video slightly differently.
Worked across Chrome, Firefox and Safari, with each using range headers in some way.
Couldn't get Safari to chunk though. Did an initial byte request, then consumed the rest in one go, even without playing the video, bit strange and leaves the user waiting for download if they scrub.

For cloud (S3) storage, this added functionality is only semi-supported.
Range responses to the browser will work but the full content is fetched to BookStack, then partially streamed. 
Means it acts the same browser side, but not great for large video as you'll still be waiting for the full content.
Could benefit in some minor cases though, especially where app hosted close to storage.
Is possible to stream on s3-side, but can't seek, so would need a specific solution to range on that side also lower down in driver. Support for s3 services could vary there. Might also be better to use a signed url base approach depending on support.
For now, this shouldn't have any added downsides, so we'll skip any added s3-specific complexity for now.

## Todo

- [x] Add range header support
- [x] Add support for head requests
- [x] Test in a range of browsers
- [x] Test content at boundaries
  - [x] Test with length just before sniff length
  - [x] Test with length just after sniff length
- [x] Test with streaming from s3-like storage
- [x] Cover with testing