### PR TITLE
CommentDisplayTest correct namespace

### DIFF
--- a/tests/Entity/CommentDisplayTest.php
+++ b/tests/Entity/CommentDisplayTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Entity;
+namespace Tests\Entity;
 
 use BookStack\Activity\ActivityType;
 use BookStack\Activity\Models\Comment;


### PR DESCRIPTION
Correct namespace error

Class Entity\CommentDisplayTest located in ./tests/Entity/CommentDisplayTest.php does not comply with psr-4 autoloading standard (rule: Tests\ => ./tests). Skipping.