### PR TITLE
Feature: add a read option in book show page and impliment a popup mo…

### DIFF
--- a/app/Entities/Controllers/BookApiController.php
+++ b/app/Entities/Controllers/BookApiController.php
@@ -20,8 +20,7 @@ class BookApiController extends ApiController
         protected BookRepo $bookRepo,
         protected BookQueries $queries,
         protected PageQueries $pageQueries,
-    ) {
-    }
+    ) {}
 
     /**
      * Get a listing of books visible to the user.
@@ -34,7 +33,15 @@ class BookApiController extends ApiController
             ->addSelect(['created_by', 'updated_by']);
 
         return $this->apiListingResponse($books, [
-            'id', 'name', 'slug', 'description', 'created_at', 'updated_at', 'created_by', 'updated_by', 'owned_by',
+            'id',
+            'name',
+            'slug',
+            'description',
+            'created_at',
+            'updated_at',
+            'created_by',
+            'updated_by',
+            'owned_by',
         ]);
     }
 
@@ -63,21 +70,8 @@ class BookApiController extends ApiController
      */
     public function read(string $id)
     {
-        $book = $this->queries->findVisibleByIdOrFail(intval($id));
-        $book = $this->forJsonDisplay($book);
-        $book->load(['createdBy', 'updatedBy', 'ownedBy']);
-
-        $contents = (new BookContents($book))->getTree(true, false)->all();
-        $contentsApiData = (new ApiEntityListFormatter($contents))
-            ->withType()
-            ->withField('pages', function (Entity $entity) {
-                if ($entity instanceof Chapter) {
-                    $pages = $this->pageQueries->visibleForChapterList($entity->id)->get()->all();
-                    return (new ApiEntityListFormatter($pages))->format();
-                }
-                return null;
-            })->format();
-        $book->setAttribute('contents', $contentsApiData);
+        $book = $this->queries->findVisibleByIdOrFail(intval($id))
+            ->load(['createdBy', 'updatedBy', 'ownedBy', 'pages']);
 
         return response()->json($book);
     }

--- a/app/Entities/Models/Page.php
+++ b/app/Entities/Models/Page.php
@@ -38,7 +38,7 @@ class Page extends BookChild
     public string $textField = 'text';
     public string $htmlField = 'html';
 
-    protected $hidden = ['html', 'markdown', 'text', 'pivot', 'deleted_at'];
+    protected $hidden = ['markdown', 'text', 'pivot', 'deleted_at'];
 
     protected $casts = [
         'draft'    => 'boolean',

--- a/app/Services/PDFtoTxtService.php
+++ b/app/Services/PDFtoTxtService.php
@@ -1,0 +1,23 @@
+<?php
+namespace App\Services;
+use Smalot\PdfParser\Parser;
+class PDFtoTxtService
+{
+    public function convert($pdfPath)
+    {
+        $parser = new Parser();
+        $pdf = $parser->parseFile(storage_path("app/{$pdfPath}"));
+
+        // Extract text per page
+        $pages = $pdf->getPages();
+        $pageTexts = [];
+
+        foreach ($pages as $index => $page) {
+            $pageTexts['Page ' . ($index + 1)] = trim($page->getText());
+        }
+
+        return response()->json([
+            'pages' => $pageTexts,
+        ]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "phpseclib/phpseclib": "^3.0",
         "pragmarx/google2fa": "^8.0",
         "predis/predis": "^2.1",
+        "smalot/pdfparser": "^2.11",
         "socialiteproviders/discord": "^4.1",
         "socialiteproviders/gitlab": "^4.1",
         "socialiteproviders/microsoft-azure": "^5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95a803e4d7797c8ab6c9803a6a3e99e5",
+    "content-hash": "69abe07cf3240381961687da1910df6e",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4983,6 +4983,57 @@
                 "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.7.0"
             },
             "time": "2024-10-27T17:38:32+00:00"
+        },
+        {
+            "name": "smalot/pdfparser",
+            "version": "v2.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/smalot/pdfparser.git",
+                "reference": "ac8e6678b0940e4b2ccd5caadd3fb18e68093be6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/smalot/pdfparser/zipball/ac8e6678b0940e4b2ccd5caadd3fb18e68093be6",
+                "reference": "ac8e6678b0940e4b2ccd5caadd3fb18e68093be6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-zlib": "*",
+                "php": ">=7.1",
+                "symfony/polyfill-mbstring": "^1.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Smalot\\PdfParser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastien MALOT",
+                    "email": "sebastien@malot.fr"
+                }
+            ],
+            "description": "Pdf parser library. Can read and extract information from pdf file.",
+            "homepage": "https://www.pdfparser.org",
+            "keywords": [
+                "extract",
+                "parse",
+                "parser",
+                "pdf",
+                "text"
+            ],
+            "support": {
+                "issues": "https://github.com/smalot/pdfparser/issues",
+                "source": "https://github.com/smalot/pdfparser/tree/v2.11.0"
+            },
+            "time": "2024-08-16T06:48:03+00:00"
         },
         {
             "name": "socialiteproviders/discord",
@@ -10372,7 +10423,7 @@
         "ext-xml": "*",
         "ext-zip": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.2.0"
     },

--- a/lang/en/common.php
+++ b/lang/en/common.php
@@ -10,6 +10,7 @@ return [
     'confirm' => 'Confirm',
     'back' => 'Back',
     'save' => 'Save',
+    'read' => 'Read',
     'continue' => 'Continue',
     'select' => 'Select',
     'toggle_all' => 'Toggle All',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bookstack",
+  "name": "BookStack",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/resources/views/books/parts/form.blade.php
+++ b/resources/views/books/parts/form.blade.php
@@ -1,5 +1,5 @@
 @push('head')
-    <script src="{{ versioned_asset('libs/tinymce/tinymce.min.js') }}" nonce="{{ $cspNonce }}"></script>
+<script src="{{ versioned_asset('libs/tinymce/tinymce.min.js') }}" nonce="{{ $cspNonce }}"></script>
 @endpush
 
 {{ csrf_field() }}
@@ -13,6 +13,16 @@
     @include('form.description-html-input')
 </div>
 
+<div class="form-group collapsible" component="collapsible" id="pdf-book">
+    <button refs="collapsible@trigger" type="button" class="collapse-title text-link" aria-expanded="false">
+        <label>Upload Pdf (optional)</label>
+    </button>
+    <div refs="collapsible@content" class="collapse-content">
+        <label for="book">Upload Book as PDF file</label>
+        <input type="file" name="book" id="book" />
+    </div>
+</div>
+
 <div class="form-group collapsible" component="collapsible" id="logo-control">
     <button refs="collapsible@trigger" type="button" class="collapse-title text-link" aria-expanded="false">
         <label>{{ trans('common.cover_image') }}</label>
@@ -21,10 +31,10 @@
         <p class="small">{{ trans('common.cover_image_description') }}</p>
 
         @include('form.image-picker', [
-            'defaultImage' => url('/book_default_cover.png'),
-            'currentImage' => (isset($model) && $model->cover) ? $model->getBookCover() : url('/book_default_cover.png') ,
-            'name' => 'image',
-            'imageClass' => 'cover'
+        'defaultImage' => url('/book_default_cover.png'),
+        'currentImage' => (isset($model) && $model->cover) ? $model->getBookCover() : url('/book_default_cover.png') ,
+        'name' => 'image',
+        'imageClass' => 'cover'
         ])
     </div>
 </div>

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -1,180 +1,210 @@
 @extends('layouts.tri')
+@push('head')
+<script src="{{ asset('dist/modal.js') }}" nonce="{{ $cspNonce }}"></script>
+@endpush
 
 @section('container-attrs')
-    component="entity-search"
-    option:entity-search:entity-id="{{ $book->id }}"
-    option:entity-search:entity-type="book"
+component="entity-search"
+option:entity-search:entity-id="{{ $book->id }}"
+option:entity-search:entity-type="book"
 @stop
 
 @push('social-meta')
-    <meta property="og:description" content="{{ Str::limit($book->description, 100, '...') }}">
-    @if($book->cover)
-        <meta property="og:image" content="{{ $book->getBookCover() }}">
-    @endif
+<meta property="og:description" content="{{ Str::limit($book->description, 100, '...') }}">
+@if($book->cover)
+<meta property="og:image" content="{{ $book->getBookCover() }}">
+@endif
 @endpush
 
 @include('entities.body-tag-classes', ['entity' => $book])
 
 @section('body')
+<!-- Modal -->
+<!-- Modal Container -->
+<div id="modal" style="display: none; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background: rgba(0, 0, 0, 0.8); z-index: 99999; justify-content: center; align-items: center;">
 
-    <div class="mb-s print-hidden">
-        @include('entities.breadcrumbs', ['crumbs' => [
-            $book,
-        ]])
-    </div>
+    <div id="modal-box" style="margin-top:70px; background: white; padding: 20px; border-radius: 10px; width: 80vw; height: 85vh; box-shadow: 0px 0px 10px rgba(0, 0, 0, 1.0); position: relative;">
 
-    <main class="content-wrap card">
-        <h1 class="break-text">{{$book->name}}</h1>
-        <div refs="entity-search@contentView" class="book-content">
-            <div class="text-muted break-text">{!! $book->descriptionHtml() !!}</div>
-            @if(count($bookChildren) > 0)
-                <div class="entity-list book-contents">
-                    @foreach($bookChildren as $childElement)
-                        @if($childElement->isA('chapter'))
-                            @include('chapters.parts.list-item', ['chapter' => $childElement])
-                        @else
-                            @include('pages.parts.list-item', ['page' => $childElement])
-                        @endif
-                    @endforeach
-                </div>
-            @else
-                <div class="mt-xl">
-                    <hr>
-                    <p class="text-muted italic mb-m mt-xl">{{ trans('entities.books_empty_contents') }}</p>
-
-                    <div class="icon-list block inline">
-                        @if(userCan('page-create', $book))
-                            <a href="{{ $book->getUrl('/create-page') }}" class="icon-list-item text-page">
-                                <span class="icon">@icon('page')</span>
-                                <span>{{ trans('entities.books_empty_create_page') }}</span>
-                            </a>
-                        @endif
-                        @if(userCan('chapter-create', $book))
-                            <a href="{{ $book->getUrl('/create-chapter') }}" class="icon-list-item text-chapter">
-                                <span class="icon">@icon('chapter')</span>
-                                <span>{{ trans('entities.books_empty_add_chapter') }}</span>
-                            </a>
-                        @endif
-                    </div>
-
-                </div>
-            @endif
+        <!-- Close Button -->
+        <button id="closeModalBtn" style="position: absolute; top: 10px; right: 10px; background: red; color: white; border: none; padding: 5px 10px; cursor: pointer; border-radius: 5px;">Close</button>
+        <!-- Flipbook Container -->
+        <div class="entity-list book-contents" id="modal-cont">
+            
         </div>
 
-        @include('entities.search-results')
-    </main>
+        <!-- Navigation Buttons -->
+        <button id="prevPageBtn" style="position: absolute; left: 10px; bottom: 50%; transform: translateY(50%); background: gray; color: white; border: none; padding: 10px; cursor: pointer; border-radius: 5px;">◀</button>
+        <button id="nextPageBtn" style="position: absolute; right: 10px; bottom: 50%; transform: translateY(50%); background: gray; color: white; border: none; padding: 10px; cursor: pointer; border-radius: 5px;">▶</button>
+
+    </div>
+</div>
+
+
+<div class="mb-s print-hidden">
+    @include('entities.breadcrumbs', ['crumbs' => [
+    $book,
+    ]])
+
+</div>
+
+
+<main class="content-wrap card">
+    <h1 class="break-text">{{$book->name}}</h1>
+    <div refs="entity-search@contentView" class="book-content">
+        <div class="text-muted break-text">{!! $book->descriptionHtml() !!}</div>
+        @if(count($bookChildren) > 0)
+        <div class="entity-list book-contents">
+            @foreach($bookChildren as $childElement)
+            @if($childElement->isA('chapter'))
+            @include('chapters.parts.list-item', ['chapter' => $childElement])
+            @else
+            @include('pages.parts.list-item', ['page' => $childElement])
+            @endif
+            @endforeach
+        </div>
+        @else
+        <div class="mt-xl">
+            <hr>
+            <p class="text-muted italic mb-m mt-xl">{{ trans('entities.books_empty_contents') }}</p>
+
+            <div class="icon-list block inline">
+
+                @if(userCan('page-create', $book))
+                <a href="{{ $book->getUrl('/create-page') }}" class="icon-list-item text-page">
+                    <span class="icon">@icon('page')</span>
+                    <span>{{ trans('entities.books_empty_create_page') }}</span>
+                </a>
+                @endif
+                @if(userCan('chapter-create', $book))
+                <a href="{{ $book->getUrl('/create-chapter') }}" class="icon-list-item text-chapter">
+                    <span class="icon">@icon('chapter')</span>
+                    <span>{{ trans('entities.books_empty_add_chapter') }}</span>
+                </a>
+                @endif
+            </div>
+
+        </div>
+        @endif
+    </div>
+
+    @include('entities.search-results')
+</main>
 
 @stop
 
 @section('right')
-    <div class="mb-xl">
-        <h5>{{ trans('common.details') }}</h5>
-        <div class="blended-links">
-            @include('entities.meta', ['entity' => $book, 'watchOptions' => $watchOptions])
-            @if($book->hasPermissions())
-                <div class="active-restriction">
-                    @if(userCan('restrictions-manage', $book))
-                        <a href="{{ $book->getUrl('/permissions') }}" class="entity-meta-item">
-                            @icon('lock')
-                            <div>{{ trans('entities.books_permissions_active') }}</div>
-                        </a>
-                    @else
-                        <div class="entity-meta-item">
-                            @icon('lock')
-                            <div>{{ trans('entities.books_permissions_active') }}</div>
-                        </div>
-                    @endif
-                </div>
-            @endif
-        </div>
-    </div>
-
-    <div class="actions mb-xl">
-        <h5>{{ trans('common.actions') }}</h5>
-        <div class="icon-list text-link">
-
-            @if(userCan('page-create', $book))
-                <a href="{{ $book->getUrl('/create-page') }}" data-shortcut="new" class="icon-list-item">
-                    <span>@icon('add')</span>
-                    <span>{{ trans('entities.pages_new') }}</span>
-                </a>
-            @endif
-            @if(userCan('chapter-create', $book))
-                <a href="{{ $book->getUrl('/create-chapter') }}" data-shortcut="new" class="icon-list-item">
-                    <span>@icon('add')</span>
-                    <span>{{ trans('entities.chapters_new') }}</span>
-                </a>
-            @endif
-
-            <hr class="primary-background">
-
-            @if(userCan('book-update', $book))
-                <a href="{{ $book->getUrl('/edit') }}" data-shortcut="edit" class="icon-list-item">
-                    <span>@icon('edit')</span>
-                    <span>{{ trans('common.edit') }}</span>
-                </a>
-                <a href="{{ $book->getUrl('/sort') }}" data-shortcut="sort" class="icon-list-item">
-                    <span>@icon('sort')</span>
-                    <span>{{ trans('common.sort') }}</span>
-                </a>
-            @endif
-            @if(userCan('book-create-all'))
-                <a href="{{ $book->getUrl('/copy') }}" data-shortcut="copy" class="icon-list-item">
-                    <span>@icon('copy')</span>
-                    <span>{{ trans('common.copy') }}</span>
-                </a>
-            @endif
+<div class="mb-xl">
+    <h5>{{ trans('common.details') }}</h5>
+    <div class="blended-links">
+        @include('entities.meta', ['entity' => $book, 'watchOptions' => $watchOptions])
+        @if($book->hasPermissions())
+        <div class="active-restriction">
             @if(userCan('restrictions-manage', $book))
-                <a href="{{ $book->getUrl('/permissions') }}" data-shortcut="permissions" class="icon-list-item">
-                    <span>@icon('lock')</span>
-                    <span>{{ trans('entities.permissions') }}</span>
-                </a>
-            @endif
-            @if(userCan('book-delete', $book))
-                <a href="{{ $book->getUrl('/delete') }}" data-shortcut="delete" class="icon-list-item">
-                    <span>@icon('delete')</span>
-                    <span>{{ trans('common.delete') }}</span>
-                </a>
-            @endif
-
-            <hr class="primary-background">
-
-            @if($watchOptions->canWatch() && !$watchOptions->isWatching())
-                @include('entities.watch-action', ['entity' => $book])
-            @endif
-            @if(!user()->isGuest())
-                @include('entities.favourite-action', ['entity' => $book])
-            @endif
-            @if(userCan('content-export'))
-                @include('entities.export-menu', ['entity' => $book])
+            <a href="{{ $book->getUrl('/permissions') }}" class="entity-meta-item">
+                @icon('lock')
+                <div>{{ trans('entities.books_permissions_active') }}</div>
+            </a>
+            @else
+            <div class="entity-meta-item">
+                @icon('lock')
+                <div>{{ trans('entities.books_permissions_active') }}</div>
+            </div>
             @endif
         </div>
+        @endif
     </div>
+</div>
+
+<div class="actions mb-xl">
+    <h5>{{ trans('common.actions') }}</h5>
+    <div class="icon-list text-link">
+
+        @if(userCan('page-create', $book))
+        <a href="{{ $book->getUrl('/create-page') }}" data-shortcut="new" class="icon-list-item">
+            <span>@icon('add')</span>
+            <span>{{ trans('entities.pages_new') }}</span>
+        </a>
+        @endif
+        @if(userCan('chapter-create', $book))
+        <a href="{{ $book->getUrl('/create-chapter') }}" data-shortcut="new" class="icon-list-item">
+            <span>@icon('add')</span>
+            <span>{{ trans('entities.chapters_new') }}</span>
+        </a>
+        @endif
+
+        <hr class="primary-background">
+        <a href="#" id="openModalBtn" data-shortcut="read" api-url="{{ url('/api/books') }}" book-id="{{ $book->id }}" class="icon-list-item">
+            <span>@icon('book')</span>
+            <span>{{ trans('common.read') }}</span>
+        </a>
+        @if(userCan('book-update', $book))
+        
+
+        <a href="{{ $book->getUrl('/edit') }}" data-shortcut="edit" class="icon-list-item">
+            <span>@icon('edit')</span>
+            <span>{{ trans('common.edit') }}</span>
+        </a>
+        <a href="{{ $book->getUrl('/sort') }}" data-shortcut="sort" class="icon-list-item">
+            <span>@icon('sort')</span>
+            <span>{{ trans('common.sort') }}</span>
+        </a>
+        @endif
+        @if(userCan('book-create-all'))
+        <a href="{{ $book->getUrl('/copy') }}" data-shortcut="copy" class="icon-list-item">
+            <span>@icon('copy')</span>
+            <span>{{ trans('common.copy') }}</span>
+        </a>
+        @endif
+        @if(userCan('restrictions-manage', $book))
+        <a href="{{ $book->getUrl('/permissions') }}" data-shortcut="permissions" class="icon-list-item">
+            <span>@icon('lock')</span>
+            <span>{{ trans('entities.permissions') }}</span>
+        </a>
+        @endif
+        @if(userCan('book-delete', $book))
+        <a href="{{ $book->getUrl('/delete') }}" data-shortcut="delete" class="icon-list-item">
+            <span>@icon('delete')</span>
+            <span>{{ trans('common.delete') }}</span>
+        </a>
+        @endif
+
+        <hr class="primary-background">
+
+        @if($watchOptions->canWatch() && !$watchOptions->isWatching())
+        @include('entities.watch-action', ['entity' => $book])
+        @endif
+        @if(!user()->isGuest())
+        @include('entities.favourite-action', ['entity' => $book])
+        @endif
+        @if(userCan('content-export'))
+        @include('entities.export-menu', ['entity' => $book])
+        @endif
+    </div>
+</div>
 
 @stop
 
 @section('left')
 
-    @include('entities.search-form', ['label' => trans('entities.books_search_this')])
+@include('entities.search-form', ['label' => trans('entities.books_search_this')])
 
-    @if($book->tags->count() > 0)
-        <div class="mb-xl">
-            @include('entities.tag-list', ['entity' => $book])
-        </div>
-    @endif
+@if($book->tags->count() > 0)
+<div class="mb-xl">
+    @include('entities.tag-list', ['entity' => $book])
+</div>
+@endif
 
-    @if(count($bookParentShelves) > 0)
-        <div class="actions mb-xl">
-            <h5>{{ trans('entities.shelves') }}</h5>
-            @include('entities.list', ['entities' => $bookParentShelves, 'style' => 'compact'])
-        </div>
-    @endif
+@if(count($bookParentShelves) > 0)
+<div class="actions mb-xl">
+    <h5>{{ trans('entities.shelves') }}</h5>
+    @include('entities.list', ['entities' => $bookParentShelves, 'style' => 'compact'])
+</div>
+@endif
 
-    @if(count($activity) > 0)
-        <div id="recent-activity" class="mb-xl">
-            <h5>{{ trans('entities.recent_activity') }}</h5>
-            @include('common.activity-list', ['activity' => $activity])
-        </div>
-    @endif
+@if(count($activity) > 0)
+<div id="recent-activity" class="mb-xl">
+    <h5>{{ trans('entities.recent_activity') }}</h5>
+    @include('common.activity-list', ['activity' => $activity])
+</div>
+@endif
 @stop
-

--- a/resources/views/entities/grid-item.blade.php
+++ b/resources/views/entities/grid-item.blade.php
@@ -1,16 +1,20 @@
-<a href="{{ $entity->getUrl() }}" class="grid-card"
-   data-entity-type="{{ $entity->getType() }}" data-entity-id="{{ $entity->id }}">
-    <div class="bg-{{ $entity->getType() }} featured-image-container-wrap">
-        <div class="featured-image-container" @if($entity->cover) style="background-image: url('{{ $entity->getBookCover() }}')"@endif>
+<div class="grid-card" data-entity-type="{{ $entity->getType() }}" data-entity-id="{{ $entity->id }}">
+    <a href="{{ $entity->getUrl() }}" onclick="openModal(event, '{{ $entity->getUrl() }}')">
+        <div class="bg-{{ $entity->getType() }} featured-image-container-wrap">
+            <div class="featured-image-container" @if($entity->cover) style="background-image: url('{{ $entity->getBookCover() }}')"@endif>
+            </div>
+            @icon($entity->getType())
         </div>
-        @icon($entity->getType())
-    </div>
-    <div class="grid-card-content">
-        <h2 class="text-limit-lines-2">{{ $entity->name }}</h2>
-        <p class="text-muted">{{ $entity->getExcerpt(130) }}</p>
-    </div>
-    <div class="grid-card-footer text-muted ">
+        <div class="grid-card-content">
+            <h2 class="text-limit-lines-2">{{ $entity->name }}</h2>
+            <p class="text-muted">{{ $entity->getExcerpt(130) }}</p>
+        </div>
+    </a>
+    
+
+    
+    <div class="grid-card-footer text-muted">
         <p>@icon('star')<span title="{{ $entity->created_at->toDayDateTimeString() }}">{{ trans('entities.meta_created', ['timeLength' => $entity->created_at->diffForHumans()]) }}</span></p>
         <p>@icon('edit')<span title="{{ $entity->updated_at->toDayDateTimeString() }}">{{ trans('entities.meta_updated', ['timeLength' => $entity->updated_at->diffForHumans()]) }}</span></p>
     </div>
-</a>
+</div>

--- a/resources/views/layouts/tri.blade.php
+++ b/resources/views/layouts/tri.blade.php
@@ -49,5 +49,5 @@
             </div>
         </div>
     </div>
-
+    
 @stop


### PR DESCRIPTION
# 📖 Implement Book-Like Page Reading Experience on Show Book Page

## 📝 Description  
This PR introduces a **book-like page reading experience** to the show book page on BookStack. Instead of displaying content in a standard scrolling format, the pages are now structured in a **side-by-side spread**, mimicking a real book.

## 🎯 Features  
- 📚 **Two-Page Layout** – Displays book pages in a left-right format like a real book.  
- 🔄 **Page Navigation** – Users can switch pages using **Next** and **Previous** buttons.  
- 📡 **Dynamic Content Loading** – Book data is fetched dynamically via API.  

## 🛠️ Changes Made  
- Added a **modal-based book reader**.  
- Structured book content into **page spreads**.  
- Implemented **basic page switching** (without smooth flip animations).  
- Integrated API fetching for dynamic book loading.  

## ✅ How to Test  
1. Open a book on the show page.  
2. Click the **"Read Book"** button to open the flipbook.  
3. Use the **Next** and **Previous** buttons to navigate through pages.  
4. Ensure that content loads correctly in a **two-page format**.  

## 🚀 What's Next?  
- Implement **smooth page-flipping animation** for a more realistic experience.  
- Improve mobile responsiveness and add **swipe gestures** for touchscreens.  
- Optimize performance for larger books.  
