### PR TITLE
Enhance video attachment support with preview and embed functionality

### DIFF
--- a/app/Uploads/Attachment.php
+++ b/app/Uploads/Attachment.php
@@ -36,6 +36,7 @@ class Attachment extends Model
     protected $hidden = ['path', 'page'];
     protected $casts = [
         'external' => 'bool',
+        'metadata' => 'array',
     ];
 
     /**
@@ -82,9 +83,11 @@ class Attachment extends Model
      */
     public function editorContent(): array
     {
-        $videoExtensions = ['mp4', 'webm', 'mkv', 'ogg', 'avi'];
-        if (in_array(strtolower($this->extension), $videoExtensions)) {
-            $html = '<video src="' . e($this->getUrl(true)) . '" controls width="480" height="270"></video>';
+        if ($this->isVideo()) {
+            $html = '<video controls width="100%" style="max-width: 720px; height: auto;" preload="metadata">'
+                  . '<source src="' . e($this->getUrl(true)) . '" type="' . e($this->getVideoMimeType()) . '">'
+                  . 'Your browser does not support the video tag.'
+                  . '</video>';
             return ['text/html' => $html, 'text/plain' => $html];
         }
 
@@ -105,6 +108,37 @@ class Attachment extends Model
     public function markdownLink(): string
     {
         return '[' . $this->name . '](' . $this->getUrl() . ')';
+    }
+
+    /**
+     * Check if this attachment is a video file.
+     */
+    public function isVideo(): bool
+    {
+        if ($this->external) {
+            return false;
+        }
+
+        $videoExtensions = ['mp4', 'webm', 'mkv', 'ogg', 'avi', 'mov', 'm4v'];
+        return in_array(strtolower($this->extension), $videoExtensions);
+    }
+
+    /**
+     * Get the mime type for video streaming.
+     */
+    public function getVideoMimeType(): string
+    {
+        $mimeTypes = [
+            'mp4' => 'video/mp4',
+            'webm' => 'video/webm',
+            'ogg' => 'video/ogg',
+            'avi' => 'video/x-msvideo',
+            'mov' => 'video/quicktime',
+            'm4v' => 'video/x-m4v',
+            'mkv' => 'video/x-matroska',
+        ];
+
+        return $mimeTypes[strtolower($this->extension)] ?? 'video/mp4';
     }
 
     /**

--- a/app/Uploads/Controllers/AttachmentController.php
+++ b/app/Uploads/Controllers/AttachmentController.php
@@ -227,14 +227,76 @@ class AttachmentController extends Controller
         }
 
         $fileName = $attachment->getFileName();
-        $attachmentStream = $this->attachmentService->streamAttachmentFromStorage($attachment);
         $attachmentSize = $this->attachmentService->getAttachmentFileSize($attachment);
+
+        // Handle Range Requests for video streaming
+        if ($attachment->isVideo() && $request->hasHeader('Range')) {
+            return $this->streamVideoWithRange($request, $attachment, $fileName, $attachmentSize);
+        }
+
+        $attachmentStream = $this->attachmentService->streamAttachmentFromStorage($attachment);
 
         if ($request->get('open') === 'true') {
             return $this->download()->streamedInline($attachmentStream, $fileName, $attachmentSize);
         }
 
         return $this->download()->streamedDirectly($attachmentStream, $fileName, $attachmentSize);
+    }
+
+    /**
+     * Stream video with Range Request support.
+     */
+    protected function streamVideoWithRange(Request $request, Attachment $attachment, string $fileName, int $fileSize)
+    {
+        $range = $request->header('Range');
+        $mimeType = $attachment->getVideoMimeType();
+        
+        // Parse Range header
+        if (!preg_match('/bytes=(\d+)-(\d+)?/', $range, $matches)) {
+            return response('Invalid Range', 416);
+        }
+
+        $start = intval($matches[1]);
+        $end = isset($matches[2]) && $matches[2] !== '' ? intval($matches[2]) : $fileSize - 1;
+        
+        if ($start > $end || $end >= $fileSize) {
+            return response('Range Not Satisfiable', 416)
+                ->header('Content-Range', "bytes */$fileSize");
+        }
+
+        $length = $end - $start + 1;
+        
+        // Get partial content stream
+        $stream = $this->attachmentService->streamAttachmentFromStorage($attachment);
+        
+        if ($start > 0) {
+            fseek($stream, $start);
+        }
+
+        return response()->stream(
+            function () use ($stream, $length) {
+                $remaining = $length;
+                $chunkSize = 1024 * 1024; // 1MB chunks
+                
+                while ($remaining > 0 && !feof($stream)) {
+                    $toRead = min($chunkSize, $remaining);
+                    echo fread($stream, $toRead);
+                    $remaining -= $toRead;
+                    flush();
+                }
+                
+                fclose($stream);
+            },
+            206, // Partial Content
+            [
+                'Content-Type' => $mimeType,
+                'Content-Length' => $length,
+                'Accept-Ranges' => 'bytes',
+                'Content-Range' => "bytes $start-$end/$fileSize",
+                'Cache-Control' => 'no-cache',
+                'Content-Disposition' => 'inline; filename="' . $fileName . '"',
+            ]
+        );
     }
 
     /**

--- a/database/migrations/2024_01_15_add_video_metadata_to_attachments.php
+++ b/database/migrations/2024_01_15_add_video_metadata_to_attachments.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('attachments', function (Blueprint $table) {
+            $table->string('mime_type')->nullable()->after('extension');
+            $table->json('metadata')->nullable()->after('mime_type');
+            $table->unsignedBigInteger('file_size')->nullable()->after('metadata');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('attachments', function (Blueprint $table) {
+            $table->dropColumn(['mime_type', 'metadata', 'file_size']);
+        });
+    }
+};

--- a/lang/en/common.php
+++ b/lang/en/common.php
@@ -12,6 +12,7 @@ return [
     'save' => 'Save',
     'continue' => 'Continue',
     'select' => 'Select',
+    'preview' => 'Preview',
     'toggle_all' => 'Toggle All',
     'more' => 'More',
 

--- a/lang/en/entities.php
+++ b/lang/en/entities.php
@@ -369,6 +369,7 @@ return [
     'attachments_link_url_hint' => 'Url of site or file',
     'attach' => 'Attach',
     'attachments_insert_link' => 'Add Attachment Link to Page',
+    'attachments_embed_video' => 'Embed Video',
     'attachments_edit_file' => 'Edit File',
     'attachments_edit_file_name' => 'File Name',
     'attachments_edit_drop_upload' => 'Drop files or click here to upload and overwrite',

--- a/resources/js/components/index.ts
+++ b/resources/js/components/index.ts
@@ -59,6 +59,7 @@ export {TemplateManager} from './template-manager';
 export {ToggleSwitch} from './toggle-switch';
 export {TriLayout} from './tri-layout';
 export {UserSelect} from './user-select';
+export {VideoPreview} from './video-preview';
 export {WebhookEvents} from './webhook-events';
 export {WysiwygEditor} from './wysiwyg-editor';
 export {WysiwygEditorTinymce} from './wysiwyg-editor-tinymce';

--- a/resources/js/components/video-preview.js
+++ b/resources/js/components/video-preview.js
@@ -1,0 +1,100 @@
+import {Component} from './component';
+
+export class VideoPreview extends Component {
+
+    setup() {
+        this.container = null;
+        this.setupEventListeners();
+    }
+
+    setupEventListeners() {
+        // Handle clicks via event delegation
+        document.addEventListener('click', (e) => {
+
+            if (e.target.classList.contains('video-preview-btn') || e.target.closest('.video-preview-btn')) {
+                e.preventDefault();
+                const button = e.target.classList.contains('video-preview-btn') ? e.target : e.target.closest('.video-preview-btn');
+                const url = button.getAttribute('data-video-url');
+                const name = button.getAttribute('data-video-name');
+                this.showPreview(url, name);
+            }
+            
+
+            // Handle close button clicks
+            if (e.target.classList.contains('video-preview-close') || e.target.closest('.video-preview-close')) {
+                e.preventDefault();
+                this.closePreview();
+            }
+
+            // Handle backdrop clicks
+            if (e.target.classList.contains('video-preview-backdrop')) {
+                e.preventDefault();
+                this.closePreview();
+            }
+        });
+    }
+
+    showPreview(videoUrl, videoName) {
+        // Remove any existing preview
+        this.closePreview();
+
+        // Create modal container
+        this.container = document.createElement('div');
+        this.container.className = 'video-preview-modal';
+        this.container.innerHTML = `
+            <div class="video-preview-backdrop"></div>
+            <div class="video-preview-content">
+                <div class="video-preview-header">
+                    <h3>${this.escapeHtml(videoName)}</h3>
+                    <button type="button" class="video-preview-close">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <line x1="18" y1="6" x2="6" y2="18"></line>
+                            <line x1="6" y1="6" x2="18" y2="18"></line>
+                        </svg>
+                    </button>
+                </div>
+                <div class="video-preview-player">
+                    <video controls autoplay preload="metadata">
+                        <source src="${this.escapeHtml(videoUrl)}" type="video/mp4">
+                        Your browser does not support the video tag.
+                    </video>
+                </div>
+            </div>
+        `;
+
+        document.body.appendChild(this.container);
+
+        // Add ESC key listener
+        this.escListener = (e) => {
+            if (e.key === 'Escape') {
+                this.closePreview();
+            }
+        };
+        document.addEventListener('keydown', this.escListener);
+
+        // Prevent body scroll
+        document.body.style.overflow = 'hidden';
+    }
+
+    closePreview() {
+        if (this.container) {
+            this.container.remove();
+            this.container = null;
+        }
+
+        if (this.escListener) {
+            document.removeEventListener('keydown', this.escListener);
+            this.escListener = null;
+        }
+
+        // Restore body scroll
+        document.body.style.overflow = '';
+    }
+
+
+    escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+}

--- a/resources/sass/components/_video-preview.scss
+++ b/resources/sass/components/_video-preview.scss
@@ -1,0 +1,222 @@
+// Video Preview Modal Styles
+.video-preview-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: fadeIn 0.3s ease;
+}
+
+.video-preview-backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.85);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    cursor: pointer;
+}
+
+.video-preview-content {
+    position: relative;
+    width: 90%;
+    max-width: 1200px;
+    max-height: 90vh;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
+    animation: scaleIn 0.3s ease;
+}
+
+.video-preview-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    border-bottom: 1px solid #e0e0e0;
+    
+    h3 {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 500;
+        color: #333;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: calc(100% - 40px);
+    }
+}
+
+.video-preview-close {
+    background: none;
+    border: none;
+    padding: 4px;
+    cursor: pointer;
+    color: #666;
+    transition: color 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    
+    &:hover {
+        color: #000;
+    }
+    
+    svg {
+        width: 20px;
+        height: 20px;
+    }
+}
+
+.video-preview-player {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #000;
+    
+    video {
+        width: 100%;
+        height: 100%;
+        max-height: calc(90vh - 60px);
+        object-fit: contain;
+    }
+}
+
+// Attachment list improvements for videos
+.attachment.icon-list {
+    .icon {
+        svg[data-icon="play-circle"] {
+            color: #4CAF50;
+        }
+    }
+    
+    .video-preview-btn,
+    .video-embed-btn {
+        width: 100%;
+        text-align: left;
+        background: none;
+        border: none;
+        padding: 8px 16px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        color: inherit;
+        transition: background-color 0.2s ease;
+        
+        &:hover {
+            background-color: rgba(0, 0, 0, 0.05);
+        }
+        
+        svg {
+            width: 16px;
+            height: 16px;
+            flex-shrink: 0;
+        }
+        
+        div {
+            flex: 1;
+        }
+    }
+}
+
+// Animations
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes scaleIn {
+    from {
+        transform: scale(0.9);
+        opacity: 0;
+    }
+    to {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+
+@keyframes slideIn {
+    from {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+@keyframes slideOut {
+    from {
+        transform: translateX(0);
+        opacity: 1;
+    }
+    to {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+}
+
+// Dark mode support
+html.dark-mode {
+    .video-preview-content {
+        background: #1e1e1e;
+        
+        .video-preview-header {
+            border-bottom-color: #333;
+            
+            h3 {
+                color: #ddd;
+            }
+        }
+        
+        .video-preview-close {
+            color: #aaa;
+            
+            &:hover {
+                color: #fff;
+            }
+        }
+    }
+    
+    .attachment.icon-list {
+        .video-preview-btn,
+        .video-embed-btn {
+            &:hover {
+                background-color: rgba(255, 255, 255, 0.05);
+            }
+        }
+    }
+}
+
+// Mobile responsiveness
+@media (max-width: 768px) {
+    .video-preview-content {
+        width: 100%;
+        height: 100%;
+        max-width: 100%;
+        max-height: 100%;
+        border-radius: 0;
+    }
+    
+    .video-preview-player video {
+        max-height: calc(100vh - 60px);
+    }
+}

--- a/resources/sass/styles.scss
+++ b/resources/sass/styles.scss
@@ -23,6 +23,7 @@
 @use "lists";
 @use "pages";
 @use "content";
+@use "components/video-preview";
 
 @media print {
   @include meta.load-css("print");

--- a/resources/views/attachments/list.blade.php
+++ b/resources/views/attachments/list.blade.php
@@ -1,25 +1,43 @@
 <div component="attachments-list">
+    <!-- Video Preview Component (always present for initialization) -->
+    <div component="video-preview" style="display: none;" data-debug="video-preview-list"></div>
+    
     @foreach($attachments as $attachment)
         <div class="attachment icon-list">
             <div class="split-icon-list-item attachment-{{ $attachment->external ? 'link' : 'file' }}">
                 <a href="{{ $attachment->getUrl() }}"
                    refs="attachments-list@link-type-{{ $attachment->external ? 'link' : 'file' }}"
                    @if($attachment->external) target="_blank" @endif>
-                    <div class="icon">@icon($attachment->external ? 'export' : 'file')</div>
+                    <div class="icon">@icon($attachment->external ? 'export' : ($attachment->isVideo() ? 'editor/media' : 'file'))</div>
                     <div class="label">{{ $attachment->name }}</div>
                 </a>
                 @if(!$attachment->external)
                     <div component="dropdown" class="icon-list-item-dropdown">
                         <button refs="dropdown@toggle" type="button" class="icon-list-item-dropdown-toggle">@icon('caret-down')</button>
                         <ul refs="dropdown@menu" class="dropdown-menu" role="menu">
-                            <a href="{{ $attachment->getUrl(false) }}" class="icon-item">
-                                @icon('download')
-                                <div>{{ trans('common.download') }}</div>
-                            </a>
-                            <a href="{{ $attachment->getUrl(true) }}" target="_blank" class="icon-item">
-                                @icon('export')
-                                <div>{{ trans('common.open_in_tab') }}</div>
-                            </a>
+                            @if($attachment->isVideo())
+                                <li>
+                                    <button type="button" 
+                                            class="icon-item video-preview-btn" 
+                                            data-video-url="{{ $attachment->getUrl(true) }}"
+                                            data-video-name="{{ $attachment->name }}">
+                                        @icon('editor/media')
+                                        <div>{{ trans('common.preview') }}</div>
+                                    </button>
+                                </li>
+                            @endif
+                            <li>
+                                <a href="{{ $attachment->getUrl(false) }}" class="icon-item">
+                                    @icon('download')
+                                    <div>{{ trans('common.download') }}</div>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="{{ $attachment->getUrl(true) }}" target="_blank" class="icon-item">
+                                    @icon('export')
+                                    <div>{{ trans('common.open_in_tab') }}</div>
+                                </a>
+                            </li>
                         </ul>
                     </div>
                 @endif

--- a/resources/views/attachments/manager-list.blade.php
+++ b/resources/views/attachments/manager-list.blade.php
@@ -1,5 +1,8 @@
 <div component="sortable-list"
      option:sortable-list:handle-selector=".handle, a">
+    <!-- Video Preview Component (always present for initialization) -->
+    <div component="video-preview" style="display: none;" data-debug="video-preview-manager"></div>
+    
     @foreach($attachments as $attachment)
         <div component="ajax-delete-row"
              option:ajax-delete-row:url="{{ url('/attachments/' . $attachment->id) }}"
@@ -11,11 +14,24 @@
                 <a href="{{ $attachment->getUrl() }}" target="_blank" rel="noopener">{{ $attachment->name }}</a>
             </div>
             <div class="flex-fill justify-flex-end">
-                <button component="event-emit-select"
-                        option:event-emit-select:name="insert"
-                        type="button"
-                        title="{{ trans('entities.attachments_insert_link') }}"
-                        class="drag-card-action text-center text-link">@icon('link')</button>
+                @if($attachment->isVideo())
+                    <button type="button" 
+                            class="drag-card-action text-center text-link video-preview-btn" 
+                            data-video-url="{{ $attachment->getUrl(true) }}"
+                            data-video-name="{{ $attachment->name }}"
+                            title="{{ trans('common.preview') }}">@icon('editor/media')</button>
+                    <button component="event-emit-select"
+                            option:event-emit-select:name="insert"
+                            type="button"
+                            title="{{ trans('entities.attachments_embed_video') }}"
+                            class="drag-card-action text-center text-link">@icon('add')</button>
+                @else
+                    <button component="event-emit-select"
+                            option:event-emit-select:name="insert"
+                            type="button"
+                            title="{{ trans('entities.attachments_insert_link') }}"
+                            class="drag-card-action text-center text-link">@icon('link')</button>
+                @endif
                 @if(userCan('attachment-update', $attachment))
                     <button component="event-emit-select"
                             option:event-emit-select:name="edit"


### PR DESCRIPTION
### Summary
This PR introduces improved support for video attachments:

- Inline preview modal with responsive `<video>` player.
- Embed option in editor toolbox.
- HTTP Range support for efficient streaming & seeking.
- New migration for storing `mime_type`, `metadata` and `file_size`.
- Updated UI icons and i18n strings for video actions.

### Notes
- Supported formats: mp4, webm, mkv, ogg, avi, mov, m4v.
- Changes are backward compatible (nullable DB columns).
- Frontend additions: `VideoPreview` component and styles.

### Screenshots

<img width="2555" height="1269" alt="modal-video" src="https://github.com/user-attachments/assets/f2150a8f-3731-4deb-a58f-38d8b16ada08" />
<img width="464" height="414" alt="preview-button" src="https://github.com/user-attachments/assets/06cee070-45b5-4d0c-a07f-8a6e4485d298" />
<img width="2555" height="842" alt="preview-button-2" src="https://github.com/user-attachments/assets/e8b5a6a4-f311-4a45-a3b9-0d96a0963d44" />


---
