### PR TITLE
Enhance changelog input to textarea with character counter

### DIFF
--- a/resources/js/components/page-editor.js
+++ b/resources/js/components/page-editor.js
@@ -75,7 +75,12 @@ export class PageEditor extends Component {
 
         // Changelog controls
         const updateChangelogDebounced = debounce(this.updateChangelogDisplay.bind(this), 300, false);
-        this.changelogInput.addEventListener('input', updateChangelogDebounced);
+        this.changelogInput.addEventListener('input', () => {
+            const count = this.changelogInput.value.length;
+            const counterEl = document.getElementById('changelog-count');
+            if (counterEl) counterEl.innerText = `${count} / 250`;
+            updateChangelogDebounced();
+        });
 
         // Draft Controls
         onSelect(this.saveDraftButton, this.saveDraft.bind(this));

--- a/resources/views/pages/parts/editor-toolbar.blade.php
+++ b/resources/views/pages/parts/editor-toolbar.blade.php
@@ -106,11 +106,15 @@
             <ul refs="dropdown@menu" class="wide dropdown-menu">
                 <li class="px-l py-m">
                     <p class="text-muted pb-s">{{ trans('entities.pages_edit_enter_changelog_desc') }}</p>
-                    <input refs="page-editor@changelogInput"
-                           name="summary"
-                           id="summary-input"
-                           type="text"
-                           placeholder="{{ trans('entities.pages_edit_enter_changelog') }}" />
+                    <textarea
+                        refs="page-editor@changelogInput"
+                        name="summary"
+                        id="summary-input"
+                        rows="2"
+                        maxlength="250"
+                        placeholder="{{ trans('entities.pages_edit_enter_changelog') }}"
+                    ></textarea>
+                    <small class="text-muted mt-xs" id="changelog-count">0 / 250</small>
                 </li>
             </ul>
             <span>{{-- Prevents button jumping on menu show --}}</span>


### PR DESCRIPTION
This PR addresses [#5434](https://github.com/BookStackApp/BookStack/issues/5434) by improving the UX of the changelog input field during page edits.

### Changes:
- Replaced single-line `<input>` with compact `<textarea>` (`rows="2"`, `maxlength="250"`)
- Added live character counter (`0 / 250`) below the field
- Preserved preview logic using existing debounced JS handler
- UI remains visually compact as requested

### Tested:
- Page creation and editing flow
- Character counter updates live
- Summary preview still truncates after 16 chars
- Long changelogs saved correctly and appear in revision history

### Notes:
- Revision list may overflow with long changelogs - possibly a separate CSS issue