### PR TITLE
Add popularity sorting options for books

### DIFF
--- a/app/Entities/Controllers/BookController.php
+++ b/app/Entities/Controllers/BookController.php
@@ -44,11 +44,19 @@ class BookController extends Controller
             'name' => trans('common.sort_name'),
             'created_at' => trans('common.sort_created_at'),
             'updated_at' => trans('common.sort_updated_at'),
+            'view_count' => trans('common.sort_popularity'), 
         ]);
 
-        $books = $this->queries->visibleForListWithCover()
-            ->orderBy($listOptions->getSort(), $listOptions->getOrder())
-            ->paginate(18);
+        $booksQuery = $this->queries->visibleForListWithCover();
+
+        if ($listOptions->getSort() === 'view_count') {
+            $booksQuery->scopes('withViewCount')->orderBy('view_count', $listOptions->getOrder());
+        } else {
+            $booksQuery->orderBy($listOptions->getSort(), $listOptions->getOrder());
+        }
+
+        $books = $booksQuery->paginate(18);
+
         $recents = $this->isSignedIn() ? $this->queries->recentlyViewedForCurrentUser()->take(4)->get() : false;
         $popular = $this->queries->popularForList()->take(4)->get();
         $new = $this->queries->visibleForList()->orderBy('created_at', 'desc')->take(4)->get();

--- a/lang/en/common.php
+++ b/lang/en/common.php
@@ -63,6 +63,7 @@ return [
     'sort_default' => 'Default',
     'sort_created_at' => 'Created Date',
     'sort_updated_at' => 'Updated Date',
+    'sort_popularity' => 'Popularity',
 
     // Misc
     'deleted_user' => 'Deleted User',

--- a/tests/Entity/BookSortingTest.php
+++ b/tests/Entity/BookSortingTest.php
@@ -7,11 +7,8 @@ use BookStack\Users\Models\Role;
 use Tests\TestCase;
 use Symfony\Component\DomCrawler\Crawler;
 
-
 class BookSortingTest extends TestCase
 {
-
-
     public function test_update_sort_preference()
     {
         // Step 1: Set up the test environment
@@ -122,15 +119,12 @@ class BookSortingTest extends TestCase
         $this->assertBooksOrder($response->content(), $allBooks->sortByDesc('view_count')->pluck('name')->toArray());
     }
 
-
     private function assertBooksOrder($htmlContent, $expectedOrder)
     {
         $crawler = new Crawler($htmlContent);
         $bookNames = $crawler->filter('.grid-card-content h2.text-limit-lines-2')->each(function (Crawler $node) {
             return $node->text();
         });
-        print_r($expectedOrder);
-print_r($bookNames);
         $this->assertEquals($expectedOrder, $bookNames);
     }
 }

--- a/tests/Entity/BookSortingTest.php
+++ b/tests/Entity/BookSortingTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Entity;
+
+use BookStack\Entities\Models\Book;
+use BookStack\Users\Models\Role;
+use Tests\TestCase;
+use Symfony\Component\DomCrawler\Crawler;
+
+
+class BookSortingTest extends TestCase
+{
+
+
+    public function test_update_sort_preference()
+    {
+        // Step 1: Set up the test environment
+        $editor = $this->users->editor();
+        $this->actingAs($editor);
+
+        // Step 2: Send a PATCH request to the endpoint
+        $updateRequest = $this->patch('/preferences/change-sort/books', [
+            'sort'  => 'created_at',
+            'order' => 'desc',
+        ]);
+
+        // Step 3: Assert the response status
+        $updateRequest->assertStatus(302);
+
+        // Step 4: Verify database changes
+        $this->assertDatabaseHas('settings', [
+            'setting_key' => 'user:' . $editor->id . ':books_sort',
+            'value'       => 'created_at',
+        ]);
+        $this->assertDatabaseHas('settings', [
+            'setting_key' => 'user:' . $editor->id . ':books_sort_order',
+            'value'       => 'desc',
+        ]);
+
+        // Step 5: Check user settings
+        $this->assertEquals('created_at', setting()->getForCurrentUser('books_sort'));
+        $this->assertEquals('desc', setting()->getForCurrentUser('books_sort_order'));
+        
+        // Step 6: Check the order of books on the page
+        $response = $this->get('/books');
+        $response->assertStatus(200);
+        $allBooks = Book::all();
+        $this->assertBooksOrder($response->content(), $allBooks->sortByDesc('created_at')->pluck('name')->toArray());
+    }
+
+    // Test with different sort fields and orders
+    public function test_update_sort_preference_with_different_fields_and_orders()
+    {
+        // Step 1: Set up the test environment
+        $editor = $this->users->editor();
+        $this->actingAs($editor);
+        
+        // Step 2: Send a PATCH request to the endpoint with different sort field and order
+        $updateRequest = $this->patch('/preferences/change-sort/books', [
+            'sort'  => 'updated_at',
+            'order' => 'asc',
+        ]);
+        
+        // Step 3: Assert the response status
+        $updateRequest->assertStatus(302);
+        
+        // Step 4: Verify database changes for the new sort field and order
+        $this->assertDatabaseHas('settings', [
+            'setting_key' => 'user:' . $editor->id . ':books_sort',
+            'value'       => 'updated_at',
+        ]);
+        $this->assertDatabaseHas('settings', [
+            'setting_key' => 'user:' . $editor->id . ':books_sort_order',
+            'value'       => 'asc',
+        ]);
+        
+        // Step 5: Check user settings for the updated sort field and order
+        $this->assertEquals('updated_at', setting()->getForCurrentUser('books_sort'));
+        $this->assertEquals('asc', setting()->getForCurrentUser('books_sort_order'));
+
+        // Step 6: Check the order of books on the page
+        $response = $this->get('/books');
+        $response->assertStatus(200);
+        $allBooks = Book::all();
+        $this->assertBooksOrder($response->content(), $allBooks->sortBy('updated_at')->pluck('name')->toArray());
+    }
+
+    // Test the sort field popularity
+    public function test_sort_by_popularity()
+    {
+        // Step 1: Set up the test environment
+        $editor = $this->users->editor();
+        $this->actingAs($editor);
+        
+        // Step 2: Send a PATCH request to the endpoint with sort field popularity
+        $updateRequest = $this->patch('/preferences/change-sort/books', [
+            'sort'  => 'view_count',
+            'order' => 'desc',
+        ]);
+        
+        // Step 3: Assert the response status
+        $updateRequest->assertStatus(302);
+        
+        // Step 4: Verify database changes for the sort field popularity
+        $this->assertDatabaseHas('settings', [
+            'setting_key' => 'user:' . $editor->id . ':books_sort',
+            'value'       => 'view_count',
+        ]);
+        $this->assertDatabaseHas('settings', [
+            'setting_key' => 'user:' . $editor->id . ':books_sort_order',
+            'value'       => 'desc',
+        ]);
+        
+        // Step 5: Check user settings for the sort field popularity
+        $this->assertEquals('view_count', setting()->getForCurrentUser('books_sort'));
+        $this->assertEquals('desc', setting()->getForCurrentUser('books_sort_order'));
+
+        // Step 6: Check the order of books on the page
+        $response = $this->get('/books');
+        $response->assertStatus(200);
+        $allBooks = Book::all();
+        $this->assertBooksOrder($response->content(), $allBooks->sortByDesc('view_count')->pluck('name')->toArray());
+    }
+
+
+    private function assertBooksOrder($htmlContent, $expectedOrder)
+    {
+        $crawler = new Crawler($htmlContent);
+        $bookNames = $crawler->filter('.grid-card-content h2.text-limit-lines-2')->each(function (Crawler $node) {
+            return $node->text();
+        });
+        print_r($expectedOrder);
+print_r($bookNames);
+        $this->assertEquals($expectedOrder, $bookNames);
+    }
+}


### PR DESCRIPTION
Now the user can sort the /books by the view_count. It is the #1712 feature request.

Unit tests are added too.