### PR TITLE
Add OIDC PKCE functionality

### DIFF
--- a/app/Access/Oidc/OidcOAuthProvider.php
+++ b/app/Access/Oidc/OidcOAuthProvider.php
@@ -83,15 +83,9 @@ class OidcOAuthProvider extends AbstractProvider
 
     /**
      * Checks a provider response for errors.
-     *
-     * @param ResponseInterface $response
-     * @param array|string      $data     Parsed response data
-     *
      * @throws IdentityProviderException
-     *
-     * @return void
      */
-    protected function checkResponse(ResponseInterface $response, $data)
+    protected function checkResponse(ResponseInterface $response, $data): void
     {
         if ($response->getStatusCode() >= 400 || isset($data['error'])) {
             throw new IdentityProviderException(
@@ -105,13 +99,8 @@ class OidcOAuthProvider extends AbstractProvider
     /**
      * Generates a resource owner object from a successful resource owner
      * details request.
-     *
-     * @param array       $response
-     * @param AccessToken $token
-     *
-     * @return ResourceOwnerInterface
      */
-    protected function createResourceOwner(array $response, AccessToken $token)
+    protected function createResourceOwner(array $response, AccessToken $token): ResourceOwnerInterface
     {
         return new GenericResourceOwner($response, '');
     }
@@ -121,14 +110,18 @@ class OidcOAuthProvider extends AbstractProvider
      *
      * The grant that was used to fetch the response can be used to provide
      * additional context.
-     *
-     * @param array         $response
-     * @param AbstractGrant $grant
-     *
-     * @return OidcAccessToken
      */
-    protected function createAccessToken(array $response, AbstractGrant $grant)
+    protected function createAccessToken(array $response, AbstractGrant $grant): OidcAccessToken
     {
         return new OidcAccessToken($response);
+    }
+
+    /**
+     * Get the method used for PKCE code verifier hashing, which is passed
+     * in the "code_challenge_method" parameter in the authorization request.
+     */
+    protected function getPkceMethod(): string
+    {
+        return static::PKCE_METHOD_S256;
     }
 }


### PR DESCRIPTION
Related to #4734.

### Todo

- [x] Check full implementation and library [against RFC spec](https://datatracker.ietf.org/doc/html/rfc7636).
- [x] Cover with PHPUnit testing.
- Auth system checks (Check each with and without enforcement for post/after compatibility):
  - [x] Jumpcloud
    - Works fine, Could not force PKCE, fails when invalid.
  - [x] Okta
    - Works fine, allows forcing PKCE. Fails in expected cases of invalid/missing value, including invalid when not enforced.
  - [x] Auth0
    - Could not find option to force PKCE. Does fail with invalid PKCE in auth code request.
  - [x] Keycloak
    - Works fine, allows forcing PKCE (via specifying method) and fails without, and invalid when not enforced.
  - [x] Authentik
    - Could not find easy option to force PKCE, but does fail with invalid PKCE.
  - [x] Azure
    - Could not find option to force PKCE, but does fail with invalid PKCE.

### Docs Updates

- Update OIDC guidance to indicate support of PKCE, and advise enforcement where possible for extra security.
- Update advisory to advise enforcement? Probably a good idea.