### PR TITLE
Add optional OIDC avatar fetching from the ```picture``` claim

### DIFF
--- a/app/Access/Oidc/OidcService.php
+++ b/app/Access/Oidc/OidcService.php
@@ -11,6 +11,7 @@ use BookStack\Exceptions\UserRegistrationException;
 use BookStack\Facades\Theme;
 use BookStack\Http\HttpRequestService;
 use BookStack\Theming\ThemeEvents;
+use BookStack\Uploads\UserAvatars;
 use BookStack\Users\Models\User;
 use Illuminate\Support\Facades\Cache;
 use League\OAuth2\Client\OptionProvider\HttpBasicAuthOptionProvider;
@@ -26,7 +27,8 @@ class OidcService
         protected RegistrationService $registrationService,
         protected LoginService $loginService,
         protected HttpRequestService $http,
-        protected GroupSyncService $groupService
+        protected GroupSyncService $groupService,
+        protected UserAvatars $userAvatars
     ) {
     }
 
@@ -226,6 +228,10 @@ class OidcService
         }
 
         $this->loginService->login($user, 'oidc');
+
+        if ($this->config()['fetch_avatars'] && $userDetails->picture) {
+            $this->userAvatars->assignToUserFromUrl($user, $userDetails->picture, $accessToken->getToken());
+        }
 
         return $user;
     }

--- a/app/Access/Oidc/OidcUserDetails.php
+++ b/app/Access/Oidc/OidcUserDetails.php
@@ -11,6 +11,7 @@ class OidcUserDetails
         public ?string $email = null,
         public ?string $name = null,
         public ?array $groups = null,
+        public ?string $picture = null,
     ) {
     }
 
@@ -40,6 +41,7 @@ class OidcUserDetails
         $this->email = $claims->getClaim('email') ?? $this->email;
         $this->name = static::getUserDisplayName($displayNameClaims, $claims) ?? $this->name;
         $this->groups = static::getUserGroups($groupsClaim, $claims) ?? $this->groups;
+        $this->picture    = $claims->getClaim('picture') ?: $this->picture;
     }
 
     protected static function getUserDisplayName(string $displayNameClaims, ProvidesClaims $token): string

--- a/app/Config/oidc.php
+++ b/app/Config/oidc.php
@@ -54,4 +54,7 @@ return [
     'groups_claim' => env('OIDC_GROUPS_CLAIM', 'groups'),
     // When syncing groups, remove any groups that no longer match. Otherwise, sync only adds new groups.
     'remove_from_groups' => env('OIDC_REMOVE_FROM_GROUPS', false),
+
+    // When enabled, BookStack will fetch the user’s avatar from the 'picture' claim (SSRF risk if URLs are untrusted).
+    'fetch_avatars' => env('OIDC_FETCH_AVATARS', false),
 ];


### PR DESCRIPTION
This update enables BookStack to **optionally** fetch user avatars from the OIDC `picture` claim. The implementation:

- closes: https://github.com/BookStackApp/BookStack/issues/4271

1. Introduces a `fetch_avatars` config flag in `config/oidc.php` to toggle avatar retrieval.  
2. Uses `UserAvatars->assignToUserFromUrl($user, $picture, $accessToken)` to support **both** public and **private** (Bearer token-protected) endpoints.  
3. Fetches the `picture` claim from the user’s ID token or userinfo response, if provided.  
4. Works with various OIDC providers (Google, Okta, Keycloak, Azure, etc.), provided they include or allow retrieving a valid `picture` URL.  
5. Includes SSRF protection notes, advising users to only enable this if they trust the domains in the `picture` field.

This approach does **not** break existing behavior; avatar fetching is off by default. If enabled, BookStack will try to update a user’s avatar upon login, using the token to authenticate if necessary.