### PR TITLE
Exports: Updated perm checking for images in ZIP exports

### DIFF
--- a/app/Uploads/Image.php
+++ b/app/Uploads/Image.php
@@ -13,14 +13,14 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
- * @property int    $id
- * @property string $name
- * @property string $url
- * @property string $path
- * @property string $type
- * @property int    $uploaded_to
- * @property int    $created_by
- * @property int    $updated_by
+ * @property int      $id
+ * @property string   $name
+ * @property string   $url
+ * @property string   $path
+ * @property string   $type
+ * @property int|null $uploaded_to
+ * @property int      $created_by
+ * @property int      $updated_by
  */
 class Image extends Model implements OwnableInterface
 {

--- a/app/Uploads/ImageStorage.php
+++ b/app/Uploads/ImageStorage.php
@@ -35,6 +35,15 @@ class ImageStorage
     }
 
     /**
+     * Check if "local secure" (Fetched behind auth, either with or without permissions enforced)
+     * is currently active in the instance.
+     */
+    public function usingSecureImages(): bool
+    {
+        return config('filesystems.images') === 'local_secure' || $this->usingSecureRestrictedImages();
+    }
+
+    /**
      * Clean up an image file name to be both URL and storage safe.
      */
     public function cleanImageFileName(string $name): string


### PR DESCRIPTION
For #5885
Adds to, uses and cleans-up central permission checking in ImageService to mirror that which would be experienced by users in the UI to result in the same image access conditions.

Adds testing to cover.