### PR TITLE
Add `.svg` extension to supported image file extensions

### DIFF
--- a/app/Exports/ZipExports/Models/ZipExportImage.php
+++ b/app/Exports/ZipExports/Models/ZipExportImage.php
@@ -32,7 +32,7 @@ class ZipExportImage extends ZipExportModel
 
     public static function validate(ZipValidationHelper $context, array $data): array
     {
-        $acceptedImageTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+        $acceptedImageTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'];
         $rules = [
             'id'    => ['nullable', 'int', $context->uniqueIdRule('image')],
             'name'  => ['required', 'string', 'min:1'],

--- a/app/Http/Controller.php
+++ b/app/Http/Controller.php
@@ -163,7 +163,7 @@ abstract class Controller extends BaseController
      */
     protected function getImageValidationRules(): array
     {
-        return ['image_extension', 'mimes:jpeg,png,gif,webp', 'max:' . (config('app.upload_limit') * 1000)];
+        return ['image_extension', 'mimes:jpeg,png,gif,webp,svg', 'max:' . (config('app.upload_limit') * 1000)];
     }
 
     /**

--- a/app/Uploads/ImageResizer.php
+++ b/app/Uploads/ImageResizer.php
@@ -66,6 +66,11 @@ class ImageResizer
         bool $keepRatio = false,
         bool $shouldCreate = false
     ): ?string {
+        // Do not attempt to resize SVGs, return the raw value always.
+        if ($this->isSvg($image)) {
+            return $this->storage->getPublicUrl($image->path);
+        }
+
         // Do not resize GIF images where we're not cropping
         if ($keepRatio && $this->isGif($image)) {
             return $this->storage->getPublicUrl($image->path);
@@ -224,6 +229,14 @@ class ImageResizer
     protected function isGif(Image $image): bool
     {
         return $this->getExtension($image) === 'gif';
+    }
+
+    /**
+     * Checks if the image is a svg. Returns true if it is, else false.
+     */
+    protected function isSvg(Image $image): bool
+    {
+        return $this->getExtension($image) === 'svg';
     }
 
     /**

--- a/app/Uploads/ImageService.php
+++ b/app/Uploads/ImageService.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ImageService
 {
-    protected static array $supportedExtensions = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+    protected static array $supportedExtensions = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg'];
 
     public function __construct(
         protected ImageStorage $storage,

--- a/app/Util/WebSafeMimeSniffer.php
+++ b/app/Util/WebSafeMimeSniffer.php
@@ -33,6 +33,7 @@ class WebSafeMimeSniffer
         'image/webp',
         'image/avif',
         'image/heic',
+        'image/svg+xml',
         'text/css',
         'text/csv',
         'text/javascript',


### PR DESCRIPTION
I've noticed that SVG images are not in the hardcoded list of supported image extensions. Having tested SVGs on my BookStack instance in the WYSIWYG editor these behave normally, so think it's worthwhile having this as an out-of-the-box supported image.