### PR TITLE
Added password history, complexity, and expiry validations

### DIFF
--- a/.env.example.complete
+++ b/.env.example.complete
@@ -84,6 +84,27 @@ MAIL_VERIFY_SSL=true
 
 MAIL_SENDMAIL_COMMAND="/usr/sbin/sendmail -bs"
 
+# Password security configuration
+# Number of recent passwords to check against, only enforced if set
+PASSWORD_HISTORY=5
+
+# Days before a password is forced to change, only enforced if set
+PASSWORD_MAX_AGE=60
+
+# Days before a password is allowed to change, only enforced if set
+PASSWORD_MIN_AGE=2
+
+# Built-in laravel password valdation
+# min defaults to 8, rest default to false
+# For more information please refer to https://laravel.com/docs/9.x/validation#validating-passwords
+PASSWORD_MIN=8
+PASSWORD_REQUIRE_LETTERS=true
+PASSWORD_REQUIRE_NUMBERS=true
+PASSWORD_REQUIRE_MIXED_CASE=true
+PASSWORD_REQUIRE_SYMBOLS=true
+PASSWORD_REQUIRE_UNCOMPROMISED=false
+
+
 # Cache & Session driver to use
 # Can be 'file', 'database', 'memcached' or 'redis'
 CACHE_DRIVER=file

--- a/app/Access/Controllers/LoginController.php
+++ b/app/Access/Controllers/LoginController.php
@@ -74,6 +74,7 @@ class LoginController extends Controller
 
         try {
             if ($this->attemptLogin($request)) {
+                //logout and redirect to password reset page if the user's password is expired
                 $password_created_at = Carbon::parse(PasswordHistory::where('user_id', auth()->user()->id)->orderBy('created_at', 'desc')->first()->created_at);
                 if (env('PASSWORD_MAX_AGE', false) && $password_created_at->lessThan(Carbon::now()->subDays(env('PASSWORD_MAX_AGE')))) {
                     auth()->logout();

--- a/app/Access/Controllers/LoginController.php
+++ b/app/Access/Controllers/LoginController.php
@@ -77,7 +77,7 @@ class LoginController extends Controller
                 $password_created_at = Carbon::parse(PasswordHistory::where('user_id', auth()->user()->id)->orderBy('created_at', 'desc')->first()->created_at);
                 if (env('PASSWORD_MAX_AGE', false) && $password_created_at->lessThan(Carbon::now()->subDays(env('PASSWORD_MAX_AGE')))) {
                     auth()->logout();
-                    $this->showWarningNotification('Your password has expired, please reset it.');
+                    $this->showWarningNotification(trans('errors.password_expired'));
                     return redirect('/password/email');
                 }
                 return $this->sendLoginResponse($request);

--- a/app/Access/Controllers/ResetPasswordController.php
+++ b/app/Access/Controllers/ResetPasswordController.php
@@ -56,7 +56,7 @@ class ResetPasswordController extends Controller
         // database. Otherwise we will parse the error and return the response.
         $credentials = $request->only('email', 'password', 'password_confirmation', 'token');
         $response = Password::broker()->reset($credentials, function (User $user, string $password) {
-            //validate new password with PasswordHistory model before saving
+            // validate and record new password in PasswordHistory model before saving
             try{
                 PasswordHistory::create(['user_id' => $user->id, 'password' => $password]);
             } catch (PasswordHistoryException $e) {

--- a/app/Access/Controllers/ResetPasswordController.php
+++ b/app/Access/Controllers/ResetPasswordController.php
@@ -12,7 +12,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
 use Illuminate\Validation\Rules\Password as PasswordRule;
 use BookStack\Exceptions\PasswordHistoryException;
 

--- a/app/Access/Controllers/UserInviteController.php
+++ b/app/Access/Controllers/UserInviteController.php
@@ -13,6 +13,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules\Password;
+use BookStack\Users\Models\PasswordHistory;
 
 class UserInviteController extends Controller
 {

--- a/app/Access/Controllers/UserInviteController.php
+++ b/app/Access/Controllers/UserInviteController.php
@@ -68,6 +68,13 @@ class UserInviteController extends Controller
 
         $user = $this->userRepo->getById($userId);
         $user->password = Hash::make($request->get('password'));
+
+        //save new password in histories
+        $passwordHistory = PasswordHistory::create_initial_history([
+            'user_id' => $user->id,
+            'hash' => $user->password
+        ]);
+        
         $user->email_confirmed = true;
         $user->save();
 

--- a/app/App/Providers/AuthServiceProvider.php
+++ b/app/App/Providers/AuthServiceProvider.php
@@ -25,7 +25,15 @@ class AuthServiceProvider extends ServiceProvider
     {
         // Password Configuration
         // Changes here must be reflected in ApiDocsGenerate@getValidationAsString.
-        Password::defaults(fn () => Password::min(8));
+        Password::defaults(function () {
+            $passwordRule = Password::min(env('PASSWORD_MIN', 8));
+            if (env('PASSWORD_REQUIRE_LETTERS', false)) $passwordRule->letters();
+            if (env('PASSWORD_REQUIRE_NUMBERS', false)) $passwordRule->numbers();
+            if (env('PASSWORD_REQUIRE_MIXED_CASE', false)) $passwordRule->mixedCase();
+            if (env('PASSWORD_REQUIRE_SYMBOLS', false)) $passwordRule->symbols();
+            if (env('PASSWORD_REQUIRE_UNCOMPROMISED', false)) $passwordRule->uncompromised();
+            return $passwordRule;
+        });
 
         // Custom guards
         Auth::extend('api-token', function ($app, $name, array $config) {

--- a/app/Exceptions/PasswordHistoryException.php
+++ b/app/Exceptions/PasswordHistoryException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BookStack\Exceptions;
+
+class PasswordHistoryException extends NotifyException
+{
+}

--- a/app/Users/Models/PasswordHistory.php
+++ b/app/Users/Models/PasswordHistory.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace BookStack\Users\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Carbon;
+use BookStack\App\Model;
+use BookStack\Exceptions\PasswordHistoryException;
+
+
+class PasswordHistory extends Model
+{
+    protected $fillable = [
+        'user_id', 'hash'
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::Class);
+    }
+
+    /**
+    * Creates a password history log upon password creation or change
+    * @throws PasswordHistoryException
+    */
+    public static function create(array $newHistory)
+    {
+
+        if (env('PASSWORD_HISTORY', 0) < 1) return;
+
+        $histories = PasswordHistory::where('user_id', $newHistory['user_id'])->orderBy('created_at', 'desc')->take(env('PASSWORD_HISTORY'))->get();
+        $last_password_created_at = $histories->first()->created_at;
+
+        if ($last_password_created_at->greaterThan(Carbon::now()->subDays(env('PASSWORD_MIN_AGE', 0)))){
+            throw new PasswordHistoryException('Password has been recently changed');
+        }
+
+        foreach($histories as $history) {
+            if (Hash::check($newHistory['password'], $history['hash'])){
+                throw new PasswordHistoryException('Password has been recently used');
+            }
+        }
+
+        return static::query()->create([
+            'user_id' => $newHistory['user_id'],
+            'hash' => Hash::make($newHistory['password']),
+        ]);
+    }
+
+    /**
+    * Creates a history for existing passwords, only used in initial migration
+    */
+    public static function create_initial_history(array $newHistory)
+    {
+        return static::query()->create([
+            'user_id' => $newHistory['user_id'],
+            'hash' => $newHistory['hash'],
+        ]);
+    }
+
+}

--- a/app/Users/Models/PasswordHistory.php
+++ b/app/Users/Models/PasswordHistory.php
@@ -33,12 +33,12 @@ class PasswordHistory extends Model
         $last_password_created_at = $histories->first()->created_at;
 
         if ($last_password_created_at->greaterThan(Carbon::now()->subDays(env('PASSWORD_MIN_AGE', 0)))){
-            throw new PasswordHistoryException('Password has been recently changed');
+            throw new PasswordHistoryException(trans('errors.password_cannot_be_changed', ['days' => env('PASSWORD_MIN_AGE')]));
         }
 
         foreach($histories as $history) {
             if (Hash::check($newHistory['password'], $history['hash'])){
-                throw new PasswordHistoryException('Password has been recently used');
+                throw new PasswordHistoryException(trans('errors.cannot_reuse_password', ['passwords' => env('PASSWORD_HISTORY')]));
             }
         }
 

--- a/app/Users/Models/PasswordHistory.php
+++ b/app/Users/Models/PasswordHistory.php
@@ -21,7 +21,7 @@ class PasswordHistory extends Model
     }
 
     /**
-    * Creates a password history log upon password creation or change
+    * Creates a password history log upon password change
     * @throws PasswordHistoryException
     */
     public static function create(array $newHistory)
@@ -49,7 +49,7 @@ class PasswordHistory extends Model
     }
 
     /**
-    * Creates a history for existing passwords, only used in initial migration
+    * Creates a password history log upon user creation and initial migration
     */
     public static function create_initial_history(array $newHistory)
     {

--- a/app/Users/UserRepo.php
+++ b/app/Users/UserRepo.php
@@ -11,10 +11,12 @@ use BookStack\Facades\Activity;
 use BookStack\Uploads\UserAvatars;
 use BookStack\Users\Models\Role;
 use BookStack\Users\Models\User;
+use BookStack\Users\Models\PasswordHistory;
 use Exception;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Illuminate\Support\Carbon;
 
 class UserRepo
 {
@@ -65,6 +67,12 @@ class UserRepo
 
         $user->refreshSlug();
         $user->save();
+
+        //save new password in histories
+        $passwordHistory = PasswordHistory::create_initial_history([
+            'user_id' => $user->id,
+            'hash' => $user->password
+        ]);
 
         if (!empty($data['language'])) {
             setting()->putUser($user, 'language', $data['language']);
@@ -124,6 +132,7 @@ class UserRepo
         }
 
         if (!empty($data['password'])) {
+            $passwordHistory = PasswordHistory::create(['user_id' => $user->id, 'password' => $data['password']]);
             $user->password = Hash::make($data['password']);
         }
 

--- a/app/Users/UserRepo.php
+++ b/app/Users/UserRepo.php
@@ -68,7 +68,7 @@ class UserRepo
         $user->save();
 
         //save new password in histories
-        $passwordHistory = PasswordHistory::create_initial_history([
+        PasswordHistory::create_initial_history([
             'user_id' => $user->id,
             'hash' => $user->password
         ]);
@@ -131,7 +131,8 @@ class UserRepo
         }
 
         if (!empty($data['password'])) {
-            $passwordHistory = PasswordHistory::create(['user_id' => $user->id, 'password' => $data['password']]);
+            // validate and record new password in PasswordHistory model before saving
+            PasswordHistory::create(['user_id' => $user->id, 'password' => $data['password']]);
             $user->password = Hash::make($data['password']);
         }
 

--- a/app/Users/UserRepo.php
+++ b/app/Users/UserRepo.php
@@ -16,7 +16,6 @@ use Exception;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
 
 class UserRepo
 {

--- a/database/migrations/2024_01_28_112712_create_password_histories_table.php
+++ b/database/migrations/2024_01_28_112712_create_password_histories_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use BookStack\Users\Models\User;
+use BookStack\Users\Models\PasswordHistory;
+
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('password_histories', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id')->unsigned();
+            $table->string('hash', 60);
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')
+            ->onUpdate('cascade')->onDelete('cascade');
+        });
+        
+        foreach (User::all() as $user) {
+            PasswordHistory::create_initial_history([
+                'user_id' => $user->id,
+                'hash' => $user->password
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('password_histories');
+    }
+};

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -77,6 +77,12 @@ return [
     // Users
     'users_cannot_delete_only_admin' => 'You cannot delete the only admin',
     'users_cannot_delete_guest' => 'You cannot delete the guest user',
+    
+    // Password history
+    'password_cannot_be_changed' => 'Password cannot be changed for :days day(s)',
+    'cannot_reuse_password' => 'Password cannot be within the last :passwords password(s)',
+    'password_expired' => 'Your password has expired, please reset it',
+    
 
     // Roles
     'role_cannot_be_edited' => 'This role cannot be edited',


### PR DESCRIPTION
This PR implements the following validations for passwords:

1- Password history: stops the user from re-using a password they have previously used. The number of passwords to be validated can be set in the PASSWORD_HISTORY environment variable.

2- Password expiry: forces the user to reset their password after a specified period. The number of days before expiry can be set in the PASSWORD_MAX_AGE environment variable.

3- Password lock: Stops the password from being changed until a specified period has elapsed. The number of days until a password can be changed can be set in the PASSWORD_MIN_AGE environment variable.

4- Password complexity: uses Laravel's built-in password validation to enforce password policies that can be set as environment variables. Please see .env.example.complete for the complete list of complexity validations.