### PR TITLE
Add firstName and lastName variables for LDAP

### DIFF
--- a/app/Access/LdapService.php
+++ b/app/Access/LdapService.php
@@ -82,10 +82,12 @@ class LdapService
         $idAttr = $this->config['id_attribute'];
         $emailAttr = $this->config['email_attribute'];
         $displayNameAttr = $this->config['display_name_attribute'];
+        $firstNameAttr = $this->config['first_name_attribute'];
+        $lastNameAttr = $this->config['last_name_attribute'];
         $thumbnailAttr = $this->config['thumbnail_attribute'];
 
         $user = $this->getUserWithAttributes($userName, array_filter([
-            'cn', 'dn', $idAttr, $emailAttr, $displayNameAttr, $thumbnailAttr,
+            'cn', 'dn', $idAttr, $emailAttr, $displayNameAttr, $firstNameAttr, $lastNameAttr, $thumbnailAttr
         ]));
 
         if (is_null($user)) {
@@ -93,9 +95,18 @@ class LdapService
         }
 
         $userCn = $this->getUserResponseProperty($user, 'cn', null);
+
+        $name = $this->getUserResponseProperty($user, $displayNameAttr, $userCn);
+
+        if ($firstNameAttr and $lastNameAttr) {
+            $firstName = $this->getUserResponseProperty($user, $firstNameAttr, null);
+            $lastName = $this->getUserResponseProperty($user, $lastNameAttr, null);
+            $name = $firstName . ' ' . $lastName;
+        }
+
         $formatted = [
             'uid'   => $this->getUserResponseProperty($user, $idAttr, $user['dn']),
-            'name'  => $this->getUserResponseProperty($user, $displayNameAttr, $userCn),
+            'name'  => $name,
             'dn'    => $user['dn'],
             'email' => $this->getUserResponseProperty($user, $emailAttr, null),
             'avatar' => $thumbnailAttr ? $this->getUserResponseProperty($user, $thumbnailAttr, null) : null,

--- a/app/Config/services.php
+++ b/app/Config/services.php
@@ -128,6 +128,8 @@ return [
         'id_attribute'           => env('LDAP_ID_ATTRIBUTE', 'uid'),
         'email_attribute'        => env('LDAP_EMAIL_ATTRIBUTE', 'mail'),
         'display_name_attribute' => env('LDAP_DISPLAY_NAME_ATTRIBUTE', 'cn'),
+        'first_name_attribute'   => env('LDAP_FIRST_NAME_ATTRIBUTE', null),
+        'last_name_attribute'    => env('LDAP_LAST_NAME_ATTRIBUTE', null),
         'follow_referrals'       => env('LDAP_FOLLOW_REFERRALS', false),
         'user_to_groups'         => env('LDAP_USER_TO_GROUPS', false),
         'group_attribute'        => env('LDAP_GROUP_ATTRIBUTE', 'memberOf'),


### PR DESCRIPTION
Hello !

To resolve #1684 

I added two fields, LDAP_FIRST_NAME_ATTRIBUTE and LDAP_LAST_NAME_ATTRIBUTE, which, if both are filled, allow replacing LDAP_DISPLAY_NAME_ATTRIBUTE.

I did not set default values to avoid breaking existing installations.

