### PR TITLE
Fix draw.io/diagrams.net "export" function

### DIFF
--- a/app/Util/CspService.php
+++ b/app/Util/CspService.php
@@ -143,6 +143,7 @@ class CspService
             $drawioSourceParsed = parse_url($drawioSource);
             $drawioHost = $drawioSourceParsed['scheme'] . '://' . $drawioSourceParsed['host'];
             $hosts[] = $drawioHost;
+            $hosts[] = 'blob:';
         }
 
         return $hosts;

--- a/tests/SecurityHeaderTest.php
+++ b/tests/SecurityHeaderTest.php
@@ -136,7 +136,7 @@ class SecurityHeaderTest extends TestCase
 
         $resp = $this->get('/');
         $scriptHeader = $this->getCspHeader($resp, 'frame-src');
-        $this->assertEquals('frame-src \'self\' https://example.com https://diagrams.example.com', $scriptHeader);
+        $this->assertEquals('frame-src \'self\' https://example.com https://diagrams.example.com blob:', $scriptHeader);
     }
 
     public function test_cache_control_headers_are_set_on_responses()


### PR DESCRIPTION
Exporting a diagram is done using the "blob:" scheme. This is not allowed by the current CSP. Add it automatically when we have draw.io/diagrams.net integration enabled.

Fix #4710