### PR TITLE
Images: Updated local disk to have open dir perms

### DIFF
--- a/app/Config/filesystems.php
+++ b/app/Config/filesystems.php
@@ -34,6 +34,7 @@ return [
             'root'       => public_path(),
             'serve'      => false,
             'throw'      => true,
+            'directory_visibility' => 'public',
         ],
 
         'local_secure_attachments' => [

--- a/app/Uploads/ImageStorageDisk.php
+++ b/app/Uploads/ImageStorageDisk.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Log;
 use League\Flysystem\UnableToSetVisibility;
+use League\Flysystem\Visibility;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ImageStorageDisk
@@ -85,7 +86,7 @@ class ImageStorageDisk
         // require different ACLs for S3, and this provides us more logical control.
         if ($makePublic && !$this->isS3Like()) {
             try {
-                $this->filesystem->setVisibility($path, 'public');
+                $this->filesystem->setVisibility($path, Visibility::PUBLIC);
             } catch (UnableToSetVisibility $e) {
                 Log::warning("Unable to set visibility for image upload with relative path: {$path}");
             }

--- a/tests/Uploads/ImageStorageTest.php
+++ b/tests/Uploads/ImageStorageTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Uploads;
+
+use BookStack\Uploads\ImageStorage;
+use Tests\TestCase;
+
+class ImageStorageTest extends TestCase
+{
+    public function test_local_image_storage_sets_755_directory_permissions()
+    {
+        if (PHP_OS_FAMILY !== 'Linux') {
+            $this->markTestSkipped('Test only works on Linux');
+        }
+
+        config()->set('filesystems.default', 'local');
+        $storage = $this->app->make(ImageStorage::class);
+        $dirToCheck = 'test-dir-perms-' . substr(md5(random_bytes(16)), 0, 6);
+
+        $disk = $storage->getDisk('gallery');
+        $disk->put("{$dirToCheck}/image.png", 'abc', true);
+
+        $expectedPath = public_path("uploads/images/{$dirToCheck}");
+        $permissionsApplied = substr(sprintf('%o', fileperms($expectedPath)), -4);
+        $this->assertEquals('0755', $permissionsApplied);
+
+        @unlink("{$expectedPath}/image.png");
+        @rmdir($expectedPath);
+    }
+}


### PR DESCRIPTION
Sets directories created for images to have open group/all read/execute permissions so that other process users can access the files within, which goes back to how directory permissions were set before PR #5601.

Closes #5605