### PR TITLE
Ability to prefix an S3 bucket

### DIFF
--- a/app/Config/filesystems.php
+++ b/app/Config/filesystems.php
@@ -59,6 +59,7 @@ return [
             'use_path_style_endpoint' => env('STORAGE_S3_ENDPOINT', null) !== null,
             'throw'                   => true,
             'stream_reads'            => false,
+	    'root'		      => env('STORAGE_S3_ROOT', null)
         ],
 
     ],


### PR DESCRIPTION
We are running two bookstack instances. One for production and one for development.
This allows the ability to use a single s3 bucket but prefix where files are stored.
e.g. dev could use my-s3-bucket/dev and production could use my-s3-bucket/production