### PR TITLE
Translations: Fixed incorrect french translation

### DIFF
--- a/lang/fr/entities.php
+++ b/lang/fr/entities.php
@@ -162,7 +162,7 @@ return [
     'books_empty_create_page' => 'Créer une nouvelle page',
     'books_empty_sort_current_book' => 'Trier les pages du livre',
     'books_empty_add_chapter' => 'Ajouter un chapitre',
-    'books_permissions_active' => 'Permissions personnalisées activées',
+    'books_permissions_active' => 'Permissions de livre actives',
     'books_search_this' => 'Rechercher dans ce livre',
     'books_navigation' => 'Navigation dans le livre',
     'books_sort' => 'Trier les contenus du livre',


### PR DESCRIPTION
In English, the link text for book and page permissions are:
- Book Permissions Active
- Page Permissions Active

In French, this translates as:
- Permissions de livre actives
- Permissions de page actives

The current translation for Book Permissions Active, "Permissions personnalisées activées", doesn't refer to the book and is confusing. This PR fixes the translation.