### PR TITLE
Allow api search to filter by book_id and chapter_id

### DIFF
--- a/app/Search/SearchRunner.php
+++ b/app/Search/SearchRunner.php
@@ -454,6 +454,20 @@ class SearchRunner
         }
     }
 
+    protected function filterBookId(EloquentBuilder $query, Entity $model, string $input, bool $negated)
+    {
+        if ($model instanceof Page || $model instanceof Chapter) {
+            $this->applyNegatableWhere($query, $negated, 'book_id', '=', $input);
+        }
+    }
+
+    protected function filterChapterId(EloquentBuilder $query, Entity $model, string $input, bool $negated)
+    {
+        if ($model instanceof Page) {
+            $this->applyNegatableWhere($query, $negated, 'chapter_id', '=', $input);
+        }
+    }
+
     /**
      * Sorting filter options.
      */

--- a/tests/Entity/EntitySearchTest.php
+++ b/tests/Entity/EntitySearchTest.php
@@ -30,6 +30,25 @@ class EntitySearchTest extends TestCase
         $search->assertSeeText($shelf->name, true);
     }
 
+    public function test_book_id_search()
+    {
+        $book = Book::first();
+
+        $search = $this->asEditor()->get('/search?query={type:page}{book_id:' . $book->id . '}');
+        $search->assertSee('Search Results');
+        $search->assertSeeText($book->id, true);
+    }
+
+    public function test_chapter_id_search()
+    {
+        $book = Book::first();
+        $chapter = $book->chapters->last();
+
+        $search = $this->asEditor()->get('/search?query={type:page}{chapter_id:' . $chapter->id . '}');
+        $search->assertSee('Search Results');
+        $search->assertSeeText($chapter->id, true);
+    }
+
     public function test_invalid_page_search()
     {
         $resp = $this->asEditor()->get('/search?term=' . urlencode('<p>test</p>'));


### PR DESCRIPTION
In Api we should be able to search by book_id and or chapter_id to reduce the set of results.

Example search using book_id filtering:
http://localhost:6875/api/search?count=100&page=1&query=p{type:page}{book_id:5}
Example search using chapter_id filtering:
http://localhost:6875/api/search?count=100&page=1&query=p{type:page}{chapter_id:2}