### PR TITLE
Fix search issue for words inside Guillemets (« ») without spaces

### DIFF
--- a/app/Search/SearchIndex.php
+++ b/app/Search/SearchIndex.php
@@ -16,7 +16,7 @@ class SearchIndex
     /**
      * A list of delimiter characters used to break-up parsed content into terms for indexing.
      */
-    public static string $delimiters = " \n\t.,!?:;()[]{}<>`'\"";
+    public static string $delimiters = " \n\t.,!?:;()[]{}<>`'\"«»";
 
     public function __construct(
         protected EntityProvider $entityProvider


### PR DESCRIPTION
This commit fixes an issue where words enclosed in Guillemets (« ») were not indexed correctly for search when there was no space after the opening quote. The search engine was not recognizing such words as separate terms, leading to failed search results.

The fix involves updating the list of delimiter characters in SearchIndex::$delimiters to include Guillemets (« and »), ensuring that words within them are properly tokenized and indexed.