### PR TITLE
Turned off autocomplete for TOTP codes

### DIFF
--- a/resources/views/mfa/parts/verify-totp.blade.php
+++ b/resources/views/mfa/parts/verify-totp.blade.php
@@ -2,7 +2,7 @@
 
 <p class="small mb-m">{{ trans('auth.mfa_verify_totp_desc') }}</p>
 
-<form action="{{ url('/mfa/totp/verify') }}" method="post">
+<form action="{{ url('/mfa/totp/verify') }}" method="post" autocomplete="off">
     {{ csrf_field() }}
     <input type="text"
            name="code"


### PR DESCRIPTION
Small QOL change to turn off autocomplete when entering TOTP codes since they're one time use only.