### PR TITLE
Create Admin Command: New Flags

### DIFF
--- a/app/Users/UserRepo.php
+++ b/app/Users/UserRepo.php
@@ -100,13 +100,13 @@ class UserRepo
     }
 
     /**
-     * Update the given user with the given data.
+     * Update the given user with the given data, but do not create an activity.
      *
      * @param array{name: ?string, email: ?string, external_auth_id: ?string, password: ?string, roles: ?array<int>, language: ?string} $data
      *
      * @throws UserUpdateException
      */
-    public function update(User $user, array $data, bool $manageUsersAllowed): User
+    public function updateWithoutActivity(User $user, array $data, bool $manageUsersAllowed): User
     {
         if (!empty($data['name'])) {
             $user->name = $data['name'];
@@ -134,6 +134,21 @@ class UserRepo
         }
 
         $user->save();
+
+        return $user;
+    }
+
+    /**
+     * Update the given user with the given data.
+     *
+     * @param array{name: ?string, email: ?string, external_auth_id: ?string, password: ?string, roles: ?array<int>, language: ?string} $data
+     *
+     * @throws UserUpdateException
+     */
+    public function update(User $user, array $data, bool $manageUsersAllowed): User
+    {
+        $user = $this->updateWithoutActivity($user, $data, $manageUsersAllowed);
+
         Activity::add(ActivityType::USER_UPDATE, $user);
 
         return $user;

--- a/tests/Commands/CreateAdminCommandTest.php
+++ b/tests/Commands/CreateAdminCommandTest.php
@@ -109,7 +109,7 @@ class CreateAdminCommandTest extends TestCase
             '--password' => 'testing-7',
             '--initial' => true,
         ])->expectsOutput('Non-default admin user already exists. Skipping creation of new admin user.')
-            ->assertExitCode(0);
+            ->assertExitCode(2);
 
         $defaultAdmin->refresh();
 
@@ -156,7 +156,7 @@ class CreateAdminCommandTest extends TestCase
             '--password' => 'testing-7',
             '--initial' => true,
         ])->expectsOutput("Non-default admin user already exists. Skipping creation of new admin user.")
-            ->assertExitCode(0);
+            ->assertExitCode(2);
     }
 
     public function test_initial_option_creation_errors_if_email_already_exists()

--- a/tests/Commands/CreateAdminCommandTest.php
+++ b/tests/Commands/CreateAdminCommandTest.php
@@ -2,8 +2,11 @@
 
 namespace Tests\Commands;
 
+use BookStack\Users\Models\Role;
 use BookStack\Users\Models\User;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;
 
 class CreateAdminCommandTest extends TestCase
@@ -11,14 +14,14 @@ class CreateAdminCommandTest extends TestCase
     public function test_standard_command_usage()
     {
         $this->artisan('bookstack:create-admin', [
-            '--email'    => 'admintest@example.com',
-            '--name'     => 'Admin Test',
+            '--email' => 'admintest@example.com',
+            '--name' => 'Admin Test',
             '--password' => 'testing-4',
         ])->assertExitCode(0);
 
         $this->assertDatabaseHas('users', [
             'email' => 'admintest@example.com',
-            'name'  => 'Admin Test',
+            'name' => 'Admin Test',
         ]);
 
         /** @var User $user */
@@ -30,14 +33,14 @@ class CreateAdminCommandTest extends TestCase
     public function test_providing_external_auth_id()
     {
         $this->artisan('bookstack:create-admin', [
-            '--email'            => 'admintest@example.com',
-            '--name'             => 'Admin Test',
+            '--email' => 'admintest@example.com',
+            '--name' => 'Admin Test',
             '--external-auth-id' => 'xX_admin_Xx',
         ])->assertExitCode(0);
 
         $this->assertDatabaseHas('users', [
-            'email'            => 'admintest@example.com',
-            'name'             => 'Admin Test',
+            'email' => 'admintest@example.com',
+            'name' => 'Admin Test',
             'external_auth_id' => 'xX_admin_Xx',
         ]);
 
@@ -50,14 +53,178 @@ class CreateAdminCommandTest extends TestCase
     {
         $this->artisan('bookstack:create-admin', [
             '--email' => 'admintest@example.com',
-            '--name'  => 'Admin Test',
+            '--name' => 'Admin Test',
         ])->expectsQuestion('Please specify a password for the new admin user (8 characters min)', 'hunter2000')
             ->assertExitCode(0);
 
         $this->assertDatabaseHas('users', [
             'email' => 'admintest@example.com',
-            'name'  => 'Admin Test',
+            'name' => 'Admin Test',
         ]);
         $this->assertTrue(Auth::attempt(['email' => 'admintest@example.com', 'password' => 'hunter2000']));
+    }
+
+    public function test_generate_password_option()
+    {
+        $this->withoutMockingConsoleOutput()
+            ->artisan('bookstack:create-admin', [
+                '--email' => 'admintest@example.com',
+                '--name' => 'Admin Test',
+                '--generate-password' => true,
+            ]);
+
+        $output = trim(Artisan::output());
+        $this->assertMatchesRegularExpression('/^[a-zA-Z0-9]{32}$/', $output);
+
+        $user = User::query()->where('email', '=', 'admintest@example.com')->first();
+        $this->assertTrue(Hash::check($output, $user->password));
+    }
+
+    public function test_initial_option_updates_default_admin()
+    {
+        $defaultAdmin = User::query()->where('email', '=', 'admin@admin.com')->first();
+
+        $this->artisan('bookstack:create-admin', [
+            '--email' => 'firstadmin@example.com',
+            '--name' => 'Admin Test',
+            '--password' => 'testing-7',
+            '--initial' => true,
+        ])->expectsOutput('The default admin user has been updated with the provided details!')
+            ->assertExitCode(0);
+
+        $defaultAdmin->refresh();
+
+        $this->assertEquals('firstadmin@example.com', $defaultAdmin->email);
+    }
+
+    public function test_initial_option_does_not_update_if_only_non_default_admin_exists()
+    {
+        $defaultAdmin = User::query()->where('email', '=', 'admin@admin.com')->first();
+        $defaultAdmin->email = 'testadmin@example.com';
+        $defaultAdmin->save();
+
+        $this->artisan('bookstack:create-admin', [
+            '--email' => 'firstadmin@example.com',
+            '--name' => 'Admin Test',
+            '--password' => 'testing-7',
+            '--initial' => true,
+        ])->expectsOutput('Non-default admin user already exists. Skipping creation of new admin user.')
+            ->assertExitCode(0);
+
+        $defaultAdmin->refresh();
+
+        $this->assertEquals('testadmin@example.com', $defaultAdmin->email);
+    }
+
+    public function test_initial_option_updates_creates_new_admin_if_none_exists()
+    {
+        $adminRole = Role::getSystemRole('admin');
+        $adminRole->users()->delete();
+        $this->assertEquals(0, $adminRole->users()->count());
+
+        $this->artisan('bookstack:create-admin', [
+            '--email' => 'firstadmin@example.com',
+            '--name' => 'My initial admin',
+            '--password' => 'testing-7',
+            '--initial' => true,
+        ])->expectsOutput("Admin account with email \"firstadmin@example.com\" successfully created!")
+            ->assertExitCode(0);
+
+        $this->assertEquals(1, $adminRole->users()->count());
+        $this->assertDatabaseHas('users', [
+            'email' => 'firstadmin@example.com',
+            'name' => 'My initial admin',
+        ]);
+    }
+
+    public function test_initial_rerun_does_not_error_but_skips()
+    {
+        $adminRole = Role::getSystemRole('admin');
+        $adminRole->users()->delete();
+
+        $this->artisan('bookstack:create-admin', [
+            '--email' => 'firstadmin@example.com',
+            '--name' => 'My initial admin',
+            '--password' => 'testing-7',
+            '--initial' => true,
+        ])->expectsOutput("Admin account with email \"firstadmin@example.com\" successfully created!")
+            ->assertExitCode(0);
+
+        $this->artisan('bookstack:create-admin', [
+            '--email' => 'firstadmin@example.com',
+            '--name' => 'My initial admin',
+            '--password' => 'testing-7',
+            '--initial' => true,
+        ])->expectsOutput("Non-default admin user already exists. Skipping creation of new admin user.")
+            ->assertExitCode(0);
+    }
+
+    public function test_initial_option_creation_errors_if_email_already_exists()
+    {
+        $adminRole = Role::getSystemRole('admin');
+        $adminRole->users()->delete();
+        $editor = $this->users->editor();
+
+        $this->artisan('bookstack:create-admin', [
+            '--email' => $editor->email,
+            '--name' => 'My initial admin',
+            '--password' => 'testing-7',
+            '--initial' => true,
+        ])->expectsOutput("Could not create admin account.")
+            ->expectsOutput("An account with the email address \"{$editor->email}\" already exists.")
+            ->assertExitCode(1);
+    }
+
+    public function test_initial_option_updating_errors_if_email_already_exists()
+    {
+        $editor = $this->users->editor();
+        $defaultAdmin = User::query()->where('email', '=', 'admin@admin.com')->first();
+        $this->assertNotNull($defaultAdmin);
+
+        $this->artisan('bookstack:create-admin', [
+            '--email' => $editor->email,
+            '--name' => 'My initial admin',
+            '--password' => 'testing-7',
+            '--initial' => true,
+        ])->expectsOutput("Could not create admin account.")
+            ->expectsOutput("An account with the email address \"{$editor->email}\" already exists.")
+            ->assertExitCode(1);
+    }
+
+    public function test_initial_option_does_not_require_name_or_email_to_be_passed()
+    {
+        $adminRole = Role::getSystemRole('admin');
+        $adminRole->users()->delete();
+        $this->assertEquals(0, $adminRole->users()->count());
+
+        $this->artisan('bookstack:create-admin', [
+            '--generate-password' => true,
+            '--initial' => true,
+        ])->assertExitCode(0);
+
+        $this->assertEquals(1, $adminRole->users()->count());
+        $this->assertDatabaseHas('users', [
+            'email' => 'admin@example.com',
+            'name' => 'Admin',
+        ]);
+    }
+
+    public function test_initial_option_updating_existing_user_with_generate_password_only_outputs_password()
+    {
+        $defaultAdmin = User::query()->where('email', '=', 'admin@admin.com')->first();
+
+        $this->withoutMockingConsoleOutput()
+            ->artisan('bookstack:create-admin', [
+            '--email' => 'firstadmin@example.com',
+            '--name' => 'Admin Test',
+            '--generate-password' => true,
+            '--initial' => true,
+        ]);
+
+        $output = Artisan::output();
+        $this->assertMatchesRegularExpression('/^[a-zA-Z0-9]{32}$/', $output);
+
+        $defaultAdmin->refresh();
+        $this->assertEquals('firstadmin@example.com', $defaultAdmin->email);
     }
 }


### PR DESCRIPTION
This adds flags to target changes to the first default admin user, and to generate a password.

Related to #4575.

New flags:

- `--generate-password`: Generate a random password, and echo it back out as the only output on success.
- `--initial`: Update the default `admin@admin.com` user if an existing admin, otherwise create a new admin user if there's no existing admin accounts.

When the `--initial` flag is given, the email and name of the account will default to `admin@example.com` and `Admin` if not provided (Allowing simpler default account creation in future). If the default admin does not exist with this flag, and an existing non-default admin already exists, then user creation will be skipped with a message and an exit code of `2`.

### Docs Updates

- Details these flags and behaviours in the command line docs
