### PR TITLE
simpifly Dockerfiles

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -1,34 +1,34 @@
 FROM php:8.3-apache
 
-ENV APACHE_DOCUMENT_ROOT /app/public
-WORKDIR /app
-
-RUN <<EOR
 # Install additional dependencies
-apt-get update
-apt-get install -y \
-	git \
-	zip \
-	unzip \
-	libpng-dev \
-	libldap2-dev \
-	libzip-dev \
-	wait-for-it
-rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y \
+        git \
+        zip \
+        unzip \
+        libpng-dev \
+        libldap2-dev \
+        libzip-dev \
+        wait-for-it && \
+    rm -rf /var/lib/apt/lists/*
 
-# Configure apache
-docker-php-ext-configure ldap --with-libdir="lib/$(gcc -dumpmachine)"
-docker-php-ext-install pdo_mysql gd ldap zip
-pecl install xdebug
-docker-php-ext-enable xdebug
-a2enmod rewrite
-sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
-sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+# Install PHP extensions
+RUN docker-php-ext-configure ldap --with-libdir="lib/$(gcc -dumpmachine)" && \
+    docker-php-ext-install pdo_mysql gd ldap zip && \
+    pecl install xdebug && \
+    docker-php-ext-enable xdebug
 
 # Install composer
-curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Configure apache
+RUN a2enmod rewrite && \
+    sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf && \
+    sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
 # Use the default production configuration and update it as required
-mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
-sed -i 's/memory_limit = 128M/memory_limit = 512M/g' "$PHP_INI_DIR/php.ini"
-EOR
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" && \
+    sed -i 's/memory_limit = 128M/memory_limit = 512M/g' "$PHP_INI_DIR/php.ini"
+
+ENV APACHE_DOCUMENT_ROOT /app/public
+WORKDIR /app

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -30,5 +30,6 @@ RUN a2enmod rewrite && \
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" && \
     sed -i 's/memory_limit = 128M/memory_limit = 512M/g' "$PHP_INI_DIR/php.ini"
 
-ENV APACHE_DOCUMENT_ROOT /app/public
+ENV APACHE_DOCUMENT_ROOT="/app/public"
+
 WORKDIR /app


### PR DESCRIPTION
some updates:
- Remove deprecated syntax
- use `mlocati/docker-php-extension-installer` to install PHP extensions: easier to read and install dependencies automatically
- use multiple docker images: docker image layers are re-usable, it can accelerate build speed while working on Dockerfile

Notes: everything should be works on `docker compose up`