### PR TITLE
fix: empty space for the empty description field

### DIFF
--- a/app/Entities/Models/HtmlDescriptionTrait.php
+++ b/app/Entities/Models/HtmlDescriptionTrait.php
@@ -13,6 +13,7 @@ trait HtmlDescriptionTrait
     public function descriptionHtml(bool $raw = false): string
     {
         $html = $this->description_html ?: '<p>' . nl2br(e($this->description)) . '</p>';
+        $html = preg_replace('/<p>(\s|&nbsp;|<br\s*\/?>)*<\/p>/i', '', $html);
         if ($raw) {
             return $html;
         }


### PR DESCRIPTION
Fix empty description rendering 
CLOSES #5724 

Centralized empty HTML trimming in HasHtmlDescription.php and updated views to prevent rendering <p> tags for empty descriptions.