### PR TITLE
Add ALLOWED_IFRAME_SOURCES to phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,7 @@
     <server name="APP_AUTO_LANG_PUBLIC" value="true"/>
     <server name="APP_URL" value="http://bookstack.dev"/>
     <server name="ALLOWED_IFRAME_HOSTS" value=""/>
+    <server name="ALLOWED_IFRAME_SOURCES" value="https://*.draw.io https://*.youtube.com https://*.youtube-nocookie.com https://*.vimeo.com"/>
     <server name="ALLOWED_SSR_HOSTS" value="*"/>
     <server name="CACHE_DRIVER" value="array"/>
     <server name="SESSION_DRIVER" value="array"/>


### PR DESCRIPTION
Fix for bug #5068
test_frame_src_csp_header_set fails when .env-file has customized ALLOWED_IFRAME_SOURCES