### PR TITLE
Do not use deprecated NAMEID_EMAIL_ADDRESS as default for SAML2 logout

### DIFF
--- a/app/Access/Saml2Service.php
+++ b/app/Access/Saml2Service.php
@@ -65,8 +65,7 @@ class Saml2Service
                 [],
                 $user->email,
                 $sessionIndex,
-                true,
-                Constants::NAMEID_EMAIL_ADDRESS
+                true
             );
             $id = $toolKit->getLastRequestID();
         } catch (Error $error) {

--- a/app/Config/saml2.php
+++ b/app/Config/saml2.php
@@ -78,7 +78,7 @@ return [
             // Specifies constraints on the name identifier to be used to
             // represent the requested subject.
             // Take a look on lib/Saml2/Constants.php to see the NameIdFormat supported
-            'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+            'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
 
             // Usually x509cert and privateKey of the SP are provided by files placed at
             // the certs folder. But we can also provide them with the following parameters


### PR DESCRIPTION
For SAML 2.0 **logout**, the "`NAMEID_EMAIL_ADDRESS`" (`urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`) is used as the default value. As the value is set, it can **not** be overwritten in the `onelogin` framework for example by setting something like

    SAML2_ONELOGIN_OVERRIDES: '{"sp":{"NameIDFormat":"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"}}'

Further, the `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress` is outdated by IDMs like shibboleth.

By removing this line, the default settings of the underlying framework are being used and users can adapt the value according to their needs by using the overrides.