### PR TITLE
remove space at the beginning of description

### DIFF
--- a/lang/en/preferences.php
+++ b/lang/en/preferences.php
@@ -27,7 +27,7 @@ return [
     'notifications_save' => 'Save Preferences',
     'notifications_update_success' => 'Notification preferences have been updated!',
     'notifications_watched' => 'Watched & Ignored Items',
-    'notifications_watched_desc' => ' Below are the items that have custom watch preferences applied. To update your preferences for these, view the item then find the watch options in the sidebar.',
+    'notifications_watched_desc' => 'Below are the items that have custom watch preferences applied. To update your preferences for these, view the item then find the watch options in the sidebar.',
 
     'auth' => 'Access & Security',
     'auth_change_password' => 'Change Password',


### PR DESCRIPTION
I notice that there is a space at the beginning of description. It maybe a typo.

Please re-confirm the changes at language file. Thanks.