### PR TITLE
Update PWA manifest

### DIFF
--- a/app/App/PwaManifestBuilder.php
+++ b/app/App/PwaManifestBuilder.php
@@ -26,7 +26,7 @@ class PwaManifestBuilder
             "launch_handler" => [
                 "client_mode" => "focus-existing"
             ],
-            "orientation" => "portrait",
+            "orientation" => "any",
             "icons" => [
                 [
                     "src" => setting('app-icon-32') ?: url('/icon-32.png'),


### PR DESCRIPTION
Changed the orientation settings in PwaManifestBuilder.php from 'portrait' to 'any'. This allows the PWA to adjust to any screen orientation, enhancing user flexibility.

> [!IMPORTANT]
> A decision was made to propose a configuration change after attempting to use BookStack on a tablet. Without this > change, webapk opens BookStack in portrait mode only.
> 
> **These changes will enhance the positive user experience for users who do not possess the required technical skills.**

