### PR TITLE
Add the option for new books to inherit permissions when created

### DIFF
--- a/app/Entities/Models/Bookshelf.php
+++ b/app/Entities/Models/Bookshelf.php
@@ -17,7 +17,7 @@ class Bookshelf extends Entity implements HasCoverImage
 
     public float $searchFactor = 1.2;
 
-    protected $fillable = ['name', 'description', 'image_id'];
+    protected $fillable = ['name', 'description', 'image_id', 'new_books_inherit_perms'];
 
     protected $hidden = ['image_id', 'deleted_at', 'description_html'];
 

--- a/database/migrations/2024_09_12_204800_add_new_books_inherit_perms_to_bookshelves.php
+++ b/database/migrations/2024_09_12_204800_add_new_books_inherit_perms_to_bookshelves.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('bookshelves', function (Blueprint $table) {
+            $table->boolean('new_books_inherit_perms')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('bookshelves', function (Blueprint $table) {
+            $table->dropColumn('new_books_inherit_perms');
+        });
+    }
+};

--- a/lang/en/entities.php
+++ b/lang/en/entities.php
@@ -97,6 +97,7 @@ return [
     'shelves_books' => 'Books on this shelf',
     'shelves_add_books' => 'Add books to this shelf',
     'shelves_drag_books' => 'Drag books below to add them to this shelf',
+    'shelves_new_books_inherit_perms' => 'Should books created under this shelf inherit it\'s permissions?',
     'shelves_empty_contents' => 'This shelf has no books assigned to it',
     'shelves_edit_and_assign' => 'Edit shelf to assign books',
     'shelves_edit_named' => 'Edit Shelf :name',

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -46,6 +46,9 @@ return [
     'app_disable_comments' => 'Disable Comments',
     'app_disable_comments_toggle' => 'Disable comments',
     'app_disable_comments_desc' => 'Disables comments across all pages in the application. <br> Existing comments are not shown.',
+    'app_new_books_inherit_perms' => 'New Books Inherit Permissions',
+    'app_new_books_inherit_perms_toggle' => 'New books inherit permissions',
+    'app_new_books_inherit_perms_desc' => 'Enabling this option will cause the bookshelve\'s permissions to be copied to any new book created under the shelf. This fixes the issue where someone creates a book, but cannot access it.<br>This can be overriden on an individual bookshelf.',
 
     // Color settings
     'color_scheme' => 'Application Color Scheme',

--- a/resources/sass/_forms.scss
+++ b/resources/sass/_forms.scss
@@ -239,6 +239,10 @@ select {
   @include rtl {
     background-position: 20px 70%;
   }
+
+  &.small {
+    width: 170px;
+  }
 }
 
 input[type=date] {

--- a/resources/views/settings/features.blade.php
+++ b/resources/views/settings/features.blade.php
@@ -56,6 +56,20 @@
                 </div>
             </div>
 
+            <div class="grid half gap-xl">
+                <div>
+                    <label class="setting-list-label">{{ trans('settings.app_new_books_inherit_perms') }}</label>
+                    <p class="small">{!! trans('settings.app_new_books_inherit_perms_desc') !!}</p>
+                </div>
+                <div>
+                    @include('form.toggle-switch', [
+                        'name' => 'setting-app-new-books-inherit-perms',
+                        'value' => setting('app-new-books-inherit-perms'),
+                        'label' => trans('settings.app_new_books_inherit_perms_toggle'),
+                    ])
+                </div>
+            </div>
+
 
         </div>
 

--- a/resources/views/shelves/parts/form.blade.php
+++ b/resources/views/shelves/parts/form.blade.php
@@ -84,6 +84,24 @@
     </div>
 </div>
 
+@if($edit_perms)
+<div class="form-group">
+    {{ trans('entities.shelves_new_books_inherit_perms') }}
+    <select
+      name="new_books_inherit_perms"
+      id="new_books_inherit_perms"
+      class="small"
+      >
+        <option value="null" @if(old("new_books_inherit_perms") === null || $shelf->new_books_inherit_perms === null) selected @endif> Use global setting </option>
+        <option value="true" @if(old("new_books_inherit_perms") || $shelf->new_books_inherit_perms) selected @endif> Yes </option>
+        <option value="false" @if(old("new_books_inherit_perms") === 0 || $shelf->new_books_inherit_perms === 0) selected @endif> No </option>
+    </select>
+    @if($errors->has('new_books_inherit_perms'))
+    <div class="text-neg text-small">{{ $errors->first('new_books_inherit_perms') }}</div>
+    @endif
+</div>
+@endif
+
 <div class="form-group text-right">
     <a href="{{ isset($shelf) ? $shelf->getUrl() : url('/shelves') }}" class="button outline">{{ trans('common.cancel') }}</a>
     <button type="submit" class="button">{{ trans('entities.shelves_save') }}</button>


### PR DESCRIPTION
Adds an option to bookshelves to copy permissions to books created under them. This fixes the issue where someone has permission to create a book but cannot view the book they created. This fixes #1596 by implementing the suggestion in [this comment](https://github.com/BookStackApp/BookStack/issues/1091#issuecomment-2250465959).