### PR TITLE
Fix PWA manifest access behind authenticated proxies

### DIFF
--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -29,7 +29,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="{{ setting('app-icon-32') ?: url('/icon-32.png') }}">
 
     <!-- PWA -->
-    <link rel="manifest" href="{{ url('/manifest.json') }}">
+    <link rel="manifest" href="{{ url('/manifest.json') }}" crossorigin="use-credentials">
     <meta name="mobile-web-app-capable" content="yes">
 
     <!-- OpenSearch -->


### PR DESCRIPTION
In environments where BookStack is served behind an authenticated proxy (such as Cloudflare Zero Trust), the browser fails to fetch `manifest.json` since credentials are not sent by default.
As a result, PWA installation and functionality do not work.

This PR resolves the issue by adding `crossorigin="use-credentials"` to the `<link rel="manifest">` tag, ensuring credentials are included when the manifest is requested.

Reference:
https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest#deploying_a_manifest
