### PR TITLE
API: Add endpoints for import/export

### DIFF
--- a/app/Exports/Controllers/BookExportApiController.php
+++ b/app/Exports/Controllers/BookExportApiController.php
@@ -4,6 +4,7 @@ namespace BookStack\Exports\Controllers;
 
 use BookStack\Entities\Queries\BookQueries;
 use BookStack\Exports\ExportFormatter;
+use BookStack\Exports\ZipExports\ZipExportBuilder;
 use BookStack\Http\ApiController;
 use Throwable;
 
@@ -62,5 +63,20 @@ class BookExportApiController extends ApiController
         $markdown = $this->exportFormatter->bookToMarkdown($book);
 
         return $this->download()->directly($markdown, $book->slug . '.md');
+    }
+
+    
+    /**
+     * Export a book to a contained ZIP export file.
+     * @throws NotFoundException
+     */
+    public function exportZip(int $id, ZipExportBuilder $builder)
+    {
+        $book = $this->queries->findVisibleByIdOrFail($id);
+        $bookName= $book->getShortName();
+     
+        $zip = $builder->buildForBook($book);
+
+        return $this->download()->streamedFileDirectly($zip, $bookName . '.zip', filesize($zip), true);
     }
 }

--- a/app/Exports/Controllers/ChapterExportApiController.php
+++ b/app/Exports/Controllers/ChapterExportApiController.php
@@ -4,6 +4,7 @@ namespace BookStack\Exports\Controllers;
 
 use BookStack\Entities\Queries\ChapterQueries;
 use BookStack\Exports\ExportFormatter;
+use BookStack\Exports\ZipExports\ZipExportBuilder;
 use BookStack\Http\ApiController;
 use Throwable;
 
@@ -62,5 +63,14 @@ class ChapterExportApiController extends ApiController
         $markdown = $this->exportFormatter->chapterToMarkdown($chapter);
 
         return $this->download()->directly($markdown, $chapter->slug . '.md');
+    }
+
+    public function exportZip(int $id, ZipExportBuilder $builder)
+    {
+        $chapter = $this->queries->findVisibleByIdOrFail($id);
+        $chapterName= $chapter->getShortName();
+        $zip = $builder->buildForChapter($chapter);
+
+        return $this->download()->streamedFileDirectly($zip, $chapterName . '.zip', filesize($zip), true);
     }
 }

--- a/app/Exports/Controllers/ImportApiController.php
+++ b/app/Exports/Controllers/ImportApiController.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BookStack\Exports\Controllers;
+
+use BookStack\Exceptions\ZipImportException;
+use BookStack\Exceptions\ZipValidationException;
+use BookStack\Exports\ImportRepo;
+use BookStack\Http\Controller;
+use BookStack\Uploads\AttachmentService;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class ImportApiController extends Controller
+{
+    public function __construct(
+        protected ImportRepo $imports,
+    ) {
+        $this->middleware('can:content-import');
+    }
+
+    /**
+     * List existing imports visible to the user.
+     */
+    public function list(): JsonResponse
+    {
+        $imports = $this->imports->getVisibleImports();
+
+        return response()->json([
+            'status' => 'success',
+            'imports' => $imports,
+        ]);
+    }
+
+    /**
+     * Upload, validate and store an import file.
+     */
+    public function upload(Request $request): JsonResponse
+    {
+        $this->validate($request, [
+            'file' => ['required', ...AttachmentService::getFileValidationRules()]
+        ]);
+
+        $file = $request->file('file');
+
+        try {
+            $import = $this->imports->storeFromUpload($file);
+        } catch (ZipValidationException $exception) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Validation failed',
+                'errors' => $exception->errors,
+            ], 422);
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'import' => $import,
+        ], 201);
+    }
+
+    /**
+     * Show details of a pending import.
+     */
+    public function read(int $id): JsonResponse
+    {
+        $import = $this->imports->findVisible($id);
+
+        return response()->json([
+            'status' => 'success',
+            'import' => $import,
+            'data' => $import->decodeMetadata(),
+        ]);
+    }
+
+    /**
+     * Run the import process.
+     */
+    public function create(int $id, Request $request): JsonResponse
+    {
+        $import = $this->imports->findVisible($id);
+        $parent = null;
+
+        if ($import->type === 'page' || $import->type === 'chapter') {
+            $data = $this->validate($request, [
+                'parent' => ['required', 'string'],
+            ]);
+            $parent = $data['parent'];
+        }
+
+        try {
+            $entity = $this->imports->runImport($import, $parent);
+        } catch (ZipImportException $exception) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Import failed',
+                'errors' => $exception->errors,
+            ], 500);
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'entity' => $entity,
+        ]);
+    }
+
+    /**
+     * Delete a pending import.
+     */
+    public function delete(int $id): JsonResponse
+    {
+        $import = $this->imports->findVisible($id);
+        $this->imports->deleteImport($import);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Import deleted successfully',
+        ]);
+    }
+}

--- a/app/Exports/Controllers/PageExportApiController.php
+++ b/app/Exports/Controllers/PageExportApiController.php
@@ -4,6 +4,7 @@ namespace BookStack\Exports\Controllers;
 
 use BookStack\Entities\Queries\PageQueries;
 use BookStack\Exports\ExportFormatter;
+use BookStack\Exports\ZipExports\ZipExportBuilder;
 use BookStack\Http\ApiController;
 use Throwable;
 
@@ -62,5 +63,16 @@ class PageExportApiController extends ApiController
         $markdown = $this->exportFormatter->pageToMarkdown($page);
 
         return $this->download()->directly($markdown, $page->slug . '.md');
+    }
+
+
+
+    public function exportZip(int $id, ZipExportBuilder $builder)
+    {
+        $page = $this->queries->findVisibleByIdOrFail($id);
+        $pageSlug = $page->slug;
+        $zip = $builder->buildForPage($page);
+
+        return $this->download()->streamedFileDirectly($zip, $pageSlug . '.zip', filesize($zip), true);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,6 +36,7 @@ Route::get('books/{id}/export/html', [ExportControllers\BookExportApiController:
 Route::get('books/{id}/export/pdf', [ExportControllers\BookExportApiController::class, 'exportPdf']);
 Route::get('books/{id}/export/plaintext', [ExportControllers\BookExportApiController::class, 'exportPlainText']);
 Route::get('books/{id}/export/markdown', [ExportControllers\BookExportApiController::class, 'exportMarkdown']);
+Route::get('books/{id}/export/zip', [ExportControllers\BookExportApiController::class, 'exportZip']);
 
 Route::get('chapters', [EntityControllers\ChapterApiController::class, 'list']);
 Route::post('chapters', [EntityControllers\ChapterApiController::class, 'create']);
@@ -46,6 +47,7 @@ Route::get('chapters/{id}/export/html', [ExportControllers\ChapterExportApiContr
 Route::get('chapters/{id}/export/pdf', [ExportControllers\ChapterExportApiController::class, 'exportPdf']);
 Route::get('chapters/{id}/export/plaintext', [ExportControllers\ChapterExportApiController::class, 'exportPlainText']);
 Route::get('chapters/{id}/export/markdown', [ExportControllers\ChapterExportApiController::class, 'exportMarkdown']);
+Route::get('chapters/{id}/export/zip', [ExportControllers\ChapterExportApiController::class, 'exportZip']);
 
 Route::get('pages', [EntityControllers\PageApiController::class, 'list']);
 Route::post('pages', [EntityControllers\PageApiController::class, 'create']);
@@ -57,6 +59,7 @@ Route::get('pages/{id}/export/html', [ExportControllers\PageExportApiController:
 Route::get('pages/{id}/export/pdf', [ExportControllers\PageExportApiController::class, 'exportPdf']);
 Route::get('pages/{id}/export/plaintext', [ExportControllers\PageExportApiController::class, 'exportPlainText']);
 Route::get('pages/{id}/export/markdown', [ExportControllers\PageExportApiController::class, 'exportMarkdown']);
+Route::get('pages/{id}/export/zip', [ExportControllers\PageExportApiController::class, 'exportZip']);
 
 Route::get('image-gallery', [ImageGalleryApiController::class, 'list']);
 Route::post('image-gallery', [ImageGalleryApiController::class, 'create']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -92,3 +92,9 @@ Route::get('content-permissions/{contentType}/{contentId}', [ContentPermissionAp
 Route::put('content-permissions/{contentType}/{contentId}', [ContentPermissionApiController::class, 'update']);
 
 Route::get('audit-log', [AuditLogApiController::class, 'list']);
+
+Route::get('import', [ExportControllers\ImportApiController::class, 'list']);
+Route::post('import', [ExportControllers\ImportApiController::class, 'upload']);
+Route::get('import/{id}', [ExportControllers\ImportApiController::class, 'read']);
+Route::post('import/{id}/create', [ExportControllers\ImportApiController::class, 'create']);
+Route::delete('import/{id}', [ExportControllers\ImportApiController::class, 'destroy']);


### PR DESCRIPTION
While working on my project, I extensively utilized BookStack as a central platform for organizing and managing content. During development, I identified the need for additional functionality to export and import books, along with their pages and chapters, as ZIP files. This would streamline data portability and enable seamless integration of BookStack content into other workflows.
To address this requirement, I implemented the following features:
- Export functionality: Allows users to package a book, its pages, and chapters into a single ZIP file for download.
- Import functionality: Provides the ability to upload ZIP files, automatically processing the directory structure to recreate books, pages, and chapters within BookStack.

This contribution aims to enhance BookStack’s usability by improving content sharing and migration capabilities.
Let me know if you'd like adjustments or additional details!
