### PR TITLE
Images: Changed how new image permissions are set

### DIFF
--- a/app/Config/filesystems.php
+++ b/app/Config/filesystems.php
@@ -32,7 +32,6 @@ return [
         'local' => [
             'driver'     => 'local',
             'root'       => public_path(),
-            'visibility' => 'public',
             'serve'      => false,
             'throw'      => true,
         ],
@@ -47,7 +46,6 @@ return [
         'local_secure_images' => [
             'driver'     => 'local',
             'root'       => storage_path('uploads/images/'),
-            'visibility' => 'public',
             'serve'      => false,
             'throw'      => true,
         ],


### PR DESCRIPTION
Removed default public visibility for images at the driver level, leaving only doing this as a specific action in the logic. Added try/catch around permission setting so that
permission-incompatible environments won't fatally fail, but instead log a warning.

Tested via a google cloud storage bucket FUSE mount, mounted under another user but with open 777 permissions.

Related to #5269