### PR TITLE
Update _text.scss to add a bottom border / underline under titles

### DIFF
--- a/resources/sass/_text.scss
+++ b/resources/sass/_text.scss
@@ -379,6 +379,10 @@ li.checkbox-item, li.task-list-item {
   overflow-wrap: break-word;
 }
 
+#bkmrk-page-title{
+  border-bottom: 1px solid rgb(121, 121, 121);
+}
+
 .text-limit-lines-1 {
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
Adds a grey border line under the title on each page view
the screenshots below show an example
![Screenshot from 2025-03-23 13-28-36](https://github.com/user-attachments/assets/a426e739-1d31-41b4-8fab-2915d018ad83)
![Screenshot from 2025-03-23 13-28-55](https://github.com/user-attachments/assets/d7f757c0-0192-4c23-b2ba-5743cfd0992b)
