### PR TITLE
Add settings for number of books/shelves that will be displayed per page

### DIFF
--- a/app/App/HomeController.php
+++ b/app/App/HomeController.php
@@ -83,7 +83,7 @@ class HomeController extends Controller
         if ($homepageOption === 'bookshelves') {
             $shelves = $this->queries->shelves->visibleForListWithCover()
                 ->orderBy($commonData['listOptions']->getSort(), $commonData['listOptions']->getOrder())
-                ->paginate(18);
+                ->paginate(intval(setting('sorting-shelves-per-page', '18')));
             $data = array_merge($commonData, ['shelves' => $shelves]);
 
             return view('home.shelves', $data);
@@ -92,7 +92,7 @@ class HomeController extends Controller
         if ($homepageOption === 'books') {
             $books = $this->queries->books->visibleForListWithCover()
                 ->orderBy($commonData['listOptions']->getSort(), $commonData['listOptions']->getOrder())
-                ->paginate(18);
+                ->paginate(intval(setting('sorting-books-per-page', '18')));
             $data = array_merge($commonData, ['books' => $books]);
 
             return view('home.books', $data);

--- a/app/Entities/Controllers/BookController.php
+++ b/app/Entities/Controllers/BookController.php
@@ -48,7 +48,7 @@ class BookController extends Controller
 
         $books = $this->queries->visibleForListWithCover()
             ->orderBy($listOptions->getSort(), $listOptions->getOrder())
-            ->paginate(18);
+            ->paginate(intval(setting('sorting-books-per-page', '18')));
         $recents = $this->isSignedIn() ? $this->queries->recentlyViewedForCurrentUser()->take(4)->get() : false;
         $popular = $this->queries->popularForList()->take(4)->get();
         $new = $this->queries->visibleForList()->orderBy('created_at', 'desc')->take(4)->get();

--- a/app/Entities/Controllers/BookshelfController.php
+++ b/app/Entities/Controllers/BookshelfController.php
@@ -42,7 +42,7 @@ class BookshelfController extends Controller
 
         $shelves = $this->queries->visibleForListWithCover()
             ->orderBy($listOptions->getSort(), $listOptions->getOrder())
-            ->paginate(18);
+            ->paginate(intval(setting('sorting-shelves-per-page', '18')));
         $recents = $this->isSignedIn() ? $this->queries->recentlyViewedForCurrentUser()->get() : false;
         $popular = $this->queries->popularForList()->get();
         $new = $this->queries->visibleForList()

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -76,6 +76,10 @@ return [
 
     // Sorting Settings
     'sorting' => 'Sorting',
+    'sorting_shelves_per_page' => 'Shelves Per Page',
+    'sorting_shelves_per_page_desc' => 'Sets the number of shelves shown per page in shelf listings.',
+    'sorting_books_per_page' => 'Books Per Page',
+    'sorting_books_per_page_desc' => 'Sets the number of books shown per page in book listings.',
     'sorting_book_default' => 'Default Book Sort',
     'sorting_book_default_desc' => 'Select the default sort rule to apply to new books. This won\'t affect existing books, and can be overridden per-book.',
     'sorting_rules' => 'Sort Rules',

--- a/resources/views/settings/categories/sorting.blade.php
+++ b/resources/views/settings/categories/sorting.blade.php
@@ -10,6 +10,40 @@
         {{ csrf_field() }}
         <input type="hidden" name="section" value="sorting">
 
+        <div class="grid half gap-xl items-center">
+            <div>
+                <label for="setting-sorting-shelves-per-page"
+                    class="setting-list-label">{{ trans('settings.sorting_shelves_per_page') }}</label>
+                <p class="small">{{ trans('settings.sorting_shelves_per_page_desc') }}</p>
+            </div>
+            <div>
+                <input type="number"
+                    id="setting-sorting-shelves-per-page"
+                    name="setting-sorting-shelves-per-page"
+                    value="{{ intval(setting('sorting-shelves-per-page', 18)) }}"
+                    min="1"
+                    step="1"
+                    class="@if($errors->has('setting-sorting-shelves-per-page')) neg @endif">
+            </div>
+        </div>
+
+        <div class="grid half gap-xl items-center">
+            <div>
+                <label for="setting-sorting-books-per-page"
+                    class="setting-list-label">{{ trans('settings.sorting_books_per_page') }}</label>
+                <p class="small">{{ trans('settings.sorting_books_per_page_desc') }}</p>
+            </div>
+            <div>
+                <input type="number"
+                    id="setting-sorting-books-per-page"
+                    name="setting-sorting-books-per-page"
+                    value="{{ intval(setting('sorting-books-per-page', 18)) }}"
+                    min="1"
+                    step="1"
+                    class="@if($errors->has('setting-sorting-books-per-page')) neg @endif">
+            </div>
+        </div>
+
         <div class="setting-list">
             <div class="grid half gap-xl items-center">
                 <div>


### PR DESCRIPTION
A trivial addition to allow setting the number of paginated results on the books/shelves tab. Unfortunately I could not find a way to do this using the Logical Theme System

I'm not sure if these settings would be better placed under the "Customization" tab but I have placed them under "Sorting" for the moment. Unfortunately this does require 4 new strings in the localization files

This would close #2343 