### PR TITLE
Export: convert tables from HTML to Markdown

### DIFF
--- a/app/Entities/Tools/Markdown/HtmlToMarkdown.php
+++ b/app/Entities/Tools/Markdown/HtmlToMarkdown.php
@@ -13,6 +13,7 @@ use League\HTMLToMarkdown\Converter\LinkConverter;
 use League\HTMLToMarkdown\Converter\ListBlockConverter;
 use League\HTMLToMarkdown\Converter\ListItemConverter;
 use League\HTMLToMarkdown\Converter\PreformattedConverter;
+use League\HTMLToMarkdown\Converter\TableConverter;
 use League\HTMLToMarkdown\Converter\TextConverter;
 use League\HTMLToMarkdown\Environment;
 use League\HTMLToMarkdown\HtmlConverter;
@@ -32,6 +33,8 @@ class HtmlToMarkdown
     public function convert(): string
     {
         $converter = new HtmlConverter($this->getConverterEnvironment());
+        $converter->getEnvironment()->addConverter(new TableConverter());
+
         $html = $this->prepareHtml($this->html);
 
         return $converter->convert($html);


### PR DESCRIPTION
When exporting pages to Markdown, tables were still HTML. This is because `league/html-to-markdown` does not convert tables to Markdown by default, "because it is not part of the original Markdown syntax" (source: https://packagist.org/packages/league/html-to-markdown)