### PR TITLE
Implement OIDC_AUTO_REGISTER setting

### DIFF
--- a/.env.example.complete
+++ b/.env.example.complete
@@ -274,6 +274,7 @@ OIDC_GROUPS_CLAIM=groups
 OIDC_REMOVE_FROM_GROUPS=false
 OIDC_EXTERNAL_ID_CLAIM=sub
 OIDC_END_SESSION_ENDPOINT=false
+OIDC_AUTO_REGISTER=true
 
 # Disable default third-party services such as Gravatar and Draw.IO
 # Service-specific options will override this option

--- a/app/Access/Oidc/OidcService.php
+++ b/app/Access/Oidc/OidcService.php
@@ -269,12 +269,17 @@ class OidcService
             throw new OidcException(trans('errors.oidc_already_logged_in'));
         }
 
+
         try {
-            $user = $this->registrationService->findOrRegister(
-                $userDetails['name'],
-                $userDetails['email'],
-                $userDetails['external_id']
-            );
+            if ($this->config()['auto_register'] === false) {
+                $user = $this->registrationService->findOrFail($userDetails['external_id']);
+            } else {
+                $user = $this->registrationService->findOrRegister(
+                    $userDetails['name'],
+                    $userDetails['email'],
+                    $userDetails['external_id']
+                );
+            }
         } catch (UserRegistrationException $exception) {
             throw new OidcException($exception->getMessage());
         }

--- a/app/Access/RegistrationService.php
+++ b/app/Access/RegistrationService.php
@@ -51,6 +51,25 @@ class RegistrationService
     }
 
     /**
+     * Attempt to find a user in the system.
+     * For use with external auth systems since password is auto-generated.
+     *
+     * @throws UserRegistrationException
+     */
+    public function findOrFail(string $externalId): User
+    {
+        $user = User::query()
+            ->where('external_auth_id', '=', $externalId)
+            ->first();
+
+        if (is_null($user)) {
+            throw new UserRegistrationException(trans('auth.failed'), '/login');
+        }
+
+        return $user;
+    }
+
+    /**
      * Attempt to find a user in the system otherwise register them as a new
      * user. For use with external auth systems since password is auto-generated.
      *

--- a/app/Config/oidc.php
+++ b/app/Config/oidc.php
@@ -42,6 +42,9 @@ return [
     // A string value is used as the URL.
     'end_session_endpoint' => env('OIDC_END_SESSION_ENDPOINT', false),
 
+    // Enable Auto Register
+    'auto_register' => env('OIDC_AUTO_REGISTER', true),
+
     // Add extra scopes, upon those required, to the OIDC authentication request
     // Multiple values can be provided comma seperated.
     'additional_scopes' => env('OIDC_ADDITIONAL_SCOPES', null),


### PR DESCRIPTION
## Overview

This PR adds a setting for OIDC_AUTO_REGISTER. This behaves similar to the other third party authentication setting XXXX_AUTO_REGISTER.

## Behavior

Defaults to true

When set to true everything behaves as it currently does. If an account does not exist for an OIDC login, then it will be automatically created for them. If it does exist then the user can log in.

When set to false, Oidc logins will fail if a user was not created beforehand. Failure message is set to `auth.failed`. In order to log in you must first create an account with another admin account and manually input the **External Authentication ID**.

## Why this would be helpful

I work for a university, and our department would like to implement bookstack while using our university's authentication services to handle logins. 

Problem is anyone affiliated with the university has a login, but I only want people from my department to have access to our bookstacks instance. Everyone at this university knows their own External Authentication ID so it makes it easy for us to create the accounts manually and control who has access.