### PR TITLE
More flexible OIDC key support

### DIFF
--- a/app/Access/Oidc/OidcJwtSigningKey.php
+++ b/app/Access/Oidc/OidcJwtSigningKey.php
@@ -2,6 +2,7 @@
 
 namespace BookStack\Access\Oidc;
 
+use Illuminate\Support\Facades\Log;
 use phpseclib3\Crypt\Common\PublicKey;
 use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Crypt\RSA;
@@ -63,8 +64,9 @@ class OidcJwtSigningKey
         // 'alg' is optional for a JWK, but we will still attempt to validate if
         // it exists otherwise presume it will be compatible.
         $alg = $jwk['alg'] ?? null;
-        if ($jwk['kty'] !== 'RSA' || !(is_null($alg) || $alg === 'RS256')) {
-            throw new OidcInvalidKeyException("Only RS256 keys are currently supported. Found key using {$alg}");
+        $algorithm = OidcJwtSigningKeyAlgorithm::tryFrom($alg ?? OidcJwtSigningKeyAlgorithm::RS256->value);
+        if ($jwk['kty'] !== 'RSA' || $algorithm === null) {
+            throw new OidcInvalidKeyException("Only " . OidcJwtSigningKeyAlgorithm::getSupportedAlgorithms() . " keys are currently supported. Found key using {$alg}");
         }
 
         // 'use' is optional for a JWK but we assume 'sig' where no value exists since that's what
@@ -97,7 +99,16 @@ class OidcJwtSigningKey
             throw new OidcInvalidKeyException('Key loaded from file path is not an RSA key as expected');
         }
 
-        $this->key = $key->withPadding(RSA::SIGNATURE_PKCS1);
+        // apply key-algorithm depending hash
+        $key = match ($algorithm) {
+            OidcJwtSigningKeyAlgorithm::RS256 => $key->withHash('sha256'),
+            OidcJwtSigningKeyAlgorithm::RS512 => $key->withHash('sha512'),
+        };
+        // apply key-algorithm depending padding
+        $this->key = match ($algorithm) {
+            OidcJwtSigningKeyAlgorithm::RS256,
+            OidcJwtSigningKeyAlgorithm::RS512 => $key->withPadding(RSA::SIGNATURE_PKCS1),
+        };
     }
 
     /**

--- a/app/Access/Oidc/OidcJwtSigningKeyAlgorithm.php
+++ b/app/Access/Oidc/OidcJwtSigningKeyAlgorithm.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BookStack\Access\Oidc;
+
+use UnitEnum;
+
+enum OidcJwtSigningKeyAlgorithm: string
+{
+    case RS256 = 'RS256';
+    case RS512 = 'RS512';
+
+    public static function getSupportedAlgorithms(): string
+    {
+        return join(',', array_map(static fn (UnitEnum $enum) => $enum->value, self::cases()));
+    }
+}

--- a/app/Access/Oidc/OidcJwtWithClaims.php
+++ b/app/Access/Oidc/OidcJwtWithClaims.php
@@ -119,8 +119,8 @@ class OidcJwtWithClaims implements ProvidesClaims
      */
     protected function validateTokenSignature(): void
     {
-        if ($this->header['alg'] !== 'RS256') {
-            throw new OidcInvalidTokenException("Only RS256 signature validation is supported. Token reports using {$this->header['alg']}");
+        if (OidcJwtSigningKeyAlgorithm::tryFrom($this->header['alg']) === null) {
+            throw new OidcInvalidTokenException("Only " . OidcJwtSigningKeyAlgorithm::getSupportedAlgorithms() . " signature validation is supported. Token reports using {$this->header['alg']}");
         }
 
         $parsedKeys = array_map(function ($key) {

--- a/app/Access/Oidc/OidcProviderSettings.php
+++ b/app/Access/Oidc/OidcProviderSettings.php
@@ -158,10 +158,10 @@ class OidcProviderSettings
     protected function filterKeys(array $keys): array
     {
         return array_filter($keys, function (array $key) {
-            $alg = $key['alg'] ?? 'RS256';
+            $alg = $key['alg'] ?? OidcJwtSigningKeyAlgorithm::RS256->value;
             $use = $key['use'] ?? 'sig';
 
-            return $key['kty'] === 'RSA' && $use === 'sig' && $alg === 'RS256';
+            return $key['kty'] === 'RSA' && $use === 'sig' && OidcJwtSigningKeyAlgorithm::tryFrom($alg) !== null;
         });
     }
 


### PR DESCRIPTION
The goal of this PR is to allow more key algorithms for OIDC signing keys.

The concerns regarding such implementation in #5390 were considered. I try to address them by allowing a flexible, extensible, and somewhat maintainable approach, which I gratefully take feedback on and am willing to improve by the feedback provided.

Therefore, the issue with this PR is not the few lines of code changed but the architecture of how more key algorithms could be supported. For presentation reasons, I added the RS512 algorithm, which I had done before.
If the suggested approach would be considered by the maintainers, I needed some support to extend and test this with more common algorithms like ES256 as described in the issue mentioned above.

Besides that, the test suits would probably need at least a test case per key algorithm to confirm that the implementations are working, which is currently a ToDo.