### PR TITLE
Dependency Licensing Improvements

### DIFF
--- a/app/App/HomeController.php
+++ b/app/App/HomeController.php
@@ -9,7 +9,6 @@ use BookStack\Entities\Queries\QueryRecentlyViewed;
 use BookStack\Entities\Queries\QueryTopFavourites;
 use BookStack\Entities\Tools\PageContent;
 use BookStack\Http\Controller;
-use BookStack\Uploads\FaviconHandler;
 use BookStack\Util\SimpleListOptions;
 use Illuminate\Http\Request;
 
@@ -111,49 +110,5 @@ class HomeController extends Controller
         }
 
         return view('home.default', $commonData);
-    }
-
-    /**
-     * Show the view for /robots.txt.
-     */
-    public function robots()
-    {
-        $sitePublic = setting('app-public', false);
-        $allowRobots = config('app.allow_robots');
-
-        if ($allowRobots === null) {
-            $allowRobots = $sitePublic;
-        }
-
-        return response()
-            ->view('misc.robots', ['allowRobots' => $allowRobots])
-            ->header('Content-Type', 'text/plain');
-    }
-
-    /**
-     * Show the route for 404 responses.
-     */
-    public function notFound()
-    {
-        return response()->view('errors.404', [], 404);
-    }
-
-    /**
-     * Serve the application favicon.
-     * Ensures a 'favicon.ico' file exists at the web root location (if writable) to be served
-     * directly by the webserver in the future.
-     */
-    public function favicon(FaviconHandler $favicons)
-    {
-        $exists = $favicons->restoreOriginalIfNotExists();
-        return response()->file($exists ? $favicons->getPath() : $favicons->getOriginalPath());
-    }
-
-    /**
-     * Serve a PWA application manifest.
-     */
-    public function pwaManifest(PwaManifestBuilder $manifestBuilder)
-    {
-        return response()->json($manifestBuilder->build());
     }
 }

--- a/app/App/MetaController.php
+++ b/app/App/MetaController.php
@@ -56,7 +56,7 @@ class MetaController extends Controller
      */
     public function licenses()
     {
-        $this->setPageTitle('Licenses');
+        $this->setPageTitle(trans('settings.licenses'));
 
         return view('help.licenses', [
             'license' => file_get_contents(base_path('LICENSE')),

--- a/app/App/MetaController.php
+++ b/app/App/MetaController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace BookStack\App;
+
+use BookStack\Http\Controller;
+use BookStack\Uploads\FaviconHandler;
+
+class MetaController extends Controller
+{
+    /**
+     * Show the view for /robots.txt.
+     */
+    public function robots()
+    {
+        $sitePublic = setting('app-public', false);
+        $allowRobots = config('app.allow_robots');
+
+        if ($allowRobots === null) {
+            $allowRobots = $sitePublic;
+        }
+
+        return response()
+            ->view('misc.robots', ['allowRobots' => $allowRobots])
+            ->header('Content-Type', 'text/plain');
+    }
+
+    /**
+     * Show the route for 404 responses.
+     */
+    public function notFound()
+    {
+        return response()->view('errors.404', [], 404);
+    }
+
+    /**
+     * Serve the application favicon.
+     * Ensures a 'favicon.ico' file exists at the web root location (if writable) to be served
+     * directly by the webserver in the future.
+     */
+    public function favicon(FaviconHandler $favicons)
+    {
+        $exists = $favicons->restoreOriginalIfNotExists();
+        return response()->file($exists ? $favicons->getPath() : $favicons->getOriginalPath());
+    }
+
+    /**
+     * Serve a PWA application manifest.
+     */
+    public function pwaManifest(PwaManifestBuilder $manifestBuilder)
+    {
+        return response()->json($manifestBuilder->build());
+    }
+
+    /**
+     * Show license information for the application.
+     */
+    public function licenses()
+    {
+        $this->setPageTitle('Licenses');
+
+        return view('help.licenses', [
+            'license' => file_get_contents(base_path('LICENSE')),
+            'phpLibData' => file_get_contents(base_path('dev/licensing/php-library-licenses.txt')),
+            'jsLibData' => file_get_contents(base_path('dev/licensing/js-library-licenses.txt')),
+        ]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,10 @@
         "lint": "phpcs",
         "test": "phpunit",
         "t-reset": "@php artisan test --recreate-databases",
+        "build-licenses": [
+            "@php ./dev/licensing/gen-js-licenses",
+            "@php ./dev/licensing/gen-php-licenses"
+        ],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"

--- a/dev/build/esbuild.js
+++ b/dev/build/esbuild.js
@@ -30,6 +30,10 @@ esbuild.build({
     format: 'esm',
     minify: isProd,
     logLevel: 'info',
+    banner: {
+        js: '// See the "/licenses" URI for full package license details',
+        css: '/* See the "/licenses" URI for full package license details */',
+    },
 }).then(result => {
     fs.writeFileSync('esbuild-meta.json', JSON.stringify(result.metafile));
 }).catch(() => process.exit(1));

--- a/dev/licensing/gen-js-licenses
+++ b/dev/licensing/gen-js-licenses
@@ -1,0 +1,121 @@
+#!/usr/bin/env php
+<?php
+
+// This script reads the project composer.lock file to generate
+// clear license details for our PHP dependencies.
+
+$rootPath = dirname(__DIR__, 2);
+$outputPath = "{$rootPath}/dev/licensing/js-library-licenses.txt";
+$outputSeparator = "\n-----------\n";
+$warnings = [];
+
+$packages = [
+    ...glob("{$rootPath}/node_modules/*/package.json"),
+    ...glob("{$rootPath}/node_modules/@*/*/package.json"),
+];
+
+$packageOutput = array_map(packageToOutput(...), $packages);
+
+$licenseInfo = implode($outputSeparator, $packageOutput) . "\n";
+file_put_contents($outputPath, $licenseInfo);
+
+echo "License information written to {$outputPath}\n";
+echo implode("\n", $warnings);
+
+function dd(mixed $data): never {
+    print_r($data);
+    exit(0);
+}
+
+function packageToOutput(string $packagePath): string
+{
+    global $rootPath;
+    $package = json_decode(file_get_contents($packagePath));
+    $output = ["{$package->name}"];
+
+    $license = $package->license ?? '';
+    if ($license) {
+        $output[] = "License: {$license}";
+    } else {
+        warn("Package {$package->name}: No license found");
+    }
+
+    $licenseFile = findLicenseFile($package->name, $packagePath);
+    if ($licenseFile) {
+        $relLicenseFile = str_replace("{$rootPath}/", '', $licenseFile);
+        $output[] = "License File: {$relLicenseFile}";
+        $copyright = findCopyright($licenseFile);
+        if ($copyright) {
+            $output[] = "Copyright: {$copyright}";
+        } else {
+            warn("Package {$package->name}: no copyright found in its license");
+        }
+    }
+
+    $source = $package->repository->url ?? $package->repository ?? '';
+    if ($source) {
+        $output[] = "Source: {$source}";
+    }
+
+    $link = $package->homepage ?? $source;
+    if ($link) {
+        $output[] = "Link: {$link}";
+    }
+
+    return implode("\n", $output);
+}
+
+function findLicenseFile(string $packageName, string $packagePath): string
+{
+    $licenseNameOptions = [
+        'license', 'LICENSE', 'License',
+        'license.*', 'LICENSE.*', 'License.*',
+        'license-*.*', 'LICENSE-*.*', 'License-*.*',
+    ];
+    $packageDir = dirname($packagePath);
+
+    $foundLicenses = [];
+    foreach ($licenseNameOptions as $option) {
+        $search = glob("{$packageDir}/$option");
+        array_push($foundLicenses, ...$search);
+    }
+
+    if (count($foundLicenses) > 1) {
+        warn("Package {$packageName}: more than one license file found");
+    }
+
+    if (count($foundLicenses) > 0) {
+        $fileName = basename($foundLicenses[0]);
+        return "{$packageDir}/{$fileName}";
+    }
+
+    warn("Package {$packageName}: no license files found");
+    return '';
+}
+
+function findCopyright(string $licenseFile): string
+{
+    $fileContents = file_get_contents($licenseFile);
+    $pattern = '/^.*?copyright (\(c\)|\d{4})[\s\S]*?(\n\n|\.\n)/mi';
+    $matches = [];
+    preg_match($pattern, $fileContents, $matches);
+    $copyright = trim($matches[0] ?? '');
+
+    if (str_contains($copyright, 'i.e.')) {
+        return '';
+    }
+
+    $emailPattern = '/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/i';
+    return preg_replace_callback($emailPattern, obfuscateEmail(...), $copyright);
+}
+
+function obfuscateEmail(array $matches): string
+{
+    return preg_replace('/[^@.]/', '*', $matches[1]);
+}
+
+function warn(string $text): void
+{
+    global $warnings;
+    $warnings[] = "WARN:" . $text;
+}

--- a/dev/licensing/gen-js-licenses
+++ b/dev/licensing/gen-js-licenses
@@ -22,7 +22,7 @@ $licenseInfo = implode($outputSeparator, $packageOutput) . "\n";
 file_put_contents($outputPath, $licenseInfo);
 
 echo "License information written to {$outputPath}\n";
-echo implode("\n", getWarnings());
+echo implode("\n", getWarnings()) . "\n";
 
 function packageToOutput(string $packagePath): string
 {

--- a/dev/licensing/gen-js-licenses
+++ b/dev/licensing/gen-js-licenses
@@ -4,10 +4,12 @@
 // This script reads the project composer.lock file to generate
 // clear license details for our PHP dependencies.
 
+declare(strict_types=1);
+require "gen-licenses-shared.php";
+
 $rootPath = dirname(__DIR__, 2);
 $outputPath = "{$rootPath}/dev/licensing/js-library-licenses.txt";
 $outputSeparator = "\n-----------\n";
-$warnings = [];
 
 $packages = [
     ...glob("{$rootPath}/node_modules/*/package.json"),
@@ -20,12 +22,7 @@ $licenseInfo = implode($outputSeparator, $packageOutput) . "\n";
 file_put_contents($outputPath, $licenseInfo);
 
 echo "License information written to {$outputPath}\n";
-echo implode("\n", $warnings);
-
-function dd(mixed $data): never {
-    print_r($data);
-    exit(0);
-}
+echo implode("\n", getWarnings());
 
 function packageToOutput(string $packagePath): string
 {
@@ -63,59 +60,4 @@ function packageToOutput(string $packagePath): string
     }
 
     return implode("\n", $output);
-}
-
-function findLicenseFile(string $packageName, string $packagePath): string
-{
-    $licenseNameOptions = [
-        'license', 'LICENSE', 'License',
-        'license.*', 'LICENSE.*', 'License.*',
-        'license-*.*', 'LICENSE-*.*', 'License-*.*',
-    ];
-    $packageDir = dirname($packagePath);
-
-    $foundLicenses = [];
-    foreach ($licenseNameOptions as $option) {
-        $search = glob("{$packageDir}/$option");
-        array_push($foundLicenses, ...$search);
-    }
-
-    if (count($foundLicenses) > 1) {
-        warn("Package {$packageName}: more than one license file found");
-    }
-
-    if (count($foundLicenses) > 0) {
-        $fileName = basename($foundLicenses[0]);
-        return "{$packageDir}/{$fileName}";
-    }
-
-    warn("Package {$packageName}: no license files found");
-    return '';
-}
-
-function findCopyright(string $licenseFile): string
-{
-    $fileContents = file_get_contents($licenseFile);
-    $pattern = '/^.*?copyright (\(c\)|\d{4})[\s\S]*?(\n\n|\.\n)/mi';
-    $matches = [];
-    preg_match($pattern, $fileContents, $matches);
-    $copyright = trim($matches[0] ?? '');
-
-    if (str_contains($copyright, 'i.e.')) {
-        return '';
-    }
-
-    $emailPattern = '/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/i';
-    return preg_replace_callback($emailPattern, obfuscateEmail(...), $copyright);
-}
-
-function obfuscateEmail(array $matches): string
-{
-    return preg_replace('/[^@.]/', '*', $matches[1]);
-}
-
-function warn(string $text): void
-{
-    global $warnings;
-    $warnings[] = "WARN:" . $text;
 }

--- a/dev/licensing/gen-licenses-shared.php
+++ b/dev/licensing/gen-licenses-shared.php
@@ -1,0 +1,4 @@
+<?php
+
+declare(strict_types=1);
+

--- a/dev/licensing/gen-licenses-shared.php
+++ b/dev/licensing/gen-licenses-shared.php
@@ -2,3 +2,65 @@
 
 declare(strict_types=1);
 
+$warnings = [];
+
+function findLicenseFile(string $packageName, string $packagePath): string
+{
+    $licenseNameOptions = [
+        'license', 'LICENSE', 'License',
+        'license.*', 'LICENSE.*', 'License.*',
+        'license-*.*', 'LICENSE-*.*', 'License-*.*',
+    ];
+    $packageDir = dirname($packagePath);
+
+    $foundLicenses = [];
+    foreach ($licenseNameOptions as $option) {
+        $search = glob("{$packageDir}/$option");
+        array_push($foundLicenses, ...$search);
+    }
+
+    if (count($foundLicenses) > 1) {
+        warn("Package {$packageName}: more than one license file found");
+    }
+
+    if (count($foundLicenses) > 0) {
+        $fileName = basename($foundLicenses[0]);
+        return "{$packageDir}/{$fileName}";
+    }
+
+    warn("Package {$packageName}: no license files found");
+    return '';
+}
+
+function findCopyright(string $licenseFile): string
+{
+    $fileContents = file_get_contents($licenseFile);
+    $pattern = '/^.*?copyright (\(c\)|\d{4})[\s\S]*?(\n\n|\.\n)/mi';
+    $matches = [];
+    preg_match($pattern, $fileContents, $matches);
+    $copyright = trim($matches[0] ?? '');
+
+    if (str_contains($copyright, 'i.e.')) {
+        return '';
+    }
+
+    $emailPattern = '/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/i';
+    return preg_replace_callback($emailPattern, obfuscateEmail(...), $copyright);
+}
+
+function obfuscateEmail(array $matches): string
+{
+    return preg_replace('/[^@.]/', '*', $matches[1]);
+}
+
+function warn(string $text): void
+{
+    global $warnings;
+    $warnings[] = "WARN:" . $text;
+}
+
+function getWarnings(): array
+{
+    global $warnings;
+    return $warnings;
+}

--- a/dev/licensing/gen-php-licenses
+++ b/dev/licensing/gen-php-licenses
@@ -19,7 +19,7 @@ $licenseInfo =  implode($outputSeparator, $packageOutput) . "\n";
 file_put_contents($outputPath, $licenseInfo);
 
 echo "License information written to {$outputPath}\n";
-echo implode("\n", getWarnings());
+echo implode("\n", getWarnings()) . "\n";
 
 function packageToOutput(stdClass $package) : string {
     global $rootPath;

--- a/dev/licensing/gen-php-licenses
+++ b/dev/licensing/gen-php-licenses
@@ -1,0 +1,96 @@
+#!/usr/bin/env php
+<?php
+
+// This script reads the project composer.lock file to generate
+// clear license details for our PHP dependencies.
+
+$rootPath = dirname(__DIR__, 2);
+$outputPath = "{$rootPath}/dev/licensing/php-library-licenses.txt";
+$composerLock = json_decode(file_get_contents($rootPath . "/composer.lock"));
+$outputSeparator = "\n-----------\n";
+$warnings = [];
+
+$packages = $composerLock->packages;
+$packageOutput = array_map(packageToOutput(...), $packages);
+
+$licenseInfo =  implode($outputSeparator, $packageOutput) . "\n";
+file_put_contents($outputPath, $licenseInfo);
+
+echo "License information written to {$outputPath}\n";
+echo implode("\n", $warnings);
+
+function packageToOutput(stdClass $package) : string {
+    $output = ["{$package->name}"];
+
+    $licenses = is_array($package->license) ? $package->license : [$package->license];
+    $output[] = "License: " . implode(' ', $licenses);
+
+    $licenseFile = findLicenseFile($package->name);
+    if ($licenseFile) {
+        $output[] = "License File: {$licenseFile}";
+        $copyright = findCopyright($licenseFile);
+        if ($copyright) {
+            $output[] = "Copyright: {$copyright}";
+        } else {
+            warn("Package {$package->name} has no copyright found in its license");
+        }
+    }
+
+    $source = $package->source->url;
+    if ($source) {
+        $output[] = "Source: {$source}";
+    }
+
+    $link = $package->homepage ?? $package->source->url ?? '';
+    if ($link) {
+        $output[] = "Link: {$link}";
+    }
+
+    return implode("\n", $output);
+}
+
+function findLicenseFile(string $packageName): string {
+    global $rootPath;
+    $licenseNameOptions = ['license', 'LICENSE', 'license.*', 'LICENSE.*'];
+
+    $packagePath = "vendor/{$packageName}";
+    $filePath = "{$rootPath}/{$packagePath}";
+
+    $foundLicenses = [];
+    foreach ($licenseNameOptions as $option) {
+        $search = glob("{$filePath}/$option");
+        array_push($foundLicenses, ...$search);
+    }
+
+    if (count($foundLicenses) > 1) {
+        warn("Package {$packagePath} has more than one license file found");
+    }
+
+    if (count($foundLicenses) > 0) {
+        $fileName = basename($foundLicenses[0]);
+        return "{$packagePath}/{$fileName}";
+    }
+
+    warn("Package {$packageName} has no license files found");
+    return '';
+}
+
+function findCopyright(string $licenseFile): string {
+    $fileContents = file_get_contents($licenseFile);
+    $pattern = '/^.*?copyright (\(c\)|\d{4})[\s\S]*?(\n\n|\.\n)/mi';
+    $matches = [];
+    preg_match($pattern, $fileContents, $matches);
+    $copyright = trim($matches[0] ?? '');
+
+    $emailPattern = '/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/i';
+    return preg_replace_callback($emailPattern, obfuscateEmail(...), $copyright);
+}
+
+function obfuscateEmail(array $matches): string {
+    return preg_replace('/[^@.]/', '*', $matches[1]);
+}
+
+function warn(string $text): void {
+    global $warnings;
+    $warnings[] = "WARN:" . $text;
+}

--- a/dev/licensing/gen-php-licenses
+++ b/dev/licensing/gen-php-licenses
@@ -4,11 +4,13 @@
 // This script reads the project composer.lock file to generate
 // clear license details for our PHP dependencies.
 
+declare(strict_types=1);
+require "gen-licenses-shared.php";
+
 $rootPath = dirname(__DIR__, 2);
 $outputPath = "{$rootPath}/dev/licensing/php-library-licenses.txt";
 $composerLock = json_decode(file_get_contents($rootPath . "/composer.lock"));
 $outputSeparator = "\n-----------\n";
-$warnings = [];
 
 $packages = $composerLock->packages;
 $packageOutput = array_map(packageToOutput(...), $packages);
@@ -17,22 +19,25 @@ $licenseInfo =  implode($outputSeparator, $packageOutput) . "\n";
 file_put_contents($outputPath, $licenseInfo);
 
 echo "License information written to {$outputPath}\n";
-echo implode("\n", $warnings);
+echo implode("\n", getWarnings());
 
 function packageToOutput(stdClass $package) : string {
+    global $rootPath;
     $output = ["{$package->name}"];
 
     $licenses = is_array($package->license) ? $package->license : [$package->license];
     $output[] = "License: " . implode(' ', $licenses);
 
-    $licenseFile = findLicenseFile($package->name);
+    $packagePath = "{$rootPath}/vendor/{$package->name}/package.json";
+    $licenseFile = findLicenseFile($package->name, $packagePath);
     if ($licenseFile) {
-        $output[] = "License File: {$licenseFile}";
+        $relLicenseFile = str_replace("{$rootPath}/", '', $licenseFile);
+        $output[] = "License File: {$relLicenseFile}";
         $copyright = findCopyright($licenseFile);
         if ($copyright) {
             $output[] = "Copyright: {$copyright}";
         } else {
-            warn("Package {$package->name} has no copyright found in its license");
+            warn("Package {$package->name}: no copyright found in its license");
         }
     }
 
@@ -47,50 +52,4 @@ function packageToOutput(stdClass $package) : string {
     }
 
     return implode("\n", $output);
-}
-
-function findLicenseFile(string $packageName): string {
-    global $rootPath;
-    $licenseNameOptions = ['license', 'LICENSE', 'license.*', 'LICENSE.*'];
-
-    $packagePath = "vendor/{$packageName}";
-    $filePath = "{$rootPath}/{$packagePath}";
-
-    $foundLicenses = [];
-    foreach ($licenseNameOptions as $option) {
-        $search = glob("{$filePath}/$option");
-        array_push($foundLicenses, ...$search);
-    }
-
-    if (count($foundLicenses) > 1) {
-        warn("Package {$packagePath} has more than one license file found");
-    }
-
-    if (count($foundLicenses) > 0) {
-        $fileName = basename($foundLicenses[0]);
-        return "{$packagePath}/{$fileName}";
-    }
-
-    warn("Package {$packageName} has no license files found");
-    return '';
-}
-
-function findCopyright(string $licenseFile): string {
-    $fileContents = file_get_contents($licenseFile);
-    $pattern = '/^.*?copyright (\(c\)|\d{4})[\s\S]*?(\n\n|\.\n)/mi';
-    $matches = [];
-    preg_match($pattern, $fileContents, $matches);
-    $copyright = trim($matches[0] ?? '');
-
-    $emailPattern = '/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/i';
-    return preg_replace_callback($emailPattern, obfuscateEmail(...), $copyright);
-}
-
-function obfuscateEmail(array $matches): string {
-    return preg_replace('/[^@.]/', '*', $matches[1]);
-}
-
-function warn(string $text): void {
-    global $warnings;
-    $warnings[] = "WARN:" . $text;
 }

--- a/dev/licensing/js-library-licenses.txt
+++ b/dev/licensing/js-library-licenses.txt
@@ -1,0 +1,1978 @@
+acorn-jsx
+License: MIT
+License File: node_modules/acorn-jsx/LICENSE
+Copyright: Copyright (C) 2012-2017 by Ingvar Stepanyan
+Source: https://github.com/acornjs/acorn-jsx
+Link: https://github.com/acornjs/acorn-jsx
+-----------
+acorn
+License: MIT
+License File: node_modules/acorn/LICENSE
+Copyright: Copyright (C) 2012-2022 by various contributors (see AUTHORS)
+Source: https://github.com/acornjs/acorn.git
+Link: https://github.com/acornjs/acorn
+-----------
+ajv
+License: MIT
+License File: node_modules/ajv/LICENSE
+Copyright: Copyright (c) 2015-2017 Evgeny Poberezkin
+Source: https://github.com/ajv-validator/ajv.git
+Link: https://github.com/ajv-validator/ajv
+-----------
+ansi-regex
+License: MIT
+License File: node_modules/ansi-regex/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: chalk/ansi-regex
+Link: chalk/ansi-regex
+-----------
+ansi-styles
+License: MIT
+License File: node_modules/ansi-styles/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: chalk/ansi-styles
+Link: chalk/ansi-styles
+-----------
+anymatch
+License: ISC
+License File: node_modules/anymatch/LICENSE
+Copyright: Copyright (c) 2019 Elan Shanker, Paul Miller (https://paulmillr.com)
+Source: https://github.com/micromatch/anymatch
+Link: https://github.com/micromatch/anymatch
+-----------
+argparse
+License: Python-2.0
+License File: node_modules/argparse/LICENSE
+Source: nodeca/argparse
+Link: nodeca/argparse
+-----------
+array-buffer-byte-length
+License: MIT
+License File: node_modules/array-buffer-byte-length/LICENSE
+Copyright: Copyright (c) 2023 Inspect JS
+Source: git+https://github.com/inspect-js/array-buffer-byte-length.git
+Link: https://github.com/inspect-js/array-buffer-byte-length#readme
+-----------
+array-includes
+License: MIT
+License File: node_modules/array-includes/LICENSE
+Copyright: Copyright (C) 2015 Jordan Harband
+Source: git://github.com/es-shims/array-includes.git
+Link: git://github.com/es-shims/array-includes.git
+-----------
+array.prototype.filter
+License: MIT
+License File: node_modules/array.prototype.filter/LICENSE
+Copyright: Copyright (c) 2021 Jordan Harband
+Source: git+https://github.com/es-shims/Array.prototype.filter.git
+Link: https://github.com/es-shims/Array.prototype.filter#readme
+-----------
+array.prototype.findlastindex
+License: MIT
+License File: node_modules/array.prototype.findlastindex/LICENSE
+Copyright: Copyright (c) 2021 ECMAScript Shims
+Source: git+https://github.com/es-shims/Array.prototype.findLastIndex.git
+Link: https://github.com/es-shims/Array.prototype.findLastIndex#readme
+-----------
+array.prototype.flat
+License: MIT
+License File: node_modules/array.prototype.flat/LICENSE
+Copyright: Copyright (c) 2017 ECMAScript Shims
+Source: git://github.com/es-shims/Array.prototype.flat.git
+Link: git://github.com/es-shims/Array.prototype.flat.git
+-----------
+array.prototype.flatmap
+License: MIT
+License File: node_modules/array.prototype.flatmap/LICENSE
+Copyright: Copyright (c) 2017 ECMAScript Shims
+Source: git://github.com/es-shims/Array.prototype.flatMap.git
+Link: git://github.com/es-shims/Array.prototype.flatMap.git
+-----------
+arraybuffer.prototype.slice
+License: MIT
+License File: node_modules/arraybuffer.prototype.slice/LICENSE
+Copyright: Copyright (c) 2023 ECMAScript Shims
+Source: git+https://github.com/es-shims/ArrayBuffer.prototype.slice.git
+Link: https://github.com/es-shims/ArrayBuffer.prototype.slice#readme
+-----------
+available-typed-arrays
+License: MIT
+License File: node_modules/available-typed-arrays/LICENSE
+Copyright: Copyright (c) 2020 Inspect JS
+Source: git+https://github.com/inspect-js/available-typed-arrays.git
+Link: https://github.com/inspect-js/available-typed-arrays#readme
+-----------
+balanced-match
+License: MIT
+License File: node_modules/balanced-match/LICENSE.md
+Copyright: Copyright (c) 2013 Julian Gruber &lt;******@************.***&gt;
+Source: git://github.com/juliangruber/balanced-match.git
+Link: https://github.com/juliangruber/balanced-match
+-----------
+binary-extensions
+License: MIT
+License File: node_modules/binary-extensions/license
+Copyright: Copyright (c) 2019 Sindre Sorhus <************@*****.***> (https://sindresorhus.com), Paul Miller (https://paulmillr.com)
+Source: sindresorhus/binary-extensions
+Link: sindresorhus/binary-extensions
+-----------
+brace-expansion
+License: MIT
+License File: node_modules/brace-expansion/LICENSE
+Copyright: Copyright (c) 2013 Julian Gruber <******@************.***>
+Source: git://github.com/juliangruber/brace-expansion.git
+Link: https://github.com/juliangruber/brace-expansion
+-----------
+braces
+License: MIT
+License File: node_modules/braces/LICENSE
+Copyright: Copyright (c) 2014-2018, Jon Schlinkert.
+Source: micromatch/braces
+Link: https://github.com/micromatch/braces
+-----------
+call-bind
+License: MIT
+License File: node_modules/call-bind/LICENSE
+Copyright: Copyright (c) 2020 Jordan Harband
+Source: git+https://github.com/ljharb/call-bind.git
+Link: https://github.com/ljharb/call-bind#readme
+-----------
+callsites
+License: MIT
+License File: node_modules/callsites/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/callsites
+Link: sindresorhus/callsites
+-----------
+camelcase
+License: MIT
+License File: node_modules/camelcase/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/camelcase
+Link: sindresorhus/camelcase
+-----------
+chalk
+License: MIT
+License File: node_modules/chalk/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: chalk/chalk
+Link: chalk/chalk
+-----------
+chokidar-cli
+License: MIT
+License File: node_modules/chokidar-cli/LICENSE
+Copyright: Copyright (c) 2015 Kimmo Brunfeldt
+Source: https://github.com/open-npm-tools/chokidar-cli.git
+Link: https://github.com/open-npm-tools/chokidar-cli
+-----------
+chokidar
+License: MIT
+License File: node_modules/chokidar/LICENSE
+Copyright: Copyright (c) 2012-2019 Paul Miller (https://paulmillr.com), Elan Shanker
+Source: git+https://github.com/paulmillr/chokidar.git
+Link: https://github.com/paulmillr/chokidar
+-----------
+cliui
+License: ISC
+License File: node_modules/cliui/LICENSE.txt
+Copyright: Copyright (c) 2015, Contributors
+Source: http://github.com/yargs/cliui.git
+Link: http://github.com/yargs/cliui.git
+-----------
+codemirror
+License: MIT
+License File: node_modules/codemirror/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <*******@*****.***> and others
+Source: https://github.com/codemirror/basic-setup.git
+Link: https://github.com/codemirror/basic-setup.git
+-----------
+color-convert
+License: MIT
+License File: node_modules/color-convert/LICENSE
+Copyright: Copyright (c) 2011-2016 Heather Arthur <**********@*****.***>
+Source: Qix-/color-convert
+Link: Qix-/color-convert
+-----------
+color-name
+License: MIT
+License File: node_modules/color-name/LICENSE
+Source: git@github.com:colorjs/color-name.git
+Link: https://github.com/colorjs/color-name
+-----------
+concat-map
+License: MIT
+License File: node_modules/concat-map/LICENSE
+Source: git://github.com/substack/node-concat-map.git
+Link: git://github.com/substack/node-concat-map.git
+-----------
+confusing-browser-globals
+License: MIT
+License File: node_modules/confusing-browser-globals/LICENSE
+Copyright: Copyright (c) 2013-present, Facebook, Inc.
+Source: https://github.com/facebook/create-react-app.git
+Link: https://github.com/facebook/create-react-app.git
+-----------
+crelt
+License: MIT
+License File: node_modules/crelt/LICENSE
+Copyright: Copyright (C) 2020 by Marijn Haverbeke <******@*********.******>
+Source: git+https://github.com/marijnh/crelt.git
+Link: https://github.com/marijnh/crelt#readme
+-----------
+cross-spawn
+License: MIT
+License File: node_modules/cross-spawn/LICENSE
+Copyright: Copyright (c) 2018 Made With MOXY Lda <*****@****.******>
+Source: git@github.com:moxystudio/node-cross-spawn.git
+Link: https://github.com/moxystudio/node-cross-spawn
+-----------
+debug
+License: MIT
+License File: node_modules/debug/LICENSE
+Copyright: Copyright (c) 2014-2017 TJ Holowaychuk <**@************.**>
+Copyright (c) 2018-2021 Josh Junon
+Source: git://github.com/debug-js/debug.git
+Link: git://github.com/debug-js/debug.git
+-----------
+decamelize
+License: MIT
+License File: node_modules/decamelize/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/decamelize
+Link: sindresorhus/decamelize
+-----------
+deep-is
+License: MIT
+License File: node_modules/deep-is/LICENSE
+Copyright: Copyright (c) 2012, 2013 Thorsten Lorenz <********@***.**>
+Copyright (c) 2012 James Halliday <****@********.***>
+Copyright (c) 2009 Thomas Robinson <280north.com>
+Source: http://github.com/thlorenz/deep-is.git
+Link: http://github.com/thlorenz/deep-is.git
+-----------
+define-data-property
+License: MIT
+License File: node_modules/define-data-property/LICENSE
+Copyright: Copyright (c) 2023 Jordan Harband
+Source: git+https://github.com/ljharb/define-data-property.git
+Link: https://github.com/ljharb/define-data-property#readme
+-----------
+define-properties
+License: MIT
+License File: node_modules/define-properties/LICENSE
+Copyright: Copyright (C) 2015 Jordan Harband
+Source: git://github.com/ljharb/define-properties.git
+Link: git://github.com/ljharb/define-properties.git
+-----------
+doctrine
+License: Apache-2.0
+License File: node_modules/doctrine/LICENSE
+Source: eslint/doctrine
+Link: https://github.com/eslint/doctrine
+-----------
+emoji-regex
+License: MIT
+License File: node_modules/emoji-regex/LICENSE-MIT.txt
+Source: https://github.com/mathiasbynens/emoji-regex.git
+Link: https://mths.be/emoji-regex
+-----------
+entities
+License: BSD-2-Clause
+License File: node_modules/entities/LICENSE
+Copyright: Copyright (c) Felix Böhm
+All rights reserved.
+Source: git://github.com/fb55/entities.git
+Link: git://github.com/fb55/entities.git
+-----------
+error-ex
+License: MIT
+License File: node_modules/error-ex/LICENSE
+Copyright: Copyright (c) 2015 JD Ballard
+Source: qix-/node-error-ex
+Link: qix-/node-error-ex
+-----------
+es-abstract
+License: MIT
+License File: node_modules/es-abstract/LICENSE
+Copyright: Copyright (C) 2015 Jordan Harband
+Source: git://github.com/ljharb/es-abstract.git
+Link: git://github.com/ljharb/es-abstract.git
+-----------
+es-array-method-boxes-properly
+License: MIT
+License File: node_modules/es-array-method-boxes-properly/LICENSE
+Copyright: Copyright (c) 2019 Jordan Harband
+Source: git+https://github.com/ljharb/es-array-method-boxes-properly.git
+Link: https://github.com/ljharb/es-array-method-boxes-properly#readme
+-----------
+es-define-property
+License: MIT
+License File: node_modules/es-define-property/LICENSE
+Copyright: Copyright (c) 2024 Jordan Harband
+Source: git+https://github.com/ljharb/es-define-property.git
+Link: https://github.com/ljharb/es-define-property#readme
+-----------
+es-errors
+License: MIT
+License File: node_modules/es-errors/LICENSE
+Copyright: Copyright (c) 2024 Jordan Harband
+Source: git+https://github.com/ljharb/es-errors.git
+Link: https://github.com/ljharb/es-errors#readme
+-----------
+es-set-tostringtag
+License: MIT
+License File: node_modules/es-set-tostringtag/LICENSE
+Copyright: Copyright (c) 2022 ECMAScript Shims
+Source: git+https://github.com/es-shims/es-set-tostringtag.git
+Link: https://github.com/es-shims/es-set-tostringtag#readme
+-----------
+es-shim-unscopables
+License: MIT
+License File: node_modules/es-shim-unscopables/LICENSE
+Copyright: Copyright (c) 2022 Jordan Harband
+Source: git+https://github.com/ljharb/es-shim-unscopables.git
+Link: https://github.com/ljharb/es-shim-unscopables#readme
+-----------
+es-to-primitive
+License: MIT
+License File: node_modules/es-to-primitive/LICENSE
+Copyright: Copyright (c) 2015 Jordan Harband
+Source: git://github.com/ljharb/es-to-primitive.git
+Link: git://github.com/ljharb/es-to-primitive.git
+-----------
+esbuild
+License: MIT
+License File: node_modules/esbuild/LICENSE.md
+Copyright: Copyright (c) 2020 Evan Wallace
+Source: git+https://github.com/evanw/esbuild.git
+Link: git+https://github.com/evanw/esbuild.git
+-----------
+escape-string-regexp
+License: MIT
+License File: node_modules/escape-string-regexp/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (https://sindresorhus.com)
+Source: sindresorhus/escape-string-regexp
+Link: sindresorhus/escape-string-regexp
+-----------
+eslint-config-airbnb-base
+License: MIT
+License File: node_modules/eslint-config-airbnb-base/LICENSE.md
+Copyright: Copyright (c) 2012 Airbnb
+Source: https://github.com/airbnb/javascript
+Link: https://github.com/airbnb/javascript
+-----------
+eslint-import-resolver-node
+License: MIT
+License File: node_modules/eslint-import-resolver-node/LICENSE
+Copyright: Copyright (c) 2015 Ben Mosher
+Source: https://github.com/import-js/eslint-plugin-import
+Link: https://github.com/import-js/eslint-plugin-import
+-----------
+eslint-module-utils
+License: MIT
+License File: node_modules/eslint-module-utils/LICENSE
+Copyright: Copyright (c) 2015 Ben Mosher
+Source: git+https://github.com/import-js/eslint-plugin-import.git
+Link: https://github.com/import-js/eslint-plugin-import#readme
+-----------
+eslint-plugin-import
+License: MIT
+License File: node_modules/eslint-plugin-import/LICENSE
+Copyright: Copyright (c) 2015 Ben Mosher
+Source: https://github.com/import-js/eslint-plugin-import
+Link: https://github.com/import-js/eslint-plugin-import
+-----------
+eslint-scope
+License: BSD-2-Clause
+License File: node_modules/eslint-scope/LICENSE
+Copyright: Copyright (C) 2012-2013 Yusuke Suzuki (twitter: @Constellation) and other contributors.
+Source: eslint/eslint-scope
+Link: http://github.com/eslint/eslint-scope
+-----------
+eslint-visitor-keys
+License: Apache-2.0
+License File: node_modules/eslint-visitor-keys/LICENSE
+Source: eslint/eslint-visitor-keys
+Link: https://github.com/eslint/eslint-visitor-keys#readme
+-----------
+eslint
+License: MIT
+License File: node_modules/eslint/LICENSE
+Source: eslint/eslint
+Link: https://eslint.org
+-----------
+espree
+License: BSD-2-Clause
+License File: node_modules/espree/LICENSE
+Copyright: Copyright (c) Open JS Foundation
+All rights reserved.
+Source: eslint/espree
+Link: https://github.com/eslint/espree
+-----------
+esquery
+License: BSD-3-Clause
+License File: node_modules/esquery/license.txt
+Copyright: Copyright (c) 2013, Joel Feenstra
+All rights reserved.
+Source: https://github.com/estools/esquery.git
+Link: https://github.com/estools/esquery/
+-----------
+esrecurse
+License: BSD-2-Clause
+Source: https://github.com/estools/esrecurse.git
+Link: https://github.com/estools/esrecurse
+-----------
+estraverse
+License: BSD-2-Clause
+License File: node_modules/estraverse/LICENSE.BSD
+Source: http://github.com/estools/estraverse.git
+Link: https://github.com/estools/estraverse
+-----------
+esutils
+License: BSD-2-Clause
+License File: node_modules/esutils/LICENSE.BSD
+Source: http://github.com/estools/esutils.git
+Link: https://github.com/estools/esutils
+-----------
+fast-deep-equal
+License: MIT
+License File: node_modules/fast-deep-equal/LICENSE
+Copyright: Copyright (c) 2017 Evgeny Poberezkin
+Source: git+https://github.com/epoberezkin/fast-deep-equal.git
+Link: https://github.com/epoberezkin/fast-deep-equal#readme
+-----------
+fast-json-stable-stringify
+License: MIT
+License File: node_modules/fast-json-stable-stringify/LICENSE
+Copyright: Copyright (c) 2017 Evgeny Poberezkin
+Copyright (c) 2013 James Halliday
+Source: git://github.com/epoberezkin/fast-json-stable-stringify.git
+Link: https://github.com/epoberezkin/fast-json-stable-stringify
+-----------
+fast-levenshtein
+License: MIT
+License File: node_modules/fast-levenshtein/LICENSE.md
+Copyright: Copyright (c) 2013 [Ramesh Nair](http://www.hiddentao.com/)
+Source: https://github.com/hiddentao/fast-levenshtein.git
+Link: https://github.com/hiddentao/fast-levenshtein.git
+-----------
+fastq
+License: ISC
+License File: node_modules/fastq/LICENSE
+Copyright: Copyright (c) 2015-2020, Matteo Collina <******.*******@*****.***>
+Source: git+https://github.com/mcollina/fastq.git
+Link: https://github.com/mcollina/fastq#readme
+-----------
+file-entry-cache
+License: MIT
+License File: node_modules/file-entry-cache/LICENSE
+Copyright: Copyright (c) 2015 Roy Riojas
+Source: royriojas/file-entry-cache
+Link: royriojas/file-entry-cache
+-----------
+fill-range
+License: MIT
+License File: node_modules/fill-range/LICENSE
+Copyright: Copyright (c) 2014-present, Jon Schlinkert.
+Source: jonschlinkert/fill-range
+Link: https://github.com/jonschlinkert/fill-range
+-----------
+find-up
+License: MIT
+License File: node_modules/find-up/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (https://sindresorhus.com)
+Source: sindresorhus/find-up
+Link: sindresorhus/find-up
+-----------
+flat-cache
+License: MIT
+License File: node_modules/flat-cache/LICENSE
+Copyright: Copyright (c) Roy Riojas and Jared Wray
+Source: jaredwray/flat-cache
+Link: jaredwray/flat-cache
+-----------
+flatted
+License: ISC
+License File: node_modules/flatted/LICENSE
+Copyright: Copyright (c) 2018-2020, Andrea Giammarchi, @WebReflection
+Source: git+https://github.com/WebReflection/flatted.git
+Link: https://github.com/WebReflection/flatted#readme
+-----------
+for-each
+License: MIT
+License File: node_modules/for-each/LICENSE
+Copyright: Copyright (c) 2012 Raynos.
+Source: git://github.com/Raynos/for-each.git
+Link: https://github.com/Raynos/for-each
+-----------
+fs.realpath
+License: ISC
+License File: node_modules/fs.realpath/LICENSE
+Copyright: Copyright (c) Isaac Z. Schlueter and Contributors
+Source: git+https://github.com/isaacs/fs.realpath.git
+Link: git+https://github.com/isaacs/fs.realpath.git
+-----------
+function-bind
+License: MIT
+License File: node_modules/function-bind/LICENSE
+Copyright: Copyright (c) 2013 Raynos.
+Source: https://github.com/Raynos/function-bind.git
+Link: https://github.com/Raynos/function-bind
+-----------
+function.prototype.name
+License: MIT
+License File: node_modules/function.prototype.name/LICENSE
+Copyright: Copyright (c) 2016 Jordan Harband
+Source: git://github.com/es-shims/Function.prototype.name.git
+Link: git://github.com/es-shims/Function.prototype.name.git
+-----------
+functions-have-names
+License: MIT
+License File: node_modules/functions-have-names/LICENSE
+Copyright: Copyright (c) 2019 Jordan Harband
+Source: git+https://github.com/inspect-js/functions-have-names.git
+Link: https://github.com/inspect-js/functions-have-names#readme
+-----------
+get-caller-file
+License: ISC
+License File: node_modules/get-caller-file/LICENSE.md
+Copyright: Copyright 2018 Stefan Penner
+Source: git+https://github.com/stefanpenner/get-caller-file.git
+Link: https://github.com/stefanpenner/get-caller-file#readme
+-----------
+get-intrinsic
+License: MIT
+License File: node_modules/get-intrinsic/LICENSE
+Copyright: Copyright (c) 2020 Jordan Harband
+Source: git+https://github.com/ljharb/get-intrinsic.git
+Link: https://github.com/ljharb/get-intrinsic#readme
+-----------
+get-symbol-description
+License: MIT
+License File: node_modules/get-symbol-description/LICENSE
+Copyright: Copyright (c) 2021 Inspect JS
+Source: git+https://github.com/inspect-js/get-symbol-description.git
+Link: https://github.com/inspect-js/get-symbol-description#readme
+-----------
+glob-parent
+License: ISC
+License File: node_modules/glob-parent/LICENSE
+Copyright: Copyright (c) 2015, 2019 Elan Shanker
+Source: gulpjs/glob-parent
+Link: gulpjs/glob-parent
+-----------
+glob
+License: ISC
+License File: node_modules/glob/LICENSE
+Copyright: Copyright (c) Isaac Z. Schlueter and Contributors
+Source: git://github.com/isaacs/node-glob.git
+Link: git://github.com/isaacs/node-glob.git
+-----------
+globals
+License: MIT
+License File: node_modules/globals/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (https://sindresorhus.com)
+Source: sindresorhus/globals
+Link: sindresorhus/globals
+-----------
+globalthis
+License: MIT
+License File: node_modules/globalthis/LICENSE
+Copyright: Copyright (c) 2016 Jordan Harband
+Source: git://github.com/ljharb/System.global.git
+Link: git://github.com/ljharb/System.global.git
+-----------
+gopd
+License: MIT
+License File: node_modules/gopd/LICENSE
+Copyright: Copyright (c) 2022 Jordan Harband
+Source: git+https://github.com/ljharb/gopd.git
+Link: https://github.com/ljharb/gopd#readme
+-----------
+graceful-fs
+License: ISC
+License File: node_modules/graceful-fs/LICENSE
+Copyright: Copyright (c) 2011-2022 Isaac Z. Schlueter, Ben Noordhuis, and Contributors
+Source: https://github.com/isaacs/node-graceful-fs
+Link: https://github.com/isaacs/node-graceful-fs
+-----------
+graphemer
+License: MIT
+License File: node_modules/graphemer/LICENSE
+Copyright: Copyright 2020 Filament (Anomalous Technologies Limited)
+Source: https://github.com/flmnt/graphemer.git
+Link: https://github.com/flmnt/graphemer
+-----------
+has-bigints
+License: MIT
+License File: node_modules/has-bigints/LICENSE
+Copyright: Copyright (c) 2019 Jordan Harband
+Source: git+https://github.com/ljharb/has-bigints.git
+Link: https://github.com/ljharb/has-bigints#readme
+-----------
+has-flag
+License: MIT
+License File: node_modules/has-flag/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/has-flag
+Link: sindresorhus/has-flag
+-----------
+has-property-descriptors
+License: MIT
+License File: node_modules/has-property-descriptors/LICENSE
+Copyright: Copyright (c) 2022 Inspect JS
+Source: git+https://github.com/inspect-js/has-property-descriptors.git
+Link: https://github.com/inspect-js/has-property-descriptors#readme
+-----------
+has-proto
+License: MIT
+License File: node_modules/has-proto/LICENSE
+Copyright: Copyright (c) 2022 Inspect JS
+Source: git+https://github.com/inspect-js/has-proto.git
+Link: https://github.com/inspect-js/has-proto#readme
+-----------
+has-symbols
+License: MIT
+License File: node_modules/has-symbols/LICENSE
+Copyright: Copyright (c) 2016 Jordan Harband
+Source: git://github.com/inspect-js/has-symbols.git
+Link: https://github.com/ljharb/has-symbols#readme
+-----------
+has-tostringtag
+License: MIT
+License File: node_modules/has-tostringtag/LICENSE
+Copyright: Copyright (c) 2021 Inspect JS
+Source: git+https://github.com/inspect-js/has-tostringtag.git
+Link: https://github.com/inspect-js/has-tostringtag#readme
+-----------
+hasown
+License: MIT
+License File: node_modules/hasown/LICENSE
+Copyright: Copyright (c) Jordan Harband and contributors
+Source: git+https://github.com/inspect-js/hasOwn.git
+Link: https://github.com/inspect-js/hasOwn#readme
+-----------
+hosted-git-info
+License: ISC
+License File: node_modules/hosted-git-info/LICENSE
+Copyright: Copyright (c) 2015, Rebecca Turner
+Source: git+https://github.com/npm/hosted-git-info.git
+Link: https://github.com/npm/hosted-git-info
+-----------
+idb-keyval
+License: Apache-2.0
+Source: git+https://github.com/jakearchibald/idb-keyval.git
+Link: https://github.com/jakearchibald/idb-keyval#readme
+-----------
+ignore
+License: MIT
+Source: git@github.com:kaelzhang/node-ignore.git
+Link: git@github.com:kaelzhang/node-ignore.git
+-----------
+immutable
+License: MIT
+License File: node_modules/immutable/LICENSE
+Copyright: Copyright (c) 2014-present, Lee Byron and other contributors.
+Source: git://github.com/immutable-js/immutable-js.git
+Link: https://immutable-js.com
+-----------
+import-fresh
+License: MIT
+License File: node_modules/import-fresh/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (https://sindresorhus.com)
+Source: sindresorhus/import-fresh
+Link: sindresorhus/import-fresh
+-----------
+imurmurhash
+License: MIT
+Source: https://github.com/jensyt/imurmurhash-js
+Link: https://github.com/jensyt/imurmurhash-js
+-----------
+inflight
+License: ISC
+License File: node_modules/inflight/LICENSE
+Copyright: Copyright (c) Isaac Z. Schlueter
+Source: https://github.com/npm/inflight.git
+Link: https://github.com/isaacs/inflight
+-----------
+inherits
+License: ISC
+License File: node_modules/inherits/LICENSE
+Copyright: Copyright (c) Isaac Z. Schlueter
+Source: git://github.com/isaacs/inherits
+Link: git://github.com/isaacs/inherits
+-----------
+internal-slot
+License: MIT
+License File: node_modules/internal-slot/LICENSE
+Copyright: Copyright (c) 2019 Jordan Harband
+Source: git+https://github.com/ljharb/internal-slot.git
+Link: https://github.com/ljharb/internal-slot#readme
+-----------
+is-array-buffer
+License: MIT
+License File: node_modules/is-array-buffer/LICENSE
+Copyright: Copyright (c) 2015 Chen Gengyuan, Inspect JS
+Source: git+https://github.com/inspect-js/is-array-buffer.git
+Link: https://github.com/inspect-js/is-array-buffer#readme
+-----------
+is-arrayish
+License: MIT
+License File: node_modules/is-arrayish/LICENSE
+Copyright: Copyright (c) 2015 JD Ballard
+Source: https://github.com/qix-/node-is-arrayish.git
+Link: https://github.com/qix-/node-is-arrayish.git
+-----------
+is-bigint
+License: MIT
+License File: node_modules/is-bigint/LICENSE
+Copyright: Copyright (c) 2018 Jordan Harband
+Source: git+https://github.com/inspect-js/is-bigint.git
+Link: https://github.com/inspect-js/is-bigint#readme
+-----------
+is-binary-path
+License: MIT
+License File: node_modules/is-binary-path/license
+Copyright: Copyright (c) 2019 Sindre Sorhus <************@*****.***> (https://sindresorhus.com), Paul Miller (https://paulmillr.com)
+Source: sindresorhus/is-binary-path
+Link: sindresorhus/is-binary-path
+-----------
+is-boolean-object
+License: MIT
+License File: node_modules/is-boolean-object/LICENSE
+Copyright: Copyright (c) 2015 Jordan Harband
+Source: git://github.com/inspect-js/is-boolean-object.git
+Link: git://github.com/inspect-js/is-boolean-object.git
+-----------
+is-callable
+License: MIT
+License File: node_modules/is-callable/LICENSE
+Copyright: Copyright (c) 2015 Jordan Harband
+Source: git://github.com/inspect-js/is-callable.git
+Link: git://github.com/inspect-js/is-callable.git
+-----------
+is-core-module
+License: MIT
+License File: node_modules/is-core-module/LICENSE
+Copyright: Copyright (c) 2014 Dave Justice
+Source: git+https://github.com/inspect-js/is-core-module.git
+Link: https://github.com/inspect-js/is-core-module
+-----------
+is-date-object
+License: MIT
+License File: node_modules/is-date-object/LICENSE
+Copyright: Copyright (c) 2015 Jordan Harband
+Source: git://github.com/inspect-js/is-date-object.git
+Link: git://github.com/inspect-js/is-date-object.git
+-----------
+is-extglob
+License: MIT
+License File: node_modules/is-extglob/LICENSE
+Copyright: Copyright (c) 2014-2016, Jon Schlinkert
+Source: jonschlinkert/is-extglob
+Link: https://github.com/jonschlinkert/is-extglob
+-----------
+is-fullwidth-code-point
+License: MIT
+License File: node_modules/is-fullwidth-code-point/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/is-fullwidth-code-point
+Link: sindresorhus/is-fullwidth-code-point
+-----------
+is-glob
+License: MIT
+License File: node_modules/is-glob/LICENSE
+Copyright: Copyright (c) 2014-2017, Jon Schlinkert.
+Source: micromatch/is-glob
+Link: https://github.com/micromatch/is-glob
+-----------
+is-negative-zero
+License: MIT
+License File: node_modules/is-negative-zero/LICENSE
+Copyright: Copyright (c) 2014 Jordan Harband
+Source: git://github.com/inspect-js/is-negative-zero.git
+Link: https://github.com/inspect-js/is-negative-zero
+-----------
+is-number-object
+License: MIT
+License File: node_modules/is-number-object/LICENSE
+Copyright: Copyright (c) 2015 Jordan Harband
+Source: git://github.com/inspect-js/is-number-object.git
+Link: https://github.com/inspect-js/is-number-object#readme
+-----------
+is-number
+License: MIT
+License File: node_modules/is-number/LICENSE
+Copyright: Copyright (c) 2014-present, Jon Schlinkert.
+Source: jonschlinkert/is-number
+Link: https://github.com/jonschlinkert/is-number
+-----------
+is-path-inside
+License: MIT
+License File: node_modules/is-path-inside/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/is-path-inside
+Link: sindresorhus/is-path-inside
+-----------
+is-regex
+License: MIT
+License File: node_modules/is-regex/LICENSE
+Copyright: Copyright (c) 2014 Jordan Harband
+Source: git://github.com/inspect-js/is-regex.git
+Link: https://github.com/inspect-js/is-regex
+-----------
+is-shared-array-buffer
+License: MIT
+License File: node_modules/is-shared-array-buffer/LICENSE
+Copyright: Copyright (c) 2021 Inspect JS
+Source: git+https://github.com/inspect-js/is-shared-array-buffer.git
+Link: https://github.com/inspect-js/is-shared-array-buffer#readme
+-----------
+is-string
+License: MIT
+License File: node_modules/is-string/LICENSE
+Copyright: Copyright (c) 2015 Jordan Harband
+Source: git://github.com/ljharb/is-string.git
+Link: git://github.com/ljharb/is-string.git
+-----------
+is-symbol
+License: MIT
+License File: node_modules/is-symbol/LICENSE
+Copyright: Copyright (c) 2015 Jordan Harband
+Source: git://github.com/inspect-js/is-symbol.git
+Link: git://github.com/inspect-js/is-symbol.git
+-----------
+is-typed-array
+License: MIT
+License File: node_modules/is-typed-array/LICENSE
+Copyright: Copyright (c) 2015 Jordan Harband
+Source: git://github.com/inspect-js/is-typed-array.git
+Link: git://github.com/inspect-js/is-typed-array.git
+-----------
+is-weakref
+License: MIT
+License File: node_modules/is-weakref/LICENSE
+Copyright: Copyright (c) 2020 Inspect JS
+Source: git+https://github.com/inspect-js/is-weakref.git
+Link: https://github.com/inspect-js/is-weakref#readme
+-----------
+isarray
+License: MIT
+License File: node_modules/isarray/LICENSE
+Copyright: Copyright (c) 2013 Julian Gruber <******@************.***>
+Source: git://github.com/juliangruber/isarray.git
+Link: https://github.com/juliangruber/isarray
+-----------
+isexe
+License: ISC
+License File: node_modules/isexe/LICENSE
+Copyright: Copyright (c) Isaac Z. Schlueter and Contributors
+Source: git+https://github.com/isaacs/isexe.git
+Link: https://github.com/isaacs/isexe#readme
+-----------
+js-yaml
+License: MIT
+License File: node_modules/js-yaml/LICENSE
+Copyright: Copyright (C) 2011-2015 by Vitaly Puzrin
+Source: nodeca/js-yaml
+Link: nodeca/js-yaml
+-----------
+json-buffer
+License: MIT
+License File: node_modules/json-buffer/LICENSE
+Copyright: Copyright (c) 2013 Dominic Tarr
+Source: git://github.com/dominictarr/json-buffer.git
+Link: https://github.com/dominictarr/json-buffer
+-----------
+json-parse-better-errors
+License: MIT
+License File: node_modules/json-parse-better-errors/LICENSE.md
+Copyright: Copyright 2017 Kat Marchán
+Source: https://github.com/zkat/json-parse-better-errors
+Link: https://github.com/zkat/json-parse-better-errors
+-----------
+json-schema-traverse
+License: MIT
+License File: node_modules/json-schema-traverse/LICENSE
+Copyright: Copyright (c) 2017 Evgeny Poberezkin
+Source: git+https://github.com/epoberezkin/json-schema-traverse.git
+Link: https://github.com/epoberezkin/json-schema-traverse#readme
+-----------
+json-stable-stringify-without-jsonify
+License: MIT
+License File: node_modules/json-stable-stringify-without-jsonify/LICENSE
+Source: git://github.com/samn/json-stable-stringify.git
+Link: https://github.com/samn/json-stable-stringify
+-----------
+json5
+License: MIT
+License File: node_modules/json5/LICENSE.md
+Copyright: Copyright (c) 2012-2018 Aseem Kishore, and [others].
+Source: git+https://github.com/json5/json5.git
+Link: http://json5.org/
+-----------
+keyv
+License: MIT
+Source: git+https://github.com/jaredwray/keyv.git
+Link: https://github.com/jaredwray/keyv
+-----------
+levn
+License: MIT
+License File: node_modules/levn/LICENSE
+Copyright: Copyright (c) George Zahariev
+Source: git://github.com/gkz/levn.git
+Link: https://github.com/gkz/levn
+-----------
+linkify-it
+License: MIT
+License File: node_modules/linkify-it/LICENSE
+Copyright: Copyright (c) 2015 Vitaly Puzrin.
+Source: markdown-it/linkify-it
+Link: markdown-it/linkify-it
+-----------
+livereload-js
+License: MIT
+License File: node_modules/livereload-js/LICENSE
+Copyright: Copyright (c) 2010-2012 Andrey Tarantsov
+Source: git://github.com/livereload/livereload-js.git
+Link: https://github.com/livereload/livereload-js
+-----------
+livereload
+License: MIT
+License File: node_modules/livereload/LICENSE
+Copyright: Copyright (c) 2010 Joshua Peek
+Source: http://github.com/napcs/node-livereload.git
+Link: http://github.com/napcs/node-livereload.git
+-----------
+load-json-file
+License: MIT
+License File: node_modules/load-json-file/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/load-json-file
+Link: sindresorhus/load-json-file
+-----------
+locate-path
+License: MIT
+License File: node_modules/locate-path/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (https://sindresorhus.com)
+Source: sindresorhus/locate-path
+Link: sindresorhus/locate-path
+-----------
+lodash.debounce
+License: MIT
+License File: node_modules/lodash.debounce/LICENSE
+Source: lodash/lodash
+Link: https://lodash.com/
+-----------
+lodash.merge
+License: MIT
+License File: node_modules/lodash.merge/LICENSE
+Source: lodash/lodash
+Link: https://lodash.com/
+-----------
+lodash.throttle
+License: MIT
+License File: node_modules/lodash.throttle/LICENSE
+Source: lodash/lodash
+Link: https://lodash.com/
+-----------
+markdown-it-task-lists
+License: ISC
+License File: node_modules/markdown-it-task-lists/LICENSE
+Copyright: Copyright (c) 2016, Revin Guillen
+Source: git@github.com:revin/markdown-it-task-lists.git
+Link: https://github.com/revin/markdown-it-task-lists#readme
+-----------
+markdown-it
+License: MIT
+License File: node_modules/markdown-it/LICENSE
+Copyright: Copyright (c) 2014 Vitaly Puzrin, Alex Kocharin.
+Source: markdown-it/markdown-it
+Link: markdown-it/markdown-it
+-----------
+mdurl
+License: MIT
+License File: node_modules/mdurl/LICENSE
+Copyright: Copyright (c) 2015 Vitaly Puzrin, Alex Kocharin.
+Source: markdown-it/mdurl
+Link: markdown-it/mdurl
+-----------
+memorystream
+License File: node_modules/memorystream/LICENSE
+Copyright: Copyright (C) 2011 Dmitry Nizovtsev
+Source: https://github.com/JSBizon/node-memorystream.git
+Link: https://github.com/JSBizon/node-memorystream
+-----------
+minimatch
+License: ISC
+License File: node_modules/minimatch/LICENSE
+Copyright: Copyright (c) Isaac Z. Schlueter and Contributors
+Source: git://github.com/isaacs/minimatch.git
+Link: git://github.com/isaacs/minimatch.git
+-----------
+minimist
+License: MIT
+License File: node_modules/minimist/LICENSE
+Source: git://github.com/minimistjs/minimist.git
+Link: https://github.com/minimistjs/minimist
+-----------
+ms
+License: MIT
+License File: node_modules/ms/license.md
+Copyright: Copyright (c) 2016 Zeit, Inc.
+Source: zeit/ms
+Link: zeit/ms
+-----------
+natural-compare
+License: MIT
+Source: git://github.com/litejs/natural-compare-lite.git
+Link: git://github.com/litejs/natural-compare-lite.git
+-----------
+nice-try
+License: MIT
+License File: node_modules/nice-try/LICENSE
+Copyright: Copyright (c) 2018 Tobias Reich
+Source: https://github.com/electerious/nice-try.git
+Link: https://github.com/electerious/nice-try
+-----------
+normalize-package-data
+License: BSD-2-Clause
+License File: node_modules/normalize-package-data/LICENSE
+Copyright: Copyright (c) Meryn Stol ("Author")
+All rights reserved.
+Source: git://github.com/npm/normalize-package-data.git
+Link: git://github.com/npm/normalize-package-data.git
+-----------
+normalize-path
+License: MIT
+License File: node_modules/normalize-path/LICENSE
+Copyright: Copyright (c) 2014-2018, Jon Schlinkert.
+Source: jonschlinkert/normalize-path
+Link: https://github.com/jonschlinkert/normalize-path
+-----------
+npm-run-all
+License: MIT
+License File: node_modules/npm-run-all/LICENSE
+Copyright: Copyright (c) 2015 Toru Nagashima
+Source: mysticatea/npm-run-all
+Link: https://github.com/mysticatea/npm-run-all
+-----------
+object-inspect
+License: MIT
+License File: node_modules/object-inspect/LICENSE
+Copyright: Copyright (c) 2013 James Halliday
+Source: git://github.com/inspect-js/object-inspect.git
+Link: https://github.com/inspect-js/object-inspect
+-----------
+object-keys
+License: MIT
+License File: node_modules/object-keys/LICENSE
+Copyright: Copyright (C) 2013 Jordan Harband
+Source: git://github.com/ljharb/object-keys.git
+Link: git://github.com/ljharb/object-keys.git
+-----------
+object.assign
+License: MIT
+License File: node_modules/object.assign/LICENSE
+Copyright: Copyright (c) 2014 Jordan Harband
+Source: git://github.com/ljharb/object.assign.git
+Link: git://github.com/ljharb/object.assign.git
+-----------
+object.entries
+License: MIT
+License File: node_modules/object.entries/LICENSE
+Copyright: Copyright (c) 2015 Jordan Harband
+Source: git://github.com/es-shims/Object.entries.git
+Link: git://github.com/es-shims/Object.entries.git
+-----------
+object.fromentries
+License: MIT
+License File: node_modules/object.fromentries/LICENSE
+Copyright: Copyright (c) 2018 Jordan Harband
+Source: git://github.com/es-shims/Object.fromEntries.git
+Link: git://github.com/es-shims/Object.fromEntries.git
+-----------
+object.groupby
+License: MIT
+License File: node_modules/object.groupby/LICENSE
+Copyright: Copyright (c) 2023 ECMAScript Shims
+Source: git+https://github.com/es-shims/Object.groupBy.git
+Link: https://github.com/es-shims/Object.groupBy#readme
+-----------
+object.values
+License: MIT
+License File: node_modules/object.values/LICENSE
+Copyright: Copyright (c) 2015 Jordan Harband
+Source: git://github.com/es-shims/Object.values.git
+Link: git://github.com/es-shims/Object.values.git
+-----------
+once
+License: ISC
+License File: node_modules/once/LICENSE
+Copyright: Copyright (c) Isaac Z. Schlueter and Contributors
+Source: git://github.com/isaacs/once
+Link: git://github.com/isaacs/once
+-----------
+optionator
+License: MIT
+License File: node_modules/optionator/LICENSE
+Copyright: Copyright (c) George Zahariev
+Source: git://github.com/gkz/optionator.git
+Link: https://github.com/gkz/optionator
+-----------
+opts
+License: BSD-2-Clause
+License File: node_modules/opts/LICENSE.txt
+Copyright: Copyright (c) 2010, Joey Mazzarelli
+All rights reserved.
+Source: github:khtdr/opts
+Link: http://khtdr.com/opts
+-----------
+p-limit
+License: MIT
+License File: node_modules/p-limit/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (https://sindresorhus.com)
+Source: sindresorhus/p-limit
+Link: sindresorhus/p-limit
+-----------
+p-locate
+License: MIT
+License File: node_modules/p-locate/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (https://sindresorhus.com)
+Source: sindresorhus/p-locate
+Link: sindresorhus/p-locate
+-----------
+p-try
+License: MIT
+License File: node_modules/p-try/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/p-try
+Link: sindresorhus/p-try
+-----------
+parent-module
+License: MIT
+License File: node_modules/parent-module/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/parent-module
+Link: sindresorhus/parent-module
+-----------
+parse-json
+License: MIT
+License File: node_modules/parse-json/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/parse-json
+Link: sindresorhus/parse-json
+-----------
+path-exists
+License: MIT
+License File: node_modules/path-exists/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/path-exists
+Link: sindresorhus/path-exists
+-----------
+path-is-absolute
+License: MIT
+License File: node_modules/path-is-absolute/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/path-is-absolute
+Link: sindresorhus/path-is-absolute
+-----------
+path-key
+License: MIT
+License File: node_modules/path-key/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/path-key
+Link: sindresorhus/path-key
+-----------
+path-parse
+License: MIT
+License File: node_modules/path-parse/LICENSE
+Copyright: Copyright (c) 2015 Javier Blanco
+Source: https://github.com/jbgutierrez/path-parse.git
+Link: https://github.com/jbgutierrez/path-parse#readme
+-----------
+path-type
+License: MIT
+License File: node_modules/path-type/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/path-type
+Link: sindresorhus/path-type
+-----------
+picomatch
+License: MIT
+License File: node_modules/picomatch/LICENSE
+Copyright: Copyright (c) 2017-present, Jon Schlinkert.
+Source: micromatch/picomatch
+Link: https://github.com/micromatch/picomatch
+-----------
+pidtree
+License: MIT
+License File: node_modules/pidtree/license
+Copyright: Copyright (c) 2018 Simone Primarosa
+Source: github:simonepri/pidtree
+Link: http://github.com/simonepri/pidtree#readme
+-----------
+pify
+License: MIT
+License File: node_modules/pify/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/pify
+Link: sindresorhus/pify
+-----------
+possible-typed-array-names
+License: MIT
+License File: node_modules/possible-typed-array-names/LICENSE
+Copyright: Copyright (c) 2024 Jordan Harband
+Source: git+https://github.com/ljharb/possible-typed-array-names.git
+Link: https://github.com/ljharb/possible-typed-array-names#readme
+-----------
+prelude-ls
+License: MIT
+License File: node_modules/prelude-ls/LICENSE
+Copyright: Copyright (c) George Zahariev
+Source: git://github.com/gkz/prelude-ls.git
+Link: http://preludels.com
+-----------
+punycode
+License: MIT
+License File: node_modules/punycode/LICENSE-MIT.txt
+Source: https://github.com/mathiasbynens/punycode.js.git
+Link: https://mths.be/punycode
+-----------
+queue-microtask
+License: MIT
+License File: node_modules/queue-microtask/LICENSE
+Copyright: Copyright (c) Feross Aboukhadijeh
+Source: git://github.com/feross/queue-microtask.git
+Link: https://github.com/feross/queue-microtask
+-----------
+read-pkg
+License: MIT
+License File: node_modules/read-pkg/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/read-pkg
+Link: sindresorhus/read-pkg
+-----------
+readdirp
+License: MIT
+License File: node_modules/readdirp/LICENSE
+Copyright: Copyright (c) 2012-2019 Thorsten Lorenz, Paul Miller (https://paulmillr.com)
+Source: git://github.com/paulmillr/readdirp.git
+Link: https://github.com/paulmillr/readdirp
+-----------
+regexp.prototype.flags
+License: MIT
+License File: node_modules/regexp.prototype.flags/LICENSE
+Copyright: Copyright (C) 2014 Jordan Harband
+Source: git://github.com/es-shims/RegExp.prototype.flags.git
+Link: git://github.com/es-shims/RegExp.prototype.flags.git
+-----------
+require-directory
+License: MIT
+License File: node_modules/require-directory/LICENSE
+Copyright: Copyright (c) 2011 Troy Goode <*********@*****.***>
+Source: git://github.com/troygoode/node-require-directory.git
+Link: https://github.com/troygoode/node-require-directory/
+-----------
+require-main-filename
+License: ISC
+License File: node_modules/require-main-filename/LICENSE.txt
+Copyright: Copyright (c) 2016, Contributors
+Source: git+ssh://git@github.com/yargs/require-main-filename.git
+Link: https://github.com/yargs/require-main-filename#readme
+-----------
+resolve-from
+License: MIT
+License File: node_modules/resolve-from/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/resolve-from
+Link: sindresorhus/resolve-from
+-----------
+resolve
+License: MIT
+License File: node_modules/resolve/LICENSE
+Copyright: Copyright (c) 2012 James Halliday
+Source: git://github.com/browserify/resolve.git
+Link: git://github.com/browserify/resolve.git
+-----------
+reusify
+License: MIT
+License File: node_modules/reusify/LICENSE
+Copyright: Copyright (c) 2015 Matteo Collina
+Source: git+https://github.com/mcollina/reusify.git
+Link: https://github.com/mcollina/reusify#readme
+-----------
+rimraf
+License: ISC
+License File: node_modules/rimraf/LICENSE
+Copyright: Copyright (c) Isaac Z. Schlueter and Contributors
+Source: git://github.com/isaacs/rimraf.git
+Link: git://github.com/isaacs/rimraf.git
+-----------
+run-parallel
+License: MIT
+License File: node_modules/run-parallel/LICENSE
+Copyright: Copyright (c) Feross Aboukhadijeh
+Source: git://github.com/feross/run-parallel.git
+Link: https://github.com/feross/run-parallel
+-----------
+safe-array-concat
+License: MIT
+License File: node_modules/safe-array-concat/LICENSE
+Copyright: Copyright (c) 2023 Jordan Harband
+Source: git+https://github.com/ljharb/safe-array-concat.git
+Link: https://github.com/ljharb/safe-array-concat#readme
+-----------
+safe-regex-test
+License: MIT
+License File: node_modules/safe-regex-test/LICENSE
+Copyright: Copyright (c) 2022 Jordan Harband
+Source: git+https://github.com/ljharb/safe-regex-test.git
+Link: https://github.com/ljharb/safe-regex-test#readme
+-----------
+sass
+License: MIT
+License File: node_modules/sass/LICENSE
+Copyright: Copyright (c) 2016, Google Inc.
+Source: https://github.com/sass/dart-sass
+Link: https://github.com/sass/dart-sass
+-----------
+semver
+License: ISC
+License File: node_modules/semver/LICENSE
+Copyright: Copyright (c) Isaac Z. Schlueter and Contributors
+Source: https://github.com/npm/node-semver.git
+Link: https://github.com/npm/node-semver.git
+-----------
+set-blocking
+License: ISC
+License File: node_modules/set-blocking/LICENSE.txt
+Copyright: Copyright (c) 2016, Contributors
+Source: git+https://github.com/yargs/set-blocking.git
+Link: https://github.com/yargs/set-blocking#readme
+-----------
+set-function-length
+License: MIT
+License File: node_modules/set-function-length/LICENSE
+Copyright: Copyright (c) Jordan Harband and contributors
+Source: git+https://github.com/ljharb/set-function-length.git
+Link: https://github.com/ljharb/set-function-length#readme
+-----------
+set-function-name
+License: MIT
+License File: node_modules/set-function-name/LICENSE
+Copyright: Copyright (c) Jordan Harband and contributors
+Source: git+https://github.com/ljharb/set-function-name.git
+Link: https://github.com/ljharb/set-function-name#readme
+-----------
+shebang-command
+License: MIT
+License File: node_modules/shebang-command/license
+Copyright: Copyright (c) Kevin Mårtensson <***************@*****.***> (github.com/kevva)
+Source: kevva/shebang-command
+Link: kevva/shebang-command
+-----------
+shebang-regex
+License: MIT
+License File: node_modules/shebang-regex/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/shebang-regex
+Link: sindresorhus/shebang-regex
+-----------
+shell-quote
+License: MIT
+License File: node_modules/shell-quote/LICENSE
+Copyright: Copyright (c) 2013 James Halliday (****@********.***)
+Source: http://github.com/ljharb/shell-quote.git
+Link: https://github.com/ljharb/shell-quote
+-----------
+side-channel
+License: MIT
+License File: node_modules/side-channel/LICENSE
+Copyright: Copyright (c) 2019 Jordan Harband
+Source: git+https://github.com/ljharb/side-channel.git
+Link: https://github.com/ljharb/side-channel#readme
+-----------
+snabbdom
+License: MIT
+License File: node_modules/snabbdom/LICENSE
+Copyright: Copyright (c) 2015 Simon Friis Vindum
+Source: git+https://github.com/snabbdom/snabbdom.git
+Link: https://github.com/snabbdom/snabbdom#readme
+-----------
+sortablejs
+License: MIT
+License File: node_modules/sortablejs/LICENSE
+Source: git://github.com/SortableJS/Sortable.git
+Link: git://github.com/SortableJS/Sortable.git
+-----------
+source-map-js
+License: BSD-3-Clause
+License File: node_modules/source-map-js/LICENSE
+Copyright: Copyright (c) 2009-2011, Mozilla Foundation and contributors
+All rights reserved.
+Source: 7rulnik/source-map-js
+Link: https://github.com/7rulnik/source-map-js
+-----------
+spdx-correct
+License: Apache-2.0
+License File: node_modules/spdx-correct/LICENSE
+Source: jslicense/spdx-correct.js
+Link: jslicense/spdx-correct.js
+-----------
+spdx-exceptions
+License: CC-BY-3.0
+Source: kemitchell/spdx-exceptions.json
+Link: kemitchell/spdx-exceptions.json
+-----------
+spdx-expression-parse
+License: MIT
+License File: node_modules/spdx-expression-parse/LICENSE
+Copyright: Copyright (c) 2015 Kyle E. Mitchell & other authors listed in AUTHORS
+Source: jslicense/spdx-expression-parse.js
+Link: jslicense/spdx-expression-parse.js
+-----------
+spdx-license-ids
+License: CC0-1.0
+Source: jslicense/spdx-license-ids
+Link: jslicense/spdx-license-ids
+-----------
+string-width
+License: MIT
+License File: node_modules/string-width/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/string-width
+Link: sindresorhus/string-width
+-----------
+string.prototype.padend
+License: MIT
+License File: node_modules/string.prototype.padend/LICENSE
+Copyright: Copyright (c) 2015 EcmaScript Shims
+Source: git://github.com/es-shims/String.prototype.padEnd.git
+Link: git://github.com/es-shims/String.prototype.padEnd.git
+-----------
+string.prototype.trim
+License: MIT
+License File: node_modules/string.prototype.trim/LICENSE
+Copyright: Copyright (c) 2015 Jordan Harband
+Source: git://github.com/es-shims/String.prototype.trim.git
+Link: git://github.com/es-shims/String.prototype.trim.git
+-----------
+string.prototype.trimend
+License: MIT
+License File: node_modules/string.prototype.trimend/LICENSE
+Copyright: Copyright (c) 2017 Khaled Al-Ansari
+Source: git://github.com/es-shims/String.prototype.trimEnd.git
+Link: git://github.com/es-shims/String.prototype.trimEnd.git
+-----------
+string.prototype.trimstart
+License: MIT
+License File: node_modules/string.prototype.trimstart/LICENSE
+Copyright: Copyright (c) 2017 Khaled Al-Ansari
+Source: git://github.com/es-shims/String.prototype.trimStart.git
+Link: git://github.com/es-shims/String.prototype.trimStart.git
+-----------
+strip-ansi
+License: MIT
+License File: node_modules/strip-ansi/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: chalk/strip-ansi
+Link: chalk/strip-ansi
+-----------
+strip-bom
+License: MIT
+License File: node_modules/strip-bom/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: sindresorhus/strip-bom
+Link: sindresorhus/strip-bom
+-----------
+strip-json-comments
+License: MIT
+License File: node_modules/strip-json-comments/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (https://sindresorhus.com)
+Source: sindresorhus/strip-json-comments
+Link: sindresorhus/strip-json-comments
+-----------
+style-mod
+License: MIT
+License File: node_modules/style-mod/LICENSE
+Copyright: Copyright (C) 2018 by Marijn Haverbeke <******@*********.******> and others
+Source: git+https://github.com/marijnh/style-mod.git
+Link: git+https://github.com/marijnh/style-mod.git
+-----------
+supports-color
+License: MIT
+License File: node_modules/supports-color/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: chalk/supports-color
+Link: chalk/supports-color
+-----------
+supports-preserve-symlinks-flag
+License: MIT
+License File: node_modules/supports-preserve-symlinks-flag/LICENSE
+Copyright: Copyright (c) 2022 Inspect JS
+Source: git+https://github.com/inspect-js/node-supports-preserve-symlinks-flag.git
+Link: https://github.com/inspect-js/node-supports-preserve-symlinks-flag#readme
+-----------
+text-table
+License: MIT
+License File: node_modules/text-table/LICENSE
+Source: git://github.com/substack/text-table.git
+Link: https://github.com/substack/text-table
+-----------
+to-regex-range
+License: MIT
+License File: node_modules/to-regex-range/LICENSE
+Copyright: Copyright (c) 2015-present, Jon Schlinkert.
+Source: micromatch/to-regex-range
+Link: https://github.com/micromatch/to-regex-range
+-----------
+tsconfig-paths
+License: MIT
+License File: node_modules/tsconfig-paths/LICENSE
+Copyright: Copyright (c) 2016 Jonas Kello
+Source: https://github.com/dividab/tsconfig-paths
+Link: https://github.com/dividab/tsconfig-paths
+-----------
+type-check
+License: MIT
+License File: node_modules/type-check/LICENSE
+Copyright: Copyright (c) George Zahariev
+Source: git://github.com/gkz/type-check.git
+Link: https://github.com/gkz/type-check
+-----------
+type-fest
+License: (MIT OR CC0-1.0)
+License File: node_modules/type-fest/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (https:/sindresorhus.com)
+Source: sindresorhus/type-fest
+Link: sindresorhus/type-fest
+-----------
+typed-array-buffer
+License: MIT
+License File: node_modules/typed-array-buffer/LICENSE
+Copyright: Copyright (c) 2023 Jordan Harband
+Source: git+https://github.com/ljharb/typed-array-buffer.git
+Link: https://github.com/ljharb/typed-array-buffer#readme
+-----------
+typed-array-byte-length
+License: MIT
+License File: node_modules/typed-array-byte-length/LICENSE
+Copyright: Copyright (c) 2020 Inspect JS
+Source: git+https://github.com/inspect-js/typed-array-byte-length.git
+Link: https://github.com/inspect-js/typed-array-byte-length#readme
+-----------
+typed-array-byte-offset
+License: MIT
+License File: node_modules/typed-array-byte-offset/LICENSE
+Copyright: Copyright (c) 2020 Inspect JS
+Source: git+https://github.com/inspect-js/typed-array-byte-offset.git
+Link: https://github.com/inspect-js/typed-array-byte-offset#readme
+-----------
+typed-array-length
+License: MIT
+License File: node_modules/typed-array-length/LICENSE
+Copyright: Copyright (c) 2020 Inspect JS
+Source: git+https://github.com/inspect-js/typed-array-length.git
+Link: https://github.com/inspect-js/typed-array-length#readme
+-----------
+uc.micro
+License: MIT
+License File: node_modules/uc.micro/LICENSE.txt
+Source: markdown-it/uc.micro
+Link: markdown-it/uc.micro
+-----------
+unbox-primitive
+License: MIT
+License File: node_modules/unbox-primitive/LICENSE
+Copyright: Copyright (c) 2019 Jordan Harband
+Source: git+https://github.com/ljharb/unbox-primitive.git
+Link: https://github.com/ljharb/unbox-primitive#readme
+-----------
+uri-js
+License: BSD-2-Clause
+License File: node_modules/uri-js/LICENSE
+Copyright: Copyright 2011 Gary Court. All rights reserved.
+Source: http://github.com/garycourt/uri-js
+Link: https://github.com/garycourt/uri-js
+-----------
+validate-npm-package-license
+License: Apache-2.0
+License File: node_modules/validate-npm-package-license/LICENSE
+Source: kemitchell/validate-npm-package-license.js
+Link: kemitchell/validate-npm-package-license.js
+-----------
+w3c-keyname
+License: MIT
+License File: node_modules/w3c-keyname/LICENSE
+Copyright: Copyright (C) 2016 by Marijn Haverbeke <******@*********.******> and others
+Source: git+https://github.com/marijnh/w3c-keyname.git
+Link: https://github.com/marijnh/w3c-keyname#readme
+-----------
+which-boxed-primitive
+License: MIT
+License File: node_modules/which-boxed-primitive/LICENSE
+Copyright: Copyright (c) 2019 Jordan Harband
+Source: git+https://github.com/inspect-js/which-boxed-primitive.git
+Link: https://github.com/inspect-js/which-boxed-primitive#readme
+-----------
+which-module
+License: ISC
+License File: node_modules/which-module/LICENSE
+Copyright: Copyright (c) 2016, Contributors
+Source: git+https://github.com/nexdrew/which-module.git
+Link: https://github.com/nexdrew/which-module#readme
+-----------
+which-typed-array
+License: MIT
+License File: node_modules/which-typed-array/LICENSE
+Copyright: Copyright (c) 2015 Jordan Harband
+Source: git://github.com/inspect-js/which-typed-array.git
+Link: git://github.com/inspect-js/which-typed-array.git
+-----------
+which
+License: ISC
+License File: node_modules/which/LICENSE
+Copyright: Copyright (c) Isaac Z. Schlueter and Contributors
+Source: git://github.com/isaacs/node-which.git
+Link: git://github.com/isaacs/node-which.git
+-----------
+wrap-ansi
+License: MIT
+License File: node_modules/wrap-ansi/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (sindresorhus.com)
+Source: chalk/wrap-ansi
+Link: chalk/wrap-ansi
+-----------
+wrappy
+License: ISC
+License File: node_modules/wrappy/LICENSE
+Copyright: Copyright (c) Isaac Z. Schlueter and Contributors
+Source: https://github.com/npm/wrappy
+Link: https://github.com/npm/wrappy
+-----------
+ws
+License: MIT
+License File: node_modules/ws/LICENSE
+Copyright: Copyright (c) 2011 Einar Otto Stangvik <*******@*****.***>
+Source: websockets/ws
+Link: https://github.com/websockets/ws
+-----------
+y18n
+License: ISC
+License File: node_modules/y18n/LICENSE
+Copyright: Copyright (c) 2015, Contributors
+Source: git@github.com:yargs/y18n.git
+Link: https://github.com/yargs/y18n
+-----------
+yargs-parser
+License: ISC
+License File: node_modules/yargs-parser/LICENSE.txt
+Copyright: Copyright (c) 2016, Contributors
+Source: git@github.com:yargs/yargs-parser.git
+Link: git@github.com:yargs/yargs-parser.git
+-----------
+yargs
+License: MIT
+License File: node_modules/yargs/LICENSE
+Copyright: Copyright 2010 James Halliday (****@********.***)
+Modified work Copyright 2014 Contributors (***@*****.***)
+Source: https://github.com/yargs/yargs.git
+Link: https://yargs.js.org/
+-----------
+yocto-queue
+License: MIT
+License File: node_modules/yocto-queue/license
+Copyright: Copyright (c) Sindre Sorhus <************@*****.***> (https://sindresorhus.com)
+Source: sindresorhus/yocto-queue
+Link: sindresorhus/yocto-queue
+-----------
+@aashutoshrathi/word-wrap
+License: MIT
+License File: node_modules/@aashutoshrathi/word-wrap/LICENSE
+Copyright: Copyright (c) 2014-2016, Jon Schlinkert
+Source: git+https://github.com/aashutoshrathi/word-wrap.git
+Link: https://github.com/aashutoshrathi/word-wrap
+-----------
+@codemirror/autocomplete
+License: MIT
+License File: node_modules/@codemirror/autocomplete/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/codemirror/autocomplete.git
+Link: https://github.com/codemirror/autocomplete.git
+-----------
+@codemirror/commands
+License: MIT
+License File: node_modules/@codemirror/commands/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/codemirror/commands.git
+Link: https://github.com/codemirror/commands.git
+-----------
+@codemirror/lang-css
+License: MIT
+License File: node_modules/@codemirror/lang-css/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/codemirror/lang-css.git
+Link: https://github.com/codemirror/lang-css.git
+-----------
+@codemirror/lang-html
+License: MIT
+License File: node_modules/@codemirror/lang-html/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/codemirror/lang-html.git
+Link: https://github.com/codemirror/lang-html.git
+-----------
+@codemirror/lang-javascript
+License: MIT
+License File: node_modules/@codemirror/lang-javascript/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/codemirror/lang-javascript.git
+Link: https://github.com/codemirror/lang-javascript.git
+-----------
+@codemirror/lang-json
+License: MIT
+License File: node_modules/@codemirror/lang-json/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <*******@*****.***> and others
+Source: https://github.com/codemirror/lang-json.git
+Link: https://github.com/codemirror/lang-json.git
+-----------
+@codemirror/lang-markdown
+License: MIT
+License File: node_modules/@codemirror/lang-markdown/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/codemirror/lang-markdown.git
+Link: https://github.com/codemirror/lang-markdown.git
+-----------
+@codemirror/lang-php
+License: MIT
+License File: node_modules/@codemirror/lang-php/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <*******@*****.***> and others
+Source: https://github.com/codemirror/lang-php.git
+Link: https://github.com/codemirror/lang-php.git
+-----------
+@codemirror/lang-xml
+License: MIT
+License File: node_modules/@codemirror/lang-xml/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <*******@*****.***> and others
+Source: https://github.com/codemirror/lang-xml.git
+Link: https://github.com/codemirror/lang-xml.git
+-----------
+@codemirror/language
+License: MIT
+License File: node_modules/@codemirror/language/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/codemirror/language.git
+Link: https://github.com/codemirror/language.git
+-----------
+@codemirror/legacy-modes
+License: MIT
+License File: node_modules/@codemirror/legacy-modes/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/codemirror/legacy-modes.git
+Link: https://github.com/codemirror/legacy-modes.git
+-----------
+@codemirror/lint
+License: MIT
+License File: node_modules/@codemirror/lint/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/codemirror/lint.git
+Link: https://github.com/codemirror/lint.git
+-----------
+@codemirror/search
+License: MIT
+License File: node_modules/@codemirror/search/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/codemirror/search.git
+Link: https://github.com/codemirror/search.git
+-----------
+@codemirror/state
+License: MIT
+License File: node_modules/@codemirror/state/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/codemirror/state.git
+Link: https://github.com/codemirror/state.git
+-----------
+@codemirror/theme-one-dark
+License: MIT
+License File: node_modules/@codemirror/theme-one-dark/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/codemirror/theme-one-dark.git
+Link: https://github.com/codemirror/theme-one-dark.git
+-----------
+@codemirror/view
+License: MIT
+License File: node_modules/@codemirror/view/LICENSE
+Copyright: Copyright (C) 2018-2021 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/codemirror/view.git
+Link: https://github.com/codemirror/view.git
+-----------
+@esbuild/linux-x64
+License: MIT
+Source: git+https://github.com/evanw/esbuild.git
+Link: git+https://github.com/evanw/esbuild.git
+-----------
+@eslint-community/eslint-utils
+License: MIT
+License File: node_modules/@eslint-community/eslint-utils/LICENSE
+Copyright: Copyright (c) 2018 Toru Nagashima
+Source: https://github.com/eslint-community/eslint-utils
+Link: https://github.com/eslint-community/eslint-utils#readme
+-----------
+@eslint-community/regexpp
+License: MIT
+License File: node_modules/@eslint-community/regexpp/LICENSE
+Copyright: Copyright (c) 2018 Toru Nagashima
+Source: https://github.com/eslint-community/regexpp
+Link: https://github.com/eslint-community/regexpp#readme
+-----------
+@eslint/eslintrc
+License: MIT
+License File: node_modules/@eslint/eslintrc/LICENSE
+Source: eslint/eslintrc
+Link: https://github.com/eslint/eslintrc#readme
+-----------
+@eslint/js
+License: MIT
+License File: node_modules/@eslint/js/LICENSE
+Source: https://github.com/eslint/eslint.git
+Link: https://eslint.org
+-----------
+@humanwhocodes/config-array
+License: Apache-2.0
+License File: node_modules/@humanwhocodes/config-array/LICENSE
+Source: git+https://github.com/humanwhocodes/config-array.git
+Link: https://github.com/humanwhocodes/config-array#readme
+-----------
+@humanwhocodes/module-importer
+License: Apache-2.0
+License File: node_modules/@humanwhocodes/module-importer/LICENSE
+Source: git+https://github.com/humanwhocodes/module-importer.git
+Link: git+https://github.com/humanwhocodes/module-importer.git
+-----------
+@humanwhocodes/object-schema
+License: BSD-3-Clause
+License File: node_modules/@humanwhocodes/object-schema/LICENSE
+Copyright: Copyright (c) 2019, Human Who Codes
+All rights reserved.
+Source: git+https://github.com/humanwhocodes/object-schema.git
+Link: https://github.com/humanwhocodes/object-schema#readme
+-----------
+@lezer/common
+License: MIT
+License File: node_modules/@lezer/common/LICENSE
+Copyright: Copyright (C) 2018 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/lezer-parser/common.git
+Link: https://github.com/lezer-parser/common.git
+-----------
+@lezer/css
+License: MIT
+License File: node_modules/@lezer/css/LICENSE
+Copyright: Copyright (C) 2018 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/lezer-parser/css.git
+Link: https://github.com/lezer-parser/css.git
+-----------
+@lezer/generator
+License: MIT
+License File: node_modules/@lezer/generator/LICENSE
+Copyright: Copyright (C) 2018 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/lezer-parser/generator.git
+Link: https://github.com/lezer-parser/generator.git
+-----------
+@lezer/highlight
+License: MIT
+License File: node_modules/@lezer/highlight/LICENSE
+Copyright: Copyright (C) 2018 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/lezer-parser/highlight.git
+Link: https://github.com/lezer-parser/highlight.git
+-----------
+@lezer/html
+License: MIT
+License File: node_modules/@lezer/html/LICENSE
+Copyright: Copyright (C) 2018 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/lezer-parser/html.git
+Link: https://github.com/lezer-parser/html.git
+-----------
+@lezer/javascript
+License: MIT
+License File: node_modules/@lezer/javascript/LICENSE
+Copyright: Copyright (C) 2018 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/lezer-parser/javascript.git
+Link: https://github.com/lezer-parser/javascript.git
+-----------
+@lezer/json
+License: MIT
+License File: node_modules/@lezer/json/LICENSE
+Copyright: Copyright (C) 2020 by Marijn Haverbeke <******@*********.******>, Arun Srinivasan <*******@*****.***>, and others
+Source: https://github.com/lezer-parser/json.git
+Link: https://github.com/lezer-parser/json.git
+-----------
+@lezer/lr
+License: MIT
+License File: node_modules/@lezer/lr/LICENSE
+Copyright: Copyright (C) 2018 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/lezer-parser/lr.git
+Link: https://github.com/lezer-parser/lr.git
+-----------
+@lezer/markdown
+License: MIT
+License File: node_modules/@lezer/markdown/LICENSE
+Copyright: Copyright (C) 2020 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/lezer-parser/markdown.git
+Link: https://github.com/lezer-parser/markdown.git
+-----------
+@lezer/php
+License: MIT
+License File: node_modules/@lezer/php/LICENSE
+Copyright: Copyright (C) 2018 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/lezer-parser/php.git
+Link: https://github.com/lezer-parser/php.git
+-----------
+@lezer/xml
+License: MIT
+License File: node_modules/@lezer/xml/LICENSE
+Copyright: Copyright (C) 2018 by Marijn Haverbeke <******@*********.******> and others
+Source: https://github.com/lezer-parser/xml.git
+Link: https://github.com/lezer-parser/xml.git
+-----------
+@nodelib/fs.scandir
+License: MIT
+License File: node_modules/@nodelib/fs.scandir/LICENSE
+Copyright: Copyright (c) Denis Malinochkin
+Source: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.scandir
+Link: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.scandir
+-----------
+@nodelib/fs.stat
+License: MIT
+License File: node_modules/@nodelib/fs.stat/LICENSE
+Copyright: Copyright (c) Denis Malinochkin
+Source: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat
+Link: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat
+-----------
+@nodelib/fs.walk
+License: MIT
+License File: node_modules/@nodelib/fs.walk/LICENSE
+Copyright: Copyright (c) Denis Malinochkin
+Source: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk
+Link: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk
+-----------
+@ssddanbrown/codemirror-lang-smarty
+License: MIT
+License File: node_modules/@ssddanbrown/codemirror-lang-smarty/LICENSE
+Copyright: Copyright (C) 2023 by Dan Brown, Marijn Haverbeke and others
+-----------
+@ssddanbrown/codemirror-lang-twig
+License: MIT
+License File: node_modules/@ssddanbrown/codemirror-lang-twig/LICENSE
+Copyright: Copyright (C) 2023 by Dan Brown, Marijn Haverbeke and others
+-----------
+@types/json5
+License: MIT
+Source: https://www.github.com/DefinitelyTyped/DefinitelyTyped.git
+Link: https://www.github.com/DefinitelyTyped/DefinitelyTyped.git
+-----------
+@ungap/structured-clone
+License: ISC
+License File: node_modules/@ungap/structured-clone/LICENSE
+Copyright: Copyright (c) 2021, Andrea Giammarchi, @WebReflection
+Source: git+https://github.com/ungap/structured-clone.git
+Link: https://github.com/ungap/structured-clone#readme

--- a/dev/licensing/php-library-licenses.txt
+++ b/dev/licensing/php-library-licenses.txt
@@ -1,0 +1,796 @@
+aws/aws-crt-php
+License: Apache-2.0
+License File: vendor/aws/aws-crt-php/LICENSE
+Source: https://github.com/awslabs/aws-crt-php.git
+Link: https://github.com/awslabs/aws-crt-php
+-----------
+aws/aws-sdk-php
+License: Apache-2.0
+License File: vendor/aws/aws-sdk-php/LICENSE
+Source: https://github.com/aws/aws-sdk-php.git
+Link: http://aws.amazon.com/sdkforphp
+-----------
+bacon/bacon-qr-code
+License: BSD-2-Clause
+License File: vendor/bacon/bacon-qr-code/LICENSE
+Copyright: Copyright (c) 2017, Ben Scholzen 'DASPRiD'
+All rights reserved.
+Source: https://github.com/Bacon/BaconQrCode.git
+Link: https://github.com/Bacon/BaconQrCode
+-----------
+barryvdh/laravel-dompdf
+License: MIT
+License File: vendor/barryvdh/laravel-dompdf/LICENSE
+Copyright: Copyright (c) 2021 barryvdh
+Source: https://github.com/barryvdh/laravel-dompdf.git
+Link: https://github.com/barryvdh/laravel-dompdf.git
+-----------
+barryvdh/laravel-snappy
+License: MIT
+License File: vendor/barryvdh/laravel-snappy/LICENSE
+Copyright: Copyright (c) 2018
+Source: https://github.com/barryvdh/laravel-snappy.git
+Link: https://github.com/barryvdh/laravel-snappy.git
+-----------
+brick/math
+License: MIT
+License File: vendor/brick/math/LICENSE
+Copyright: Copyright (c) 2013-present Benjamin Morel
+Source: https://github.com/brick/math.git
+Link: https://github.com/brick/math.git
+-----------
+carbonphp/carbon-doctrine-types
+License: MIT
+License File: vendor/carbonphp/carbon-doctrine-types/LICENSE
+Copyright: Copyright (c) 2023 Carbon
+Source: https://github.com/CarbonPHP/carbon-doctrine-types.git
+Link: https://github.com/CarbonPHP/carbon-doctrine-types.git
+-----------
+dasprid/enum
+License: BSD-2-Clause
+License File: vendor/dasprid/enum/LICENSE
+Copyright: Copyright (c) 2017, Ben Scholzen 'DASPRiD'
+All rights reserved.
+Source: https://github.com/DASPRiD/Enum.git
+Link: https://github.com/DASPRiD/Enum.git
+-----------
+dflydev/dot-access-data
+License: MIT
+License File: vendor/dflydev/dot-access-data/LICENSE
+Copyright: Copyright (c) 2012 Dragonfly Development Inc.
+Source: https://github.com/dflydev/dflydev-dot-access-data.git
+Link: https://github.com/dflydev/dflydev-dot-access-data
+-----------
+doctrine/cache
+License: MIT
+License File: vendor/doctrine/cache/LICENSE
+Copyright: Copyright (c) 2006-2015 Doctrine Project
+Source: https://github.com/doctrine/cache.git
+Link: https://www.doctrine-project.org/projects/cache.html
+-----------
+doctrine/dbal
+License: MIT
+License File: vendor/doctrine/dbal/LICENSE
+Copyright: Copyright (c) 2006-2018 Doctrine Project
+Source: https://github.com/doctrine/dbal.git
+Link: https://www.doctrine-project.org/projects/dbal.html
+-----------
+doctrine/deprecations
+License: MIT
+License File: vendor/doctrine/deprecations/LICENSE
+Copyright: Copyright (c) 2020-2021 Doctrine Project
+Source: https://github.com/doctrine/deprecations.git
+Link: https://www.doctrine-project.org/
+-----------
+doctrine/event-manager
+License: MIT
+License File: vendor/doctrine/event-manager/LICENSE
+Copyright: Copyright (c) 2006-2015 Doctrine Project
+Source: https://github.com/doctrine/event-manager.git
+Link: https://www.doctrine-project.org/projects/event-manager.html
+-----------
+doctrine/inflector
+License: MIT
+License File: vendor/doctrine/inflector/LICENSE
+Copyright: Copyright (c) 2006-2015 Doctrine Project
+Source: https://github.com/doctrine/inflector.git
+Link: https://www.doctrine-project.org/projects/inflector.html
+-----------
+doctrine/lexer
+License: MIT
+License File: vendor/doctrine/lexer/LICENSE
+Copyright: Copyright (c) 2006-2018 Doctrine Project
+Source: https://github.com/doctrine/lexer.git
+Link: https://www.doctrine-project.org/projects/lexer.html
+-----------
+dompdf/dompdf
+License: LGPL-2.1
+License File: vendor/dompdf/dompdf/LICENSE.LGPL
+Copyright: Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+Source: https://github.com/dompdf/dompdf.git
+Link: https://github.com/dompdf/dompdf
+-----------
+dragonmantank/cron-expression
+License: MIT
+License File: vendor/dragonmantank/cron-expression/LICENSE
+Copyright: Copyright (c) 2011 Michael Dowling <*********@*****.***>, 2016 Chris Tankersley <*****@***********.***>, and contributors
+Source: https://github.com/dragonmantank/cron-expression.git
+Link: https://github.com/dragonmantank/cron-expression.git
+-----------
+egulias/email-validator
+License: MIT
+License File: vendor/egulias/email-validator/LICENSE
+Copyright: Copyright (c) 2013-2023 Eduardo Gulias Davis
+Source: https://github.com/egulias/EmailValidator.git
+Link: https://github.com/egulias/EmailValidator
+-----------
+fruitcake/php-cors
+License: MIT
+License File: vendor/fruitcake/php-cors/LICENSE
+Copyright: Copyright (c) 2013-2017 Alexander <***.*****@*****.***>
+Copyright (c) 2017-2022 Barryvdh <********@*****.***>
+Source: https://github.com/fruitcake/php-cors.git
+Link: https://github.com/fruitcake/php-cors
+-----------
+graham-campbell/result-type
+License: MIT
+License File: vendor/graham-campbell/result-type/LICENSE
+Copyright: Copyright (c) 2020-2023 Graham Campbell <*****@**********.**.**>
+Source: https://github.com/GrahamCampbell/Result-Type.git
+Link: https://github.com/GrahamCampbell/Result-Type.git
+-----------
+guzzlehttp/guzzle
+License: MIT
+License File: vendor/guzzlehttp/guzzle/LICENSE
+Copyright: Copyright (c) 2011 Michael Dowling <*********@*****.***>
+Copyright (c) 2012 Jeremy Lindblom <**********@*****.***>
+Copyright (c) 2014 Graham Campbell <*****@**********.**.**>
+Copyright (c) 2015 Márk Sági-Kazár <****.*********@*****.***>
+Copyright (c) 2015 Tobias Schultze <*********@**********.**>
+Copyright (c) 2016 Tobias Nyholm <******.******@*****.***>
+Copyright (c) 2016 George Mponos <*******@*****.***>
+Source: https://github.com/guzzle/guzzle.git
+Link: https://github.com/guzzle/guzzle.git
+-----------
+guzzlehttp/promises
+License: MIT
+License File: vendor/guzzlehttp/promises/LICENSE
+Copyright: Copyright (c) 2015 Michael Dowling <*********@*****.***>
+Copyright (c) 2015 Graham Campbell <*****@**********.**.**>
+Copyright (c) 2017 Tobias Schultze <*********@**********.**>
+Copyright (c) 2020 Tobias Nyholm <******.******@*****.***>
+Source: https://github.com/guzzle/promises.git
+Link: https://github.com/guzzle/promises.git
+-----------
+guzzlehttp/psr7
+License: MIT
+License File: vendor/guzzlehttp/psr7/LICENSE
+Copyright: Copyright (c) 2015 Michael Dowling <*********@*****.***>
+Copyright (c) 2015 Márk Sági-Kazár <****.*********@*****.***>
+Copyright (c) 2015 Graham Campbell <*****@**********.**.**>
+Copyright (c) 2016 Tobias Schultze <*********@**********.**>
+Copyright (c) 2016 George Mponos <*******@*****.***>
+Copyright (c) 2018 Tobias Nyholm <******.******@*****.***>
+Source: https://github.com/guzzle/psr7.git
+Link: https://github.com/guzzle/psr7.git
+-----------
+guzzlehttp/uri-template
+License: MIT
+License File: vendor/guzzlehttp/uri-template/LICENSE
+Copyright: Copyright (c) 2014 Michael Dowling <*********@*****.***>
+Copyright (c) 2020 George Mponos <*******@*****.***>
+Copyright (c) 2020 Graham Campbell <*****@**********.**.**>
+Source: https://github.com/guzzle/uri-template.git
+Link: https://github.com/guzzle/uri-template.git
+-----------
+intervention/gif
+License: MIT
+License File: vendor/intervention/gif/LICENSE
+Copyright: Copyright (c) 2020 Oliver Vogel
+Source: https://github.com/Intervention/gif.git
+Link: https://github.com/intervention/gif
+-----------
+intervention/image
+License: MIT
+License File: vendor/intervention/image/LICENSE
+Copyright: Copyright (c) 2013-2024 Oliver Vogel
+Source: https://github.com/Intervention/image.git
+Link: https://image.intervention.io/
+-----------
+knplabs/knp-snappy
+License: MIT
+License File: vendor/knplabs/knp-snappy/LICENSE
+Copyright: Copyright (c) 2010 Matthieu Bontemps
+Source: https://github.com/KnpLabs/snappy.git
+Link: http://github.com/KnpLabs/snappy
+-----------
+laravel/framework
+License: MIT
+License File: vendor/laravel/framework/LICENSE.md
+Copyright: Copyright (c) Taylor Otwell
+Source: https://github.com/laravel/framework.git
+Link: https://laravel.com
+-----------
+laravel/prompts
+License: MIT
+License File: vendor/laravel/prompts/LICENSE.md
+Copyright: Copyright (c) Taylor Otwell
+Source: https://github.com/laravel/prompts.git
+Link: https://github.com/laravel/prompts.git
+-----------
+laravel/serializable-closure
+License: MIT
+License File: vendor/laravel/serializable-closure/LICENSE.md
+Copyright: Copyright (c) Taylor Otwell
+Source: https://github.com/laravel/serializable-closure.git
+Link: https://github.com/laravel/serializable-closure.git
+-----------
+laravel/socialite
+License: MIT
+License File: vendor/laravel/socialite/LICENSE.md
+Copyright: Copyright (c) Taylor Otwell
+Source: https://github.com/laravel/socialite.git
+Link: https://laravel.com
+-----------
+laravel/tinker
+License: MIT
+License File: vendor/laravel/tinker/LICENSE.md
+Copyright: Copyright (c) Taylor Otwell
+Source: https://github.com/laravel/tinker.git
+Link: https://github.com/laravel/tinker.git
+-----------
+league/commonmark
+License: BSD-3-Clause
+License File: vendor/league/commonmark/LICENSE
+Copyright: Copyright (c) 2014-2022, Colin O'Dell. All rights reserved. Some code based on commonmark.js (copyright 2014-2018, John MacFarlane) and commonmark-java (copyright 2015-2016, Atlassian Pty Ltd)
+Source: https://github.com/thephpleague/commonmark.git
+Link: https://commonmark.thephpleague.com
+-----------
+league/config
+License: BSD-3-Clause
+License File: vendor/league/config/LICENSE.md
+Copyright: Copyright (c) 2022, Colin O'Dell. All rights reserved.
+Source: https://github.com/thephpleague/config.git
+Link: https://config.thephpleague.com
+-----------
+league/flysystem
+License: MIT
+License File: vendor/league/flysystem/LICENSE
+Copyright: Copyright (c) 2013-2024 Frank de Jonge
+Source: https://github.com/thephpleague/flysystem.git
+Link: https://github.com/thephpleague/flysystem.git
+-----------
+league/flysystem-aws-s3-v3
+License: MIT
+License File: vendor/league/flysystem-aws-s3-v3/LICENSE
+Copyright: Copyright (c) 2013-2024 Frank de Jonge
+Source: https://github.com/thephpleague/flysystem-aws-s3-v3.git
+Link: https://github.com/thephpleague/flysystem-aws-s3-v3.git
+-----------
+league/flysystem-local
+License: MIT
+License File: vendor/league/flysystem-local/LICENSE
+Copyright: Copyright (c) 2013-2024 Frank de Jonge
+Source: https://github.com/thephpleague/flysystem-local.git
+Link: https://github.com/thephpleague/flysystem-local.git
+-----------
+league/html-to-markdown
+License: MIT
+License File: vendor/league/html-to-markdown/LICENSE
+Copyright: Copyright (c) 2015 Colin O'Dell; Originally created by Nick Cernis
+Source: https://github.com/thephpleague/html-to-markdown.git
+Link: https://github.com/thephpleague/html-to-markdown
+-----------
+league/mime-type-detection
+License: MIT
+License File: vendor/league/mime-type-detection/LICENSE
+Copyright: Copyright (c) 2013-2023 Frank de Jonge
+Source: https://github.com/thephpleague/mime-type-detection.git
+Link: https://github.com/thephpleague/mime-type-detection.git
+-----------
+league/oauth1-client
+License: MIT
+License File: vendor/league/oauth1-client/LICENSE
+Copyright: Copyright (c) 2013 Ben Corlett <**********@**.***>
+Source: https://github.com/thephpleague/oauth1-client.git
+Link: https://github.com/thephpleague/oauth1-client.git
+-----------
+league/oauth2-client
+License: MIT
+License File: vendor/league/oauth2-client/LICENSE
+Copyright: Copyright (c) 2013-2020 Alex Bilbie <*****@**********.***>
+Source: https://github.com/thephpleague/oauth2-client.git
+Link: https://github.com/thephpleague/oauth2-client.git
+-----------
+masterminds/html5
+License: MIT
+License File: vendor/masterminds/html5/LICENSE.txt
+Copyright: Copyright (c) 2013 The Authors of HTML5-PHP
+Source: https://github.com/Masterminds/html5-php.git
+Link: http://masterminds.github.io/html5-php
+-----------
+monolog/monolog
+License: MIT
+License File: vendor/monolog/monolog/LICENSE
+Copyright: Copyright (c) 2011-2020 Jordi Boggiano
+Source: https://github.com/Seldaek/monolog.git
+Link: https://github.com/Seldaek/monolog
+-----------
+mtdowling/jmespath.php
+License: MIT
+License File: vendor/mtdowling/jmespath.php/LICENSE
+Copyright: Copyright (c) 2014 Michael Dowling, https://github.com/mtdowling
+Source: https://github.com/jmespath/jmespath.php.git
+Link: https://github.com/jmespath/jmespath.php.git
+-----------
+nesbot/carbon
+License: MIT
+License File: vendor/nesbot/carbon/LICENSE
+Copyright: Copyright (C) Brian Nesbitt
+Source: https://github.com/briannesbitt/Carbon.git
+Link: https://carbon.nesbot.com
+-----------
+nette/schema
+License: BSD-3-Clause GPL-2.0-only GPL-3.0-only
+License File: vendor/nette/schema/license.md
+Copyright: Copyright (c) 2004, 2014 David Grudl (https://davidgrudl.com)
+All rights reserved.
+Source: https://github.com/nette/schema.git
+Link: https://nette.org
+-----------
+nette/utils
+License: BSD-3-Clause GPL-2.0-only GPL-3.0-only
+License File: vendor/nette/utils/license.md
+Copyright: Copyright (c) 2004, 2014 David Grudl (https://davidgrudl.com)
+All rights reserved.
+Source: https://github.com/nette/utils.git
+Link: https://nette.org
+-----------
+nikic/php-parser
+License: BSD-3-Clause
+License File: vendor/nikic/php-parser/LICENSE
+Copyright: Copyright (c) 2011, Nikita Popov
+All rights reserved.
+Source: https://github.com/nikic/PHP-Parser.git
+Link: https://github.com/nikic/PHP-Parser.git
+-----------
+nunomaduro/termwind
+License: MIT
+License File: vendor/nunomaduro/termwind/LICENSE.md
+Copyright: Copyright (c) Nuno Maduro <***********@*****.***>
+Source: https://github.com/nunomaduro/termwind.git
+Link: https://github.com/nunomaduro/termwind.git
+-----------
+onelogin/php-saml
+License: MIT
+License File: vendor/onelogin/php-saml/LICENSE
+Copyright: Copyright (c) 2010-2016 OneLogin, Inc.
+Source: https://github.com/onelogin/php-saml.git
+Link: https://developers.onelogin.com/saml/php
+-----------
+paragonie/constant_time_encoding
+License: MIT
+License File: vendor/paragonie/constant_time_encoding/LICENSE.txt
+Copyright: Copyright (c) 2016 - 2022 Paragon Initiative Enterprises
+Source: https://github.com/paragonie/constant_time_encoding.git
+Link: https://github.com/paragonie/constant_time_encoding.git
+-----------
+paragonie/random_compat
+License: MIT
+License File: vendor/paragonie/random_compat/LICENSE
+Copyright: Copyright (c) 2015 Paragon Initiative Enterprises
+Source: https://github.com/paragonie/random_compat.git
+Link: https://github.com/paragonie/random_compat.git
+-----------
+phenx/php-font-lib
+License: LGPL-2.1-or-later
+License File: vendor/phenx/php-font-lib/LICENSE
+Copyright: Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+Source: https://github.com/dompdf/php-font-lib.git
+Link: https://github.com/PhenX/php-font-lib
+-----------
+phenx/php-svg-lib
+License: LGPL-3.0-or-later
+License File: vendor/phenx/php-svg-lib/LICENSE
+Copyright: Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+Source: https://github.com/dompdf/php-svg-lib.git
+Link: https://github.com/PhenX/php-svg-lib
+-----------
+phpoption/phpoption
+License: Apache-2.0
+License File: vendor/phpoption/phpoption/LICENSE
+Source: https://github.com/schmittjoh/php-option.git
+Link: https://github.com/schmittjoh/php-option.git
+-----------
+phpseclib/phpseclib
+License: MIT
+License File: vendor/phpseclib/phpseclib/LICENSE
+Copyright: Copyright (c) 2011-2019 TerraFrost and other contributors
+Source: https://github.com/phpseclib/phpseclib.git
+Link: http://phpseclib.sourceforge.net
+-----------
+pragmarx/google2fa
+License: MIT
+License File: vendor/pragmarx/google2fa/LICENSE.md
+Copyright: Copyright 2014-2018 Phil, Antonio Carlos Ribeiro and All Contributors
+Source: https://github.com/antonioribeiro/google2fa.git
+Link: https://github.com/antonioribeiro/google2fa.git
+-----------
+predis/predis
+License: MIT
+License File: vendor/predis/predis/LICENSE
+Copyright: Copyright (c) 2009-2020 Daniele Alessandri (original work)
+Copyright (c) 2021-2023 Till Krüss (modified work)
+Source: https://github.com/predis/predis.git
+Link: http://github.com/predis/predis
+-----------
+psr/cache
+License: MIT
+License File: vendor/psr/cache/LICENSE.txt
+Copyright: Copyright (c) 2015 PHP Framework Interoperability Group
+Source: https://github.com/php-fig/cache.git
+Link: https://github.com/php-fig/cache.git
+-----------
+psr/clock
+License: MIT
+License File: vendor/psr/clock/LICENSE
+Copyright: Copyright (c) 2017 PHP Framework Interoperability Group
+Source: https://github.com/php-fig/clock.git
+Link: https://github.com/php-fig/clock
+-----------
+psr/container
+License: MIT
+License File: vendor/psr/container/LICENSE
+Copyright: Copyright (c) 2013-2016 container-interop
+Copyright (c) 2016 PHP Framework Interoperability Group
+Source: https://github.com/php-fig/container.git
+Link: https://github.com/php-fig/container
+-----------
+psr/event-dispatcher
+License: MIT
+License File: vendor/psr/event-dispatcher/LICENSE
+Copyright: Copyright (c) 2018 PHP-FIG
+Source: https://github.com/php-fig/event-dispatcher.git
+Link: https://github.com/php-fig/event-dispatcher.git
+-----------
+psr/http-client
+License: MIT
+License File: vendor/psr/http-client/LICENSE
+Copyright: Copyright (c) 2017 PHP Framework Interoperability Group
+Source: https://github.com/php-fig/http-client.git
+Link: https://github.com/php-fig/http-client
+-----------
+psr/http-factory
+License: MIT
+License File: vendor/psr/http-factory/LICENSE
+Copyright: Copyright (c) 2018 PHP-FIG
+Source: https://github.com/php-fig/http-factory.git
+Link: https://github.com/php-fig/http-factory.git
+-----------
+psr/http-message
+License: MIT
+License File: vendor/psr/http-message/LICENSE
+Copyright: Copyright (c) 2014 PHP Framework Interoperability Group
+Source: https://github.com/php-fig/http-message.git
+Link: https://github.com/php-fig/http-message
+-----------
+psr/log
+License: MIT
+License File: vendor/psr/log/LICENSE
+Copyright: Copyright (c) 2012 PHP Framework Interoperability Group
+Source: https://github.com/php-fig/log.git
+Link: https://github.com/php-fig/log
+-----------
+psr/simple-cache
+License: MIT
+License File: vendor/psr/simple-cache/LICENSE.md
+Copyright: Copyright (c) 2016 PHP Framework Interoperability Group
+Source: https://github.com/php-fig/simple-cache.git
+Link: https://github.com/php-fig/simple-cache.git
+-----------
+psy/psysh
+License: MIT
+License File: vendor/psy/psysh/LICENSE
+Copyright: Copyright (c) 2012-2023 Justin Hileman
+Source: https://github.com/bobthecow/psysh.git
+Link: http://psysh.org
+-----------
+ralouphie/getallheaders
+License: MIT
+License File: vendor/ralouphie/getallheaders/LICENSE
+Copyright: Copyright (c) 2014 Ralph Khattar
+Source: https://github.com/ralouphie/getallheaders.git
+Link: https://github.com/ralouphie/getallheaders.git
+-----------
+ramsey/collection
+License: MIT
+License File: vendor/ramsey/collection/LICENSE
+Copyright: Copyright (c) 2015-2022 Ben Ramsey <***@*********.***>
+Source: https://github.com/ramsey/collection.git
+Link: https://github.com/ramsey/collection.git
+-----------
+ramsey/uuid
+License: MIT
+License File: vendor/ramsey/uuid/LICENSE
+Copyright: Copyright (c) 2012-2023 Ben Ramsey <***@*********.***>
+Source: https://github.com/ramsey/uuid.git
+Link: https://github.com/ramsey/uuid.git
+-----------
+robrichards/xmlseclibs
+License: BSD-3-Clause
+License File: vendor/robrichards/xmlseclibs/LICENSE
+Copyright: Copyright (c) 2007-2019, Robert Richards <*********@*********.***>.
+Source: https://github.com/robrichards/xmlseclibs.git
+Link: https://github.com/robrichards/xmlseclibs
+-----------
+sabberworm/php-css-parser
+License: MIT
+License File: vendor/sabberworm/php-css-parser/LICENSE
+Copyright: Copyright (c) 2011 Raphael Schweikert, https://www.sabberworm.com/
+Source: https://github.com/MyIntervals/PHP-CSS-Parser.git
+Link: https://www.sabberworm.com/blog/2010/6/10/php-css-parser
+-----------
+socialiteproviders/discord
+License: MIT
+Source: https://github.com/SocialiteProviders/Discord.git
+Link: https://github.com/SocialiteProviders/Discord.git
+-----------
+socialiteproviders/gitlab
+License: MIT
+Source: https://github.com/SocialiteProviders/GitLab.git
+Link: https://github.com/SocialiteProviders/GitLab.git
+-----------
+socialiteproviders/manager
+License: MIT
+License File: vendor/socialiteproviders/manager/LICENSE
+Copyright: Copyright (c) 2015 Andy Wendt
+Source: https://github.com/SocialiteProviders/Manager.git
+Link: https://socialiteproviders.com
+-----------
+socialiteproviders/microsoft-azure
+License: MIT
+Source: https://github.com/SocialiteProviders/Microsoft-Azure.git
+Link: https://github.com/SocialiteProviders/Microsoft-Azure.git
+-----------
+socialiteproviders/okta
+License: MIT
+Source: https://github.com/SocialiteProviders/Okta.git
+Link: https://github.com/SocialiteProviders/Okta.git
+-----------
+socialiteproviders/twitch
+License: MIT
+Source: https://github.com/SocialiteProviders/Twitch.git
+Link: https://github.com/SocialiteProviders/Twitch.git
+-----------
+ssddanbrown/htmldiff
+License: MIT
+License File: vendor/ssddanbrown/htmldiff/license.md
+Copyright: Copyright (c) 2020 Nathan Herald, Rohland de Charmoy, Dan Brown
+Source: https://github.com/ssddanbrown/HtmlDiff.git
+Link: https://github.com/ssddanbrown/htmldiff
+-----------
+ssddanbrown/symfony-mailer
+License: MIT
+License File: vendor/ssddanbrown/symfony-mailer/LICENSE
+Copyright: Copyright (c) 2019-present Fabien Potencier
+Source: https://github.com/ssddanbrown/symfony-mailer.git
+Link: https://symfony.com
+-----------
+symfony/console
+License: MIT
+License File: vendor/symfony/console/LICENSE
+Copyright: Copyright (c) 2004-present Fabien Potencier
+Source: https://github.com/symfony/console.git
+Link: https://symfony.com
+-----------
+symfony/css-selector
+License: MIT
+License File: vendor/symfony/css-selector/LICENSE
+Copyright: Copyright (c) 2004-present Fabien Potencier
+Source: https://github.com/symfony/css-selector.git
+Link: https://symfony.com
+-----------
+symfony/deprecation-contracts
+License: MIT
+License File: vendor/symfony/deprecation-contracts/LICENSE
+Copyright: Copyright (c) 2020-present Fabien Potencier
+Source: https://github.com/symfony/deprecation-contracts.git
+Link: https://symfony.com
+-----------
+symfony/error-handler
+License: MIT
+License File: vendor/symfony/error-handler/LICENSE
+Copyright: Copyright (c) 2019-present Fabien Potencier
+Source: https://github.com/symfony/error-handler.git
+Link: https://symfony.com
+-----------
+symfony/event-dispatcher
+License: MIT
+License File: vendor/symfony/event-dispatcher/LICENSE
+Copyright: Copyright (c) 2004-present Fabien Potencier
+Source: https://github.com/symfony/event-dispatcher.git
+Link: https://symfony.com
+-----------
+symfony/event-dispatcher-contracts
+License: MIT
+License File: vendor/symfony/event-dispatcher-contracts/LICENSE
+Copyright: Copyright (c) 2018-present Fabien Potencier
+Source: https://github.com/symfony/event-dispatcher-contracts.git
+Link: https://symfony.com
+-----------
+symfony/finder
+License: MIT
+License File: vendor/symfony/finder/LICENSE
+Copyright: Copyright (c) 2004-present Fabien Potencier
+Source: https://github.com/symfony/finder.git
+Link: https://symfony.com
+-----------
+symfony/http-foundation
+License: MIT
+License File: vendor/symfony/http-foundation/LICENSE
+Copyright: Copyright (c) 2004-present Fabien Potencier
+Source: https://github.com/symfony/http-foundation.git
+Link: https://symfony.com
+-----------
+symfony/http-kernel
+License: MIT
+License File: vendor/symfony/http-kernel/LICENSE
+Copyright: Copyright (c) 2004-present Fabien Potencier
+Source: https://github.com/symfony/http-kernel.git
+Link: https://symfony.com
+-----------
+symfony/mime
+License: MIT
+License File: vendor/symfony/mime/LICENSE
+Copyright: Copyright (c) 2010-present Fabien Potencier
+Source: https://github.com/symfony/mime.git
+Link: https://symfony.com
+-----------
+symfony/polyfill-ctype
+License: MIT
+License File: vendor/symfony/polyfill-ctype/LICENSE
+Copyright: Copyright (c) 2018-present Fabien Potencier
+Source: https://github.com/symfony/polyfill-ctype.git
+Link: https://symfony.com
+-----------
+symfony/polyfill-intl-grapheme
+License: MIT
+License File: vendor/symfony/polyfill-intl-grapheme/LICENSE
+Copyright: Copyright (c) 2015-present Fabien Potencier
+Source: https://github.com/symfony/polyfill-intl-grapheme.git
+Link: https://symfony.com
+-----------
+symfony/polyfill-intl-idn
+License: MIT
+License File: vendor/symfony/polyfill-intl-idn/LICENSE
+Copyright: Copyright (c) 2018-present Fabien Potencier and Trevor Rowbotham <******.*********@**.**>
+Source: https://github.com/symfony/polyfill-intl-idn.git
+Link: https://symfony.com
+-----------
+symfony/polyfill-intl-normalizer
+License: MIT
+License File: vendor/symfony/polyfill-intl-normalizer/LICENSE
+Copyright: Copyright (c) 2015-present Fabien Potencier
+Source: https://github.com/symfony/polyfill-intl-normalizer.git
+Link: https://symfony.com
+-----------
+symfony/polyfill-mbstring
+License: MIT
+License File: vendor/symfony/polyfill-mbstring/LICENSE
+Copyright: Copyright (c) 2015-present Fabien Potencier
+Source: https://github.com/symfony/polyfill-mbstring.git
+Link: https://symfony.com
+-----------
+symfony/polyfill-php72
+License: MIT
+License File: vendor/symfony/polyfill-php72/LICENSE
+Copyright: Copyright (c) 2015-present Fabien Potencier
+Source: https://github.com/symfony/polyfill-php72.git
+Link: https://symfony.com
+-----------
+symfony/polyfill-php80
+License: MIT
+License File: vendor/symfony/polyfill-php80/LICENSE
+Copyright: Copyright (c) 2020-present Fabien Potencier
+Source: https://github.com/symfony/polyfill-php80.git
+Link: https://symfony.com
+-----------
+symfony/polyfill-php83
+License: MIT
+License File: vendor/symfony/polyfill-php83/LICENSE
+Copyright: Copyright (c) 2022-present Fabien Potencier
+Source: https://github.com/symfony/polyfill-php83.git
+Link: https://symfony.com
+-----------
+symfony/polyfill-uuid
+License: MIT
+License File: vendor/symfony/polyfill-uuid/LICENSE
+Copyright: Copyright (c) 2018-present Fabien Potencier
+Source: https://github.com/symfony/polyfill-uuid.git
+Link: https://symfony.com
+-----------
+symfony/process
+License: MIT
+License File: vendor/symfony/process/LICENSE
+Copyright: Copyright (c) 2004-present Fabien Potencier
+Source: https://github.com/symfony/process.git
+Link: https://symfony.com
+-----------
+symfony/routing
+License: MIT
+License File: vendor/symfony/routing/LICENSE
+Copyright: Copyright (c) 2004-present Fabien Potencier
+Source: https://github.com/symfony/routing.git
+Link: https://symfony.com
+-----------
+symfony/service-contracts
+License: MIT
+License File: vendor/symfony/service-contracts/LICENSE
+Copyright: Copyright (c) 2018-present Fabien Potencier
+Source: https://github.com/symfony/service-contracts.git
+Link: https://symfony.com
+-----------
+symfony/string
+License: MIT
+License File: vendor/symfony/string/LICENSE
+Copyright: Copyright (c) 2019-present Fabien Potencier
+Source: https://github.com/symfony/string.git
+Link: https://symfony.com
+-----------
+symfony/translation
+License: MIT
+License File: vendor/symfony/translation/LICENSE
+Copyright: Copyright (c) 2004-present Fabien Potencier
+Source: https://github.com/symfony/translation.git
+Link: https://symfony.com
+-----------
+symfony/translation-contracts
+License: MIT
+License File: vendor/symfony/translation-contracts/LICENSE
+Copyright: Copyright (c) 2018-present Fabien Potencier
+Source: https://github.com/symfony/translation-contracts.git
+Link: https://symfony.com
+-----------
+symfony/uid
+License: MIT
+License File: vendor/symfony/uid/LICENSE
+Copyright: Copyright (c) 2020-present Fabien Potencier
+Source: https://github.com/symfony/uid.git
+Link: https://symfony.com
+-----------
+symfony/var-dumper
+License: MIT
+License File: vendor/symfony/var-dumper/LICENSE
+Copyright: Copyright (c) 2014-present Fabien Potencier
+Source: https://github.com/symfony/var-dumper.git
+Link: https://symfony.com
+-----------
+tijsverkoyen/css-to-inline-styles
+License: BSD-3-Clause
+License File: vendor/tijsverkoyen/css-to-inline-styles/LICENSE.md
+Copyright: Copyright (c) Tijs Verkoyen. All rights reserved.
+Source: https://github.com/tijsverkoyen/CssToInlineStyles.git
+Link: https://github.com/tijsverkoyen/CssToInlineStyles
+-----------
+vlucas/phpdotenv
+License: BSD-3-Clause
+License File: vendor/vlucas/phpdotenv/LICENSE
+Copyright: Copyright (c) 2014, Graham Campbell.
+Source: https://github.com/vlucas/phpdotenv.git
+Link: https://github.com/vlucas/phpdotenv.git
+-----------
+voku/portable-ascii
+License: MIT
+License File: vendor/voku/portable-ascii/LICENSE.txt
+Copyright: Copyright (C) 2019 Lars Moelleken
+Source: https://github.com/voku/portable-ascii.git
+Link: https://github.com/voku/portable-ascii
+-----------
+webmozart/assert
+License: MIT
+License File: vendor/webmozart/assert/LICENSE
+Copyright: Copyright (c) 2014 Bernhard Schussek
+Source: https://github.com/webmozarts/assert.git
+Link: https://github.com/webmozarts/assert.git

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -276,6 +276,14 @@ return [
     'webhooks_last_errored' => 'Last Errored:',
     'webhooks_last_error_message' => 'Last Error Message:',
 
+    // Licensing
+    'licenses' => 'Licenses',
+    'licenses_desc' => 'This page details license information for BookStack in addition to the projects & libraries that are used within BookStack. Many projects listed may only be used in a development context.',
+    'licenses_bookstack' => 'BookStack License',
+    'licenses_php' => 'PHP Library Licenses',
+    'licenses_js' => 'JavaScript Library Licenses',
+    'licenses_other' => 'Other Licenses',
+    'license_details' => 'License Details',
 
     //! If editing translations files directly please ignore this in all
     //! languages apart from en. Content will be auto-copied from en.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,5 +19,6 @@ parameters:
 
     excludePaths:
         - ./Config/**/*.php
+        - ./dev/**/*.php
 
     checkMissingIterableValueType: false

--- a/readme.md
+++ b/readme.md
@@ -158,3 +158,5 @@ Note: This is not an exhaustive list of all libraries and projects that would be
 * [PHPStan](https://phpstan.org/) & [Larastan](https://github.com/nunomaduro/larastan) - _[MIT](https://github.com/phpstan/phpstan/blob/master/LICENSE) and [MIT](https://github.com/nunomaduro/larastan/blob/master/LICENSE.md)_
 * [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) - _[BSD 3-Clause](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt)_
 * [JakeArchibald/IDB-Keyval](https://github.com/jakearchibald/idb-keyval) - _[Apache-2.0](https://github.com/jakearchibald/idb-keyval/blob/main/LICENCE)_
+
+For a detailed breakdown of the JavaScript & PHP projects imported & used via NPM & composer package managers, along with their licenses, please see the [dev/licensing/js-library-licenses.txt](dev/licensing/js-library-licenses.txt) and [dev/licensing/php-library-licenses.txt](dev/licensing/php-library-licenses.txt) files. 

--- a/resources/views/help/licenses.blade.php
+++ b/resources/views/help/licenses.blade.php
@@ -1,0 +1,64 @@
+@extends('layouts.simple')
+
+@section('body')
+
+    <div class="container small">
+
+        <div class="my-l">&nbsp;</div>
+
+        <div class="card content-wrap auto-height">
+            <h1 class="list-heading">Licenses</h1>
+
+            <p>
+                This page details license information for BookStack in addition to the projects & libraries that are used within BookStack.
+                Many projects listed may only be used in a development context.
+            </p>
+
+            <ul>
+                <li><a href="#bookstack-license">BookStack License</a></li>
+                <li><a href="#php-lib-licenses">PHP Library Licenses</a></li>
+                <li><a href="#js-lib-licenses">JavaScript Library Licenses</a></li>
+                <li><a href="#js-lib-licenses">Other Licenses</a></li>
+            </ul>
+        </div>
+
+        <div id="bookstack-license" class="card content-wrap auto-height">
+            <h3 class="list-heading">BookStack License</h3>
+            <div style="white-space: pre-wrap;" class="mb-m">{{ $license }}</div>
+            <p>BookStack® is a UK registered trade mark of Daniel Brown. </p>
+        </div>
+
+        <div id="php-lib-licenses" class="card content-wrap auto-height">
+            <h3 class="list-heading">PHP Library Licenses</h3>
+            <div style="white-space: pre-wrap;">{{ $phpLibData }}</div>
+        </div>
+
+        <div id="js-lib-licenses" class="card content-wrap auto-height">
+            <h3 class="list-heading">JavaScript Library Licenses</h3>
+            <div style="white-space: pre-wrap;">{{ $jsLibData }}</div>
+        </div>
+
+        <div id="other-licenses" class="card content-wrap auto-height">
+            <h3 class="list-heading">Other Licenses</h3>
+            <div style="white-space: pre-line;">BookStack makes heavy use of PHP:
+                License: PHP License, version 3.01
+                License File: https://www.php.net/license/3_01.txt
+                Copyright: Copyright (c) 1999 - 2019 The PHP Group. All rights reserved.
+                Link: https://www.php.net/
+                -----------
+                BookStack uses Icons from Google Material Icons:
+                License: Apache License Version 2.0
+                License File: https://github.com/google/material-design-icons/blob/master/LICENSE
+                Copyright: Copyright 2020 Google LLC
+                Link: https://github.com/google/material-design-icons
+                -----------
+                BookStack is distributed with TinyMCE:
+                License: MIT
+                License File: https://github.com/tinymce/tinymce/blob/release/6.7/LICENSE.TXT
+                Copyright: Copyright (c) 2022 Ephox Corporation DBA Tiny Technologies, Inc.
+                Link: https://github.com/tinymce/tinymce
+            </div>
+        </div>
+    </div>
+
+@endsection

--- a/resources/views/help/licenses.blade.php
+++ b/resources/views/help/licenses.blade.php
@@ -7,39 +7,36 @@
         <div class="my-l">&nbsp;</div>
 
         <div class="card content-wrap auto-height">
-            <h1 class="list-heading">Licenses</h1>
 
-            <p>
-                This page details license information for BookStack in addition to the projects & libraries that are used within BookStack.
-                Many projects listed may only be used in a development context.
-            </p>
+            <h1 class="list-heading">{{ trans('settings.licenses') }}</h1>
+            <p>{{ trans('settings.licenses_desc') }}</p>
 
             <ul>
-                <li><a href="#bookstack-license">BookStack License</a></li>
-                <li><a href="#php-lib-licenses">PHP Library Licenses</a></li>
-                <li><a href="#js-lib-licenses">JavaScript Library Licenses</a></li>
-                <li><a href="#js-lib-licenses">Other Licenses</a></li>
+                <li><a href="#bookstack-license">{{ trans('settings.licenses_bookstack') }}</a></li>
+                <li><a href="#php-lib-licenses">{{ trans('settings.licenses_php') }}</a></li>
+                <li><a href="#js-lib-licenses">{{ trans('settings.licenses_js') }}</a></li>
+                <li><a href="#other-licenses">{{ trans('settings.licenses_other') }}</a></li>
             </ul>
         </div>
 
         <div id="bookstack-license" class="card content-wrap auto-height">
-            <h3 class="list-heading">BookStack License</h3>
+            <h3 class="list-heading">{{ trans('settings.licenses_bookstack') }}</h3>
             <div style="white-space: pre-wrap;" class="mb-m">{{ $license }}</div>
             <p>BookStack® is a UK registered trade mark of Daniel Brown. </p>
         </div>
 
         <div id="php-lib-licenses" class="card content-wrap auto-height">
-            <h3 class="list-heading">PHP Library Licenses</h3>
+            <h3 class="list-heading">{{ trans('settings.licenses_php') }}</h3>
             <div style="white-space: pre-wrap;">{{ $phpLibData }}</div>
         </div>
 
         <div id="js-lib-licenses" class="card content-wrap auto-height">
-            <h3 class="list-heading">JavaScript Library Licenses</h3>
+            <h3 class="list-heading">{{ trans('settings.licenses_js') }}</h3>
             <div style="white-space: pre-wrap;">{{ $jsLibData }}</div>
         </div>
 
         <div id="other-licenses" class="card content-wrap auto-height">
-            <h3 class="list-heading">Other Licenses</h3>
+            <h3 class="list-heading">{{ trans('settings.licenses_other') }}</h3>
             <div style="white-space: pre-line;">BookStack makes heavy use of PHP:
                 License: PHP License, version 3.01
                 License File: https://www.php.net/license/3_01.txt

--- a/resources/views/settings/layout.blade.php
+++ b/resources/views/settings/layout.blade.php
@@ -18,8 +18,10 @@
                 <h5 class="mt-xl">{{ trans('settings.system_version') }}</h5>
                 <div class="py-xs">
                     <a target="_blank" rel="noopener noreferrer" href="https://github.com/BookStackApp/BookStack/releases">
-                        BookStack @if(strpos($version, 'v') !== 0) version @endif {{ $version }}
+                        BookStack @if(!str_starts_with($version, 'v')) version @endif {{ $version }}
                     </a>
+                    <br>
+                    <a target="_blank" href="{{ url('/licenses') }}" class="text-muted">{{ trans('settings.license_details') }}</a>
                 </div>
             </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use BookStack\Activity\Controllers as ActivityControllers;
 use BookStack\Api\ApiDocsController;
 use BookStack\Api\UserApiTokenController;
 use BookStack\App\HomeController;
+use BookStack\App\MetaController;
 use BookStack\Entities\Controllers as EntityControllers;
 use BookStack\Http\Middleware\VerifyCsrfToken;
 use BookStack\Permissions\PermissionsController;
@@ -18,9 +19,10 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 Route::get('/status', [SettingControllers\StatusController::class, 'show']);
-Route::get('/robots.txt', [HomeController::class, 'robots']);
-Route::get('/favicon.ico', [HomeController::class, 'favicon']);
-Route::get('/manifest.json', [HomeController::class, 'pwaManifest']);
+Route::get('/robots.txt', [MetaController::class, 'robots']);
+Route::get('/favicon.ico', [MetaController::class, 'favicon']);
+Route::get('/manifest.json', [MetaController::class, 'pwaManifest']);
+Route::get('/licenses', [MetaController::class, 'licenses']);
 
 // Authenticated routes...
 Route::middleware('auth')->group(function () {
@@ -350,4 +352,4 @@ Route::post('/password/reset', [AccessControllers\ResetPasswordController::class
 // Metadata routes
 Route::view('/help/wysiwyg', 'help.wysiwyg');
 
-Route::fallback([HomeController::class, 'notFound'])->name('fallback');
+Route::fallback([MetaController::class, 'notFound'])->name('fallback');

--- a/tests/LicensesTest.php
+++ b/tests/LicensesTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests;
+
+class LicensesTest extends TestCase
+{
+    public function test_licenses_endpoint()
+    {
+        $resp = $this->get('/licenses');
+        $resp->assertOk();
+        $resp->assertSee('Licenses');
+        $resp->assertSee('PHP Library Licenses');
+        $resp->assertSee('Dan Brown and the BookStack Project contributors');
+        $resp->assertSee('doctrine/dbal');
+        $resp->assertSee('@codemirror/lang-html');
+    }
+
+    public function test_licenses_linked_to_from_settings()
+    {
+        $resp = $this->asAdmin()->get('/settings/features');
+        $html = $this->withHtml($resp);
+        $html->assertLinkExists(url('/licenses'), 'License Details');
+    }
+}


### PR DESCRIPTION
This PR aims to improve the transparency & clarity of the project dependencies and their licenses, and provides a standard & direct manner of attribution across all project dependencies. 

### Changes

- [x] Script listing of PHP dep licenses
- [x] Script listing of JS dep licenses
- [x] Add overall licensing info page, with other details for libraries not listed via direct deps like:
  - PHP
  - TinyMCE
  - Material Icons
  - [x] Extract text to translations (Titles/into text, not body content).
  - [x] Add tests to cover (Page exists, Link to page)
- [x] Add neatly into app somewhere (Below version information)
- [x] Add reference to license/attribution list in built source files
- [x] Update licensing/attribution info in readme to refer to new files
- [x] Build updating of deps lists into process somehow.
  - Added a composer command, which is added to release steps.