### PR TITLE
bug fix for Users can edit and rename shelves #5458

### DIFF
--- a/app/Entities/Controllers/BookshelfController.php
+++ b/app/Entities/Controllers/BookshelfController.php
@@ -16,6 +16,7 @@ use BookStack\Util\SimpleListOptions;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
+use Illuminate\Support\Facades\Auth;
 
 class BookshelfController extends Controller
 {
@@ -68,6 +69,13 @@ class BookshelfController extends Controller
      */
     public function create()
     {
+        $user = Auth::user();
+        $roles = $user->roles;
+
+        // Check if the user has the "Admin" role
+        if (!$roles->contains('display_name', 'Admin')) {
+            return redirect()->back()->with('error', 'You do not have permission to create  bookshelf.');
+        }
         $this->checkPermission('bookshelf-create-all');
         $books = $this->bookQueries->visibleForList()->orderBy('name')->get(['name', 'id', 'slug', 'created_at', 'updated_at']);
         $this->setPageTitle(trans('entities.shelves_create'));
@@ -83,6 +91,13 @@ class BookshelfController extends Controller
      */
     public function store(Request $request)
     {
+        $user = Auth::user();
+        $roles = $user->roles;
+
+        // Check if the user has the "Admin" role
+        if (!$roles->contains('display_name', 'Admin')) {
+            return redirect()->back()->with('error', 'You do not have permission to store  bookshelf.');
+        }
         $this->checkPermission('bookshelf-create-all');
         $validated = $this->validate($request, [
             'name'             => ['required', 'string', 'max:255'],
@@ -142,6 +157,13 @@ class BookshelfController extends Controller
      */
     public function edit(string $slug)
     {
+        $user = Auth::user();
+        $roles = $user->roles;
+
+        // Check if the user has the "Admin" role
+        if (!$roles->contains('display_name', 'Admin')) {
+            return redirect()->back()->with('error', 'You do not have permission to edit  bookshelf.');
+        }
         $shelf = $this->queries->findVisibleBySlugOrFail($slug);
         $this->checkOwnablePermission('bookshelf-update', $shelf);
 
@@ -168,6 +190,13 @@ class BookshelfController extends Controller
      */
     public function update(Request $request, string $slug)
     {
+        $user = Auth::user();
+        $roles = $user->roles;
+
+        // Check if the user has the "Admin" role
+        if (!$roles->contains('display_name', 'Admin')) {
+            return redirect()->back()->with('error', 'You do not have permission to update  bookshelf.');
+        }
         $shelf = $this->queries->findVisibleBySlugOrFail($slug);
         $this->checkOwnablePermission('bookshelf-update', $shelf);
         $validated = $this->validate($request, [
@@ -194,6 +223,13 @@ class BookshelfController extends Controller
      */
     public function showDelete(string $slug)
     {
+        $user = Auth::user();
+        $roles = $user->roles;
+
+        // Check if the user has the "Admin" role
+        if (!$roles->contains('display_name', 'Admin')) {
+            return redirect()->back()->with('error', 'You do not have permission to delete  bookshelf.');
+        }
         $shelf = $this->queries->findVisibleBySlugOrFail($slug);
         $this->checkOwnablePermission('bookshelf-delete', $shelf);
 
@@ -209,6 +245,13 @@ class BookshelfController extends Controller
      */
     public function destroy(string $slug)
     {
+        $user = Auth::user();
+        $roles = $user->roles;
+
+        // Check if the user has the "Admin" role
+        if (!$roles->contains('display_name', 'Admin')) {
+            return redirect()->back()->with('error', 'You do not have permission to destroy  bookshelf.');
+        }
         $shelf = $this->queries->findVisibleBySlugOrFail($slug);
         $this->checkOwnablePermission('bookshelf-delete', $shelf);
 


### PR DESCRIPTION
Fixed an issue where all users could edit and rename shelves by adding a check to ensure only admins have permission to perform these actions.