### PR TITLE
Improve Oidc userinfo response Content-Type matching

### DIFF
--- a/app/Access/Oidc/OidcUserinfoResponse.php
+++ b/app/Access/Oidc/OidcUserinfoResponse.php
@@ -11,7 +11,7 @@ class OidcUserinfoResponse implements ProvidesClaims
 
     public function __construct(ResponseInterface $response, string $issuer, array $keys)
     {
-        $contentType = $response->getHeader('Content-Type')[0];
+        $contentType = explode(';', $response->getHeader('Content-Type')[0], 2)[0];
         if ($contentType === 'application/json') {
             $this->claims = json_decode($response->getBody()->getContents(), true);
         }


### PR DESCRIPTION
Updates the OIDC userinfo endpoint request to allow for a `Content-Type` response header with optional parameters, like `application/json; charset=utf-8`. This was causing an issue (failure to find a valid subject claim) when integrating with [node-oidc-provider](https://github.com/panva/node-oidc-provider).