### PR TITLE
Add OpenSearch support

### DIFF
--- a/app/App/MetaController.php
+++ b/app/App/MetaController.php
@@ -64,4 +64,14 @@ class MetaController extends Controller
             'jsLibData' => file_get_contents(base_path('dev/licensing/js-library-licenses.txt')),
         ]);
     }
+
+    /**
+     * Show the view for /opensearch.xml.
+     */
+    public function opensearch()
+    {
+        return response()
+            ->view('misc.opensearch')
+            ->header('Content-Type', 'application/opensearchdescription+xml');
+    }
 }

--- a/lang/en/common.php
+++ b/lang/en/common.php
@@ -107,4 +107,7 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Privacy Policy',
     'terms_of_service' => 'Terms of Service',
+
+    // OpenSearch
+    'opensearch_description' => 'Search :appName',
 ];

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -32,6 +32,9 @@
     <link rel="manifest" href="{{ url('/manifest.json') }}">
     <meta name="mobile-web-app-capable" content="yes">
 
+    <!-- OpenSearch -->
+    <link rel="search" type="application/opensearchdescription+xml" title="{{ setting('app-name') }}" href="{{ url('/opensearch.xml') }}">
+
     @yield('head')
 
     <!-- Custom Styles & Head Content -->

--- a/resources/views/misc/opensearch.blade.php
+++ b/resources/views/misc/opensearch.blade.php
@@ -1,0 +1,11 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>{{ setting('app-name') }}</ShortName>
+  <Description>Search {{ setting('app-name') }}</Description>
+  <Image width="256" height="256" type="image/png">{{ setting('app-icon') ?: url('/icon.png') }}</Image>
+  <Image width="180" height="180" type="image/png">{{ setting('app-icon-180') ?: url('/icon-180.png') }}</Image>
+  <Image width="128" height="128" type="image/png">{{ setting('app-icon-128') ?: url('/icon-128.png') }}</Image>
+  <Image width="64" height="64" type="image/png">{{ setting('app-icon-64') ?: url('/icon-64.png') }}</Image>
+  <Image width="32" height="32" type="image/png">{{ setting('app-icon-32') ?: url('/icon-32.png') }}</Image>
+  <Url type="text/html" rel="results" method="get" template="{{ url('/search') }}?term={searchTerms}"/>
+  <Url type="application/opensearchdescription+xml" rel="self" template="{{ url('/opensearch.xml') }}"/>
+</OpenSearchDescription>

--- a/resources/views/misc/opensearch.blade.php
+++ b/resources/views/misc/opensearch.blade.php
@@ -6,6 +6,6 @@
   <Image width="128" height="128" type="image/png">{{ setting('app-icon-128') ?: url('/icon-128.png') }}</Image>
   <Image width="64" height="64" type="image/png">{{ setting('app-icon-64') ?: url('/icon-64.png') }}</Image>
   <Image width="32" height="32" type="image/png">{{ setting('app-icon-32') ?: url('/icon-32.png') }}</Image>
-  <Url type="text/html" rel="results" method="get" template="{{ url('/search') }}?term={searchTerms}"/>
+  <Url type="text/html" rel="results" template="{{ url('/search') }}?term={searchTerms}"/>
   <Url type="application/opensearchdescription+xml" rel="self" template="{{ url('/opensearch.xml') }}"/>
 </OpenSearchDescription>

--- a/resources/views/misc/opensearch.blade.php
+++ b/resources/views/misc/opensearch.blade.php
@@ -1,6 +1,6 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
   <ShortName>{{ mb_strimwidth(setting('app-name'), 0, 16) }}</ShortName>
-  <Description>Search {{ setting('app-name') }}</Description>
+  <Description>{{ trans('common.opensearch_description', ['appName' => setting('app-name')]) }}</Description>
   <Image width="256" height="256" type="image/png">{{ setting('app-icon') ?: url('/icon.png') }}</Image>
   <Image width="180" height="180" type="image/png">{{ setting('app-icon-180') ?: url('/icon-180.png') }}</Image>
   <Image width="128" height="128" type="image/png">{{ setting('app-icon-128') ?: url('/icon-128.png') }}</Image>

--- a/resources/views/misc/opensearch.blade.php
+++ b/resources/views/misc/opensearch.blade.php
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
   <ShortName>{{ mb_strimwidth(setting('app-name'), 0, 16) }}</ShortName>
   <Description>{{ trans('common.opensearch_description', ['appName' => setting('app-name')]) }}</Description>

--- a/resources/views/misc/opensearch.blade.php
+++ b/resources/views/misc/opensearch.blade.php
@@ -1,5 +1,5 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-  <ShortName>{{ setting('app-name') }}</ShortName>
+  <ShortName>{{ mb_strimwidth(setting('app-name'), 0, 16) }}</ShortName>
   <Description>Search {{ setting('app-name') }}</Description>
   <Image width="256" height="256" type="image/png">{{ setting('app-icon') ?: url('/icon.png') }}</Image>
   <Image width="180" height="180" type="image/png">{{ setting('app-icon-180') ?: url('/icon-180.png') }}</Image>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ Route::get('/robots.txt', [MetaController::class, 'robots']);
 Route::get('/favicon.ico', [MetaController::class, 'favicon']);
 Route::get('/manifest.json', [MetaController::class, 'pwaManifest']);
 Route::get('/licenses', [MetaController::class, 'licenses']);
+Route::get('/opensearch.xml', [MetaController::class, 'opensearch']);
 
 // Authenticated routes...
 Route::middleware('auth')->group(function () {

--- a/tests/OpensearchTest.php
+++ b/tests/OpensearchTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests;
+
+class OpensearchTest extends TestCase
+{
+    public function test_opensearch_endpoint()
+    {
+        $appName = setting('app-name');
+        $resultUrl = url('/search') . '?term={searchTerms}';
+        $selfUrl = url('/opensearch.xml');
+
+        $resp = $this->get('/opensearch.xml');
+        $resp->assertOk();
+
+        $html = $this->withHtml($resp);
+
+        $html->assertElementExists('OpenSearchDescription > ShortName');
+        $html->assertElementContains('OpenSearchDescription > ShortName', mb_strimwidth($appName, 0, 16));
+
+        $html->assertElementExists('OpenSearchDescription > Description');
+        $html->assertElementContains('OpenSearchDescription > Description', trans('common.opensearch_description', [
+            'appName' => $appName,
+        ]));
+
+        $html->assertElementExists('OpenSearchDescription > Image');
+
+        $html->assertElementExists('OpenSearchDescription > Url[rel="results"][template="' . htmlspecialchars($resultUrl) . '"]');
+        $html->assertElementExists('OpenSearchDescription > Url[rel="self"][template="' . htmlspecialchars($selfUrl) . '"]');
+    }
+
+    public function test_opensearch_linked_to_from_home()
+    {
+        $appName = setting('app-name');
+        $endpointUrl = url('/opensearch.xml');
+
+        $resp = $this->asViewer()->get('/');
+        $html = $this->withHtml($resp);
+
+        $html->assertElementExists('head > link[rel="search"][type="application/opensearchdescription+xml"][title="' . htmlspecialchars($appName) . '"][href="' . htmlspecialchars($endpointUrl) . '"]');
+    }
+}


### PR DESCRIPTION
Add XML-file and HTML meta-tag so browsers can autodiscover the search of BookStack instances. See:

https://developer.mozilla.org/en-US/docs/Web/OpenSearch

Closes BookStackApp/BookStack#5122