### PR TITLE
Fixed incorrect code shortcut reference

### DIFF
--- a/resources/views/help/wysiwyg.blade.php
+++ b/resources/views/help/wysiwyg.blade.php
@@ -98,11 +98,11 @@
             </tr>
             <tr>
                 <td>
-                    <code>Ctrl</code>+<code>Shift</code>+<code>8</code><br>
+                    <code>Ctrl</code>+<code>8</code><br>
                     <code>Ctrl</code>+<code>Shift</code>+<code>E</code>
                 </td>
                 <td>
-                    <code>Cmd</code>+<code>Shift</code>+<code>8</code><br>
+                    <code>Cmd</code>+<code>8</code><br>
                     <code>Cmd</code>+<code>Shift</code>+<code>E</code>
                 </td>
                 <td>{{ trans('editor.inline_code') }}</td>


### PR DESCRIPTION
I believe I have identified a small error in the TinyMCE shortcut description for insert inline code.

Ctrl+8 instead of Ctrl+Shift+8

I assume Mac is the same but I do not have a Mac to test with.