### PR TITLE
Enhanced diagrams.net export functionality

### DIFF
--- a/dev/docs/javascript-public-events.md
+++ b/dev/docs/javascript-public-events.md
@@ -96,6 +96,27 @@ window.addEventListener('editor-drawio::configure', event => {
 });
 ```
 
+### `editor-drawio::export`
+
+This event is triggered when an export action is initiated in the embedded diagrams.net drawing editor. It allows for dynamic configuration of the export parameters of diagrams.net, offering greater flexibility and control over the export process.
+See [this diagrams.net page](https://www.drawio.com/doc/faq/embed-mode) for details on the available options for the configure event.
+
+#### Event Data
+
+- `config` - The configuration object used for the export function in diagrams.net.
+  - The default settings include format: 'xmlpng', xml: message.xml, and spin: 'Updating drawing'.
+  - You can modify this object in-place to customize the export parameters as per your requirements.
+
+##### Example
+
+```javascript
+// Set export scale parameter to 2
+window.addEventListener('editor-drawio::export', event => {
+    const config = event.detail.config;
+    config.scale = 2;
+});
+```
+
 ### `editor-tinymce::pre-init`
 
 This event is called before the TinyMCE editor, used as the BookStack WYSIWYG page editor, is initialised.

--- a/resources/js/services/drawio.js
+++ b/resources/js/services/drawio.js
@@ -21,9 +21,11 @@ function drawEventExport(message) {
 }
 
 function drawEventSave(message) {
-    drawPostMessage({
-        action: 'export', format: 'xmlpng', xml: message.xml, spin: 'Updating drawing',
-    });
+    const config = {
+        format: 'xmlpng', xml: message.xml, spin: 'Updating drawing',
+    };
+    window.$events.emitPublic(iFrame, 'editor-drawio::export', {config});
+    drawPostMessage({action: 'export', ...config});
 }
 
 function drawEventInit() {


### PR DESCRIPTION
### Description

This Pull Request introduces the editor-drawio::export event to the BookStack platform, following the discussion in issue #4156. The primary goal of this enhancement is to provide additional flexibility and customization for the export settings of the diagrams.net integration within BookStack.

### New Public Event - editor-drawio::export

* This event allows for dynamic modification of the diagrams.net export parameters. It is triggered during the export action in the diagrams.net editor embedded within BookStack.
* Users can now customize export settings based on their specific requirements, such as adjusting the scale, format, or any other diagrams.net supported parameters.

### Testing and Validation:
* The functionality has been tested by implementing custom scripts in the 'Custom HTML Head Content' section of BookStack.
* Specifically, I verified that adjusting the scale parameter of the export configuration through the new event works as expected, without any issues.

How to Test:

To test this feature, you can add the following script to the 'Custom HTML Head Content' section in BookStack:

```script
window.addEventListener('editor-drawio::export', event => {
    const config = event.detail.config;
    config.scale = 2; // Adjust the scale as needed
});
```

This script will dynamically adjust the export scale of diagrams.net drawings.