### PR TITLE
update text color on delete buttons

### DIFF
--- a/resources/views/mfa/parts/setup-method-row.blade.php
+++ b/resources/views/mfa/parts/setup-method-row.blade.php
@@ -13,7 +13,7 @@
             </div>
             <a href="{{ url('/mfa/' . $method . '/generate') }}" class="button outline small">{{ trans('auth.mfa_setup_reconfigure') }}</a>
             <div component="dropdown" class="inline relative">
-                <button type="button" refs="dropdown@toggle" class="button outline small">{{ trans('common.remove') }}</button>
+                <button type="button" refs="dropdown@toggle" class="button outline small text-warn">{{ trans('common.remove') }}</button>
                 <div refs="dropdown@menu" class="dropdown-menu">
                     <p class="text-neg small px-m mb-xs">{{ trans('auth.mfa_setup_remove_confirmation') }}</p>
                     <form action="{{ url('/mfa/' . $method . '/remove') }}" method="post">

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -42,7 +42,7 @@
                        class="button outline">{{ trans('common.cancel') }}</a>
                     @if($authMethod !== 'system')
                         <a href="{{ url("/settings/users/{$user->id}/delete") }}"
-                           class="button outline">{{ trans('settings.users_delete') }}</a>
+                           class="button outline text-warn">{{ trans('settings.users_delete') }}</a>
                     @endif
                     <button class="button" type="submit">{{ trans('common.save') }}</button>
                 </div>


### PR DESCRIPTION
text color modified:
- delete user button
- delete MFA method buttons

Those actions can not be undone, better to add warning.

![20241115_002](https://github.com/user-attachments/assets/7ee2511d-f9db-49e2-b1c9-26ecc0dcdd7e)

![20241115_001](https://github.com/user-attachments/assets/2fa35aad-3d5b-4649-ae72-b067df249b91)

----

Is there CSS style can make button in red background and white text on buttons? Thanks