### PR TITLE
Keep draw.io theme when saving a diagram

### DIFF
--- a/resources/js/services/drawio.ts
+++ b/resources/js/services/drawio.ts
@@ -37,7 +37,7 @@ function drawEventExport(message: DrawioExportEventResponse) {
 
 function drawEventSave(message: DrawioSaveEventResponse) {
     drawPostMessage({
-        action: 'export', format: 'xmlpng', xml: message.xml, spin: 'Updating drawing',
+        action: 'export', format: 'xmlpng', xml: message.xml, spin: 'Updating drawing', keepTheme: true,
     });
 }
 


### PR DESCRIPTION
Even though #2662 is marked as solved, I don't think it's solved properly since the colors in dark mode might be not the simple invert.

@TechInterMezzo has discovered "keepTheme" option (see https://github.com/BookStackApp/BookStack/issues/2662#issuecomment-1207450833 for details), and I recently rediscovered it.

I've also tested it, and can confirm that option does work properly:
<img width="484" height="396" alt="изображение" src="https://github.com/user-attachments/assets/44cd8aa0-cfa8-4d4a-8242-9527f1eda77f" />
