### PR TITLE
Honeypot against Bot registrations

### DIFF
--- a/app/Access/Controllers/RegisterController.php
+++ b/app/Access/Controllers/RegisterController.php
@@ -87,6 +87,7 @@ class RegisterController extends Controller
             'name'     => ['required', 'min:2', 'max:100'],
             'email'    => ['required', 'email', 'max:255', 'unique:users'],
             'password' => ['required', Password::default()],
+            'username' => ['prohibited'], // this is a honeypot for bots that must not be filled in
         ]);
     }
 }

--- a/resources/sass/_forms.scss
+++ b/resources/sass/_forms.scss
@@ -400,7 +400,7 @@ input[type=color] {
     border:none !important;
     overflow: hidden !important;
     clip: rect(0,0,0,0) !important;
-	white-space: nowrap !important;
+    white-space: nowrap !important;
 }
 
 .title-input input[type="text"] {

--- a/resources/sass/_forms.scss
+++ b/resources/sass/_forms.scss
@@ -389,6 +389,17 @@ input[type=color] {
   }
 }
 
+.form-group.ambrosia-container, .form-group.ambrosia-container * {
+    position:absolute;
+    height:0px !important;
+    width:0px !important;
+    margin:0 !important;
+    padding:0 !important;
+    background:transparent !important;
+    color:transparent !important;
+    border:none !important;
+}
+
 .title-input input[type="text"] {
   display: block;
   width: 100%;

--- a/resources/sass/_forms.scss
+++ b/resources/sass/_forms.scss
@@ -390,14 +390,17 @@ input[type=color] {
 }
 
 .form-group.ambrosia-container, .form-group.ambrosia-container * {
-    position:absolute;
-    height:0px !important;
-    width:0px !important;
-    margin:0 !important;
+    position:absolute !important;
+    height:1px !important;
+    width:1px !important;
+    margin:-1px !important;
     padding:0 !important;
     background:transparent !important;
     color:transparent !important;
     border:none !important;
+    overflow: hidden !important;
+    clip: rect(0,0,0,0) !important;
+	white-space: nowrap !important;
 }
 
 .title-input input[type="text"] {

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -14,7 +14,7 @@
                 {!! csrf_field() !!}
 
                 <div class="form-group">
-                    <label for="email">{{ trans('auth.name') }}</label>
+                    <label for="name">{{ trans('auth.name') }}</label>
                     @include('form.text', ['name' => 'name'])
                 </div>
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -13,7 +13,7 @@
             <form action="{{ url("/register") }}" method="POST" class="mt-l stretch-inputs">
                 {!! csrf_field() !!}
 
-                <div class="form-group ambrosia-container">
+                <div class="form-group ambrosia-container" aria-hidden="true">
                     <label for="name">{{ trans('auth.name') }}</label>
                     @include('form.text', ['name' => 'username'])
                 </div>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -13,6 +13,11 @@
             <form action="{{ url("/register") }}" method="POST" class="mt-l stretch-inputs">
                 {!! csrf_field() !!}
 
+                <div class="form-group ambrosia-container">
+                    <label for="name">{{ trans('auth.name') }}</label>
+                    @include('form.text', ['name' => 'username'])
+                </div>
+
                 <div class="form-group">
                     <label for="name">{{ trans('auth.name') }}</label>
                     @include('form.text', ['name' => 'name'])


### PR DESCRIPTION
This PR introduces a form-field named "username" to the registration form. This field must not be filled, but it acts as a honeypot for bots. If it is filled the Validator of RegisterController would invalidate a registration attempt. To the human viewer the honeypot is made invisible through css.

The CSS deliberately omits `display:none` because it can be assumed that bots would easily recognize this. Instead it used a similar CSS like Bootstraps visually-hidden class.

Caveat: To ensure that the form remains accessible, aria-hidden=true is used to tell screenreaders to ignore the honeypot. Bots may be programmed intelligently enough to recognize the attribute and ignore the field. But I do think that accessibility comes first and I haven't seen a bot that recognizes aria-hidden yet

