### PR TITLE
ExportFormatter: Add missing book description and remove extra newlines in markdown export

### DIFF
--- a/app/Entities/Tools/ExportFormatter.php
+++ b/app/Entities/Tools/ExportFormatter.php
@@ -315,7 +315,11 @@ class ExportFormatter
     public function chapterToMarkdown(Chapter $chapter): string
     {
         $text = '# ' . $chapter->name . "\n\n";
-        $text .= $chapter->description . "\n\n";
+
+        if (!empty($chapter->description)) {
+            $text .= $chapter->description . "\n\n";
+        }
+
         foreach ($chapter->pages as $page) {
             $text .= $this->pageToMarkdown($page) . "\n\n";
         }
@@ -330,6 +334,11 @@ class ExportFormatter
     {
         $bookTree = (new BookContents($book))->getTree(false, true);
         $text = '# ' . $book->name . "\n\n";
+        
+        if (!empty($book->description)) {
+            $text .= $book->description . "\n\n";
+        }
+
         foreach ($bookTree as $bookChild) {
             if ($bookChild instanceof Chapter) {
                 $text .= $this->chapterToMarkdown($bookChild) . "\n\n";


### PR DESCRIPTION
Hi,

This pull request includes two updates to the `app/Entities/Tools/ExportFormatter.php` file regarding the markdown export:

1. Added the missing book description in the `bookToMarkdown()` method.
2. Added a check for an empty chapter description, preventing unwanted extra lines (`\n\n`) between the chapter name and the page content when the description is empty.