### PR TITLE
Add link to missing setup.md from Codeberg

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,3 +175,4 @@ Note: This is not an exhaustive list of all libraries and projects that would be
 * [JakeArchibald/IDB-Keyval](https://github.com/jakearchibald/idb-keyval) - _[Apache-2.0](https://github.com/jakearchibald/idb-keyval/blob/main/LICENCE)_
 
 For a detailed breakdown of the JavaScript & PHP projects imported & used via NPM & composer package managers, along with their licenses, please see the [dev/licensing/js-library-licenses.txt](dev/licensing/js-library-licenses.txt) and [dev/licensing/php-library-licenses.txt](dev/licensing/php-library-licenses.txt) files. 
+This is a placeholder Pull Request for missing installation documentation.


### PR DESCRIPTION
 The BookStackApp installation guide is not explanatory for new users. There are missing parts in the .env file  database connection for BookStackApp. Laravel and PHP installations are not for beginners. The installation steps could be more explanatory and detailed for beginners. It is necessary to make sure that some folders are writable, but the more information section does not work. This statement means that users expect more detailed instructions in this section. How to make the storage and bookstrep/cache folders writable is missing.   
It is available on Codeberg at the following location:

[Installation.md on Codeberg] ( https://codeberg.org/sedefkazan/website/src/commit/73856595cc081fdc3a1180f2c8675668ef3b5173/content/docs/admin/installation.md )

Change in read.md for content/docs/admin/installation.md path in Codeberg.