### PR TITLE
Add MetricsApiController with /api/status endpoint

### DIFF
--- a/app/Api/MetricsApiController.php
+++ b/app/Api/MetricsApiController.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * MetricsApiController
+ * 
+ * Provides a lightweight endpoint for retrieving basic BookStack usage statistics,
+ * including the total count of shelves, books, pages, and users. This endpoint
+ * is useful for health checks, dashboards, or external monitoring integrations.
+ * 
+ * Route: GET /api/status
+ */
+
+namespace BookStack\Api;
+
+use BookStack\Http\Controller;
+use BookStack\Entities\Models\Bookshelf;
+use BookStack\Entities\Models\Book;
+use BookStack\Entities\Models\Page;
+use BookStack\Users\Models\User;
+
+class MetricsApiController extends Controller
+{
+    /**
+     * Return basic system metrics for shelves, books, pages, and users.
+     */
+    public function getStatus()
+    {
+        return response()->json([
+            'shelves' => Bookshelf::count(),
+            'books'   => Book::count(),
+            'pages'   => Page::count(),
+            'users'   => User::count(),
+        ]);
+    }
+}
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@
 
 use BookStack\Activity\Controllers\AuditLogApiController;
 use BookStack\Api\ApiDocsController;
+use BookStack\Api\MetricsApiController;
 use BookStack\App\SystemApiController;
 use BookStack\Entities\Controllers as EntityControllers;
 use BookStack\Exports\Controllers as ExportControllers;
@@ -20,6 +21,8 @@ use BookStack\Users\Controllers\UserApiController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('docs.json', [ApiDocsController::class, 'json']);
+
+Route::get('status', [MetricsApiController::class, 'getStatus']);
 
 Route::get('attachments', [AttachmentApiController::class, 'list']);
 Route::post('attachments', [AttachmentApiController::class, 'create']);


### PR DESCRIPTION
Introduced MetricsApiController to expose basic system stats for BookStack. Provides a JSON response with counts for shelves, books, pages, and users. Registered the endpoint at /api/status for use in monitoring and dashboards. 

Specifically getHomepage in my case.

![Screenshot 2025-06-19 095603](https://github.com/user-attachments/assets/4476d784-ecb5-4a76-a8d4-6201be667ebc)

Using the customapi service feature settings below:

- Documentation:
    - bookstack:
        icon: /icons/bookstack.png
        href: "{{HOMEPAGE_VAR_BOOKSTACK_HREF}}"
        ping: http://bookstack:80
        description: document manager
        widget:
            type: customapi
            url: http://bookstack:80/api/status
            refreshInterval: 60000
            method: GET
            display: block
            mappings:
                - field: shelves
                  label: Shelves
                  format: number            
                - field: books
                  label: Books
                  format: number
                - field: pages
                  label: Pages
                  format: number
                - field: users
                  label: Users
                  format: number 