### PR TITLE
Slug History Tracking & Usage

### DIFF
--- a/app/App/SluggableInterface.php
+++ b/app/App/SluggableInterface.php
@@ -5,11 +5,9 @@ namespace BookStack\App;
 /**
  * Assigned to models that can have slugs.
  * Must have the below properties.
+ *
+ * @property string $slug
  */
 interface SluggableInterface
 {
-    /**
-     * Regenerate the slug for this model.
-     */
-    public function refreshSlug(): string;
 }

--- a/app/Entities/Controllers/ChapterController.php
+++ b/app/Entities/Controllers/ChapterController.php
@@ -77,7 +77,15 @@ class ChapterController extends Controller
      */
     public function show(string $bookSlug, string $chapterSlug)
     {
-        $chapter = $this->queries->findVisibleBySlugsOrFail($bookSlug, $chapterSlug);
+        try {
+            $chapter = $this->queries->findVisibleBySlugsOrFail($bookSlug, $chapterSlug);
+        } catch (NotFoundException $exception) {
+            $chapter = $this->entityQueries->findVisibleByOldSlugs('chapter', $chapterSlug, $bookSlug);
+            if (is_null($chapter)) {
+                throw $exception;
+            }
+            return redirect($chapter->getUrl());
+        }
 
         $sidebarTree = (new BookContents($chapter->book))->getTree();
         $pages = $this->entityQueries->pages->visibleForChapterList($chapter->id)->get();

--- a/app/Entities/Controllers/PageController.php
+++ b/app/Entities/Controllers/PageController.php
@@ -17,7 +17,6 @@ use BookStack\Entities\Tools\PageContent;
 use BookStack\Entities\Tools\PageEditActivity;
 use BookStack\Entities\Tools\PageEditorData;
 use BookStack\Exceptions\NotFoundException;
-use BookStack\Exceptions\NotifyException;
 use BookStack\Exceptions\PermissionsException;
 use BookStack\Http\Controller;
 use BookStack\Permissions\Permission;
@@ -140,9 +139,7 @@ class PageController extends Controller
         try {
             $page = $this->queries->findVisibleBySlugsOrFail($bookSlug, $pageSlug);
         } catch (NotFoundException $e) {
-            $revision = $this->entityQueries->revisions->findLatestVersionBySlugs($bookSlug, $pageSlug);
-            $page = $revision->page ?? null;
-
+            $page = $this->entityQueries->findVisibleByOldSlugs('page', $pageSlug, $bookSlug);
             if (is_null($page)) {
                 throw $e;
             }

--- a/app/Entities/Models/BookChild.php
+++ b/app/Entities/Models/BookChild.php
@@ -16,6 +16,7 @@ abstract class BookChild extends Entity
 {
     /**
      * Get the book this page sits in.
+     * @return BelongsTo<Book, $this>
      */
     public function book(): BelongsTo
     {

--- a/app/Entities/Models/BookChild.php
+++ b/app/Entities/Models/BookChild.php
@@ -2,7 +2,6 @@
 
 namespace BookStack\Entities\Models;
 
-use BookStack\References\ReferenceUpdater;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -21,30 +20,5 @@ abstract class BookChild extends Entity
     public function book(): BelongsTo
     {
         return $this->belongsTo(Book::class)->withTrashed();
-    }
-
-    /**
-     * Change the book that this entity belongs to.
-     */
-    public function changeBook(int $newBookId): self
-    {
-        $oldUrl = $this->getUrl();
-        $this->book_id = $newBookId;
-        $this->unsetRelation('book');
-        $this->refreshSlug();
-        $this->save();
-
-        if ($oldUrl !== $this->getUrl()) {
-            app()->make(ReferenceUpdater::class)->updateEntityReferences($this, $oldUrl);
-        }
-
-        // Update all child pages if a chapter
-        if ($this instanceof Chapter) {
-            foreach ($this->pages()->withTrashed()->get() as $page) {
-                $page->changeBook($newBookId);
-            }
-        }
-
-        return $this;
     }
 }

--- a/app/Entities/Models/Entity.php
+++ b/app/Entities/Models/Entity.php
@@ -13,7 +13,6 @@ use BookStack\Activity\Models\Viewable;
 use BookStack\Activity\Models\Watch;
 use BookStack\App\Model;
 use BookStack\App\SluggableInterface;
-use BookStack\Entities\Tools\SlugGenerator;
 use BookStack\Permissions\JointPermissionBuilder;
 use BookStack\Permissions\Models\EntityPermission;
 use BookStack\Permissions\Models\JointPermission;
@@ -403,16 +402,6 @@ abstract class Entity extends Model implements
     public function indexForSearch(): void
     {
         app()->make(SearchIndex::class)->indexEntity(clone $this);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function refreshSlug(): string
-    {
-        $this->slug = app()->make(SlugGenerator::class)->generate($this, $this->name);
-
-        return $this->slug;
     }
 
     /**

--- a/app/Entities/Models/Entity.php
+++ b/app/Entities/Models/Entity.php
@@ -431,6 +431,14 @@ abstract class Entity extends Model implements
     }
 
     /**
+     * Get the related slug history for this entity.
+     */
+    public function slugHistory(): MorphMany
+    {
+        return $this->morphMany(SlugHistory::class, 'sluggable');
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function logDescriptor(): string

--- a/app/Entities/Models/SlugHistory.php
+++ b/app/Entities/Models/SlugHistory.php
@@ -4,6 +4,7 @@ namespace BookStack\Entities\Models;
 
 use BookStack\App\Model;
 use BookStack\Permissions\Models\JointPermission;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
@@ -15,6 +16,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 class SlugHistory extends Model
 {
+    use HasFactory;
+
     protected $table = 'slug_history';
 
     public function jointPermissions(): HasMany

--- a/app/Entities/Models/SlugHistory.php
+++ b/app/Entities/Models/SlugHistory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace BookStack\Entities\Models;
+
+use BookStack\App\Model;
+use BookStack\Permissions\Models\JointPermission;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $sluggable_id
+ * @property string $sluggable_type
+ * @property string $slug
+ * @property ?string $parent_slug
+ */
+class SlugHistory extends Model
+{
+    protected $table = 'slug_history';
+
+    public function jointPermissions(): HasMany
+    {
+        return $this->hasMany(JointPermission::class, 'entity_id', 'sluggable_id')
+            ->whereColumn('joint_permissions.entity_type', '=', 'slug_history.sluggable_type');
+    }
+}

--- a/app/Entities/Repos/BaseRepo.php
+++ b/app/Entities/Repos/BaseRepo.php
@@ -8,6 +8,8 @@ use BookStack\Entities\Models\HasCoverInterface;
 use BookStack\Entities\Models\HasDescriptionInterface;
 use BookStack\Entities\Models\Entity;
 use BookStack\Entities\Queries\PageQueries;
+use BookStack\Entities\Tools\SlugGenerator;
+use BookStack\Entities\Tools\SlugHistory;
 use BookStack\Exceptions\ImageUploadException;
 use BookStack\References\ReferenceStore;
 use BookStack\References\ReferenceUpdater;
@@ -25,6 +27,8 @@ class BaseRepo
         protected ReferenceStore $referenceStore,
         protected PageQueries $pageQueries,
         protected BookSorter $bookSorter,
+        protected SlugGenerator $slugGenerator,
+        protected SlugHistory $slugHistory,
     ) {
     }
 
@@ -43,7 +47,7 @@ class BaseRepo
             'updated_by' => user()->id,
             'owned_by'   => user()->id,
         ]);
-        $entity->refreshSlug();
+        $this->refreshSlug($entity);
 
         if ($entity instanceof HasDescriptionInterface) {
             $this->updateDescription($entity, $input);
@@ -78,7 +82,7 @@ class BaseRepo
         $entity->updated_by = user()->id;
 
         if ($entity->isDirty('name') || empty($entity->slug)) {
-            $entity->refreshSlug();
+            $this->refreshSlug($entity);
         }
 
         if ($entity instanceof HasDescriptionInterface) {
@@ -154,5 +158,17 @@ class BaseRepo
         } else if (isset($input['description'])) {
             $entity->descriptionInfo()->set('', $input['description']);
         }
+    }
+
+    /**
+     * Refresh the slug for the given entity.
+     */
+    public function refreshSlug(Entity $entity): void
+    {
+        if ($entity->id) {
+            $this->slugHistory->recordForEntity($entity);
+        }
+
+        $this->slugGenerator->regenerateForEntity($entity);
     }
 }

--- a/app/Entities/Repos/BaseRepo.php
+++ b/app/Entities/Repos/BaseRepo.php
@@ -165,10 +165,7 @@ class BaseRepo
      */
     public function refreshSlug(Entity $entity): void
     {
-        if ($entity->id) {
-            $this->slugHistory->recordForEntity($entity);
-        }
-
+        $this->slugHistory->recordForEntity($entity);
         $this->slugGenerator->regenerateForEntity($entity);
     }
 }

--- a/app/Entities/Repos/ChapterRepo.php
+++ b/app/Entities/Repos/ChapterRepo.php
@@ -7,6 +7,7 @@ use BookStack\Entities\Models\Book;
 use BookStack\Entities\Models\Chapter;
 use BookStack\Entities\Queries\EntityQueries;
 use BookStack\Entities\Tools\BookContents;
+use BookStack\Entities\Tools\ParentChanger;
 use BookStack\Entities\Tools\TrashCan;
 use BookStack\Exceptions\MoveOperationException;
 use BookStack\Exceptions\PermissionsException;
@@ -21,6 +22,7 @@ class ChapterRepo
         protected BaseRepo $baseRepo,
         protected EntityQueries $entityQueries,
         protected TrashCan $trashCan,
+        protected ParentChanger $parentChanger,
     ) {
     }
 
@@ -97,7 +99,7 @@ class ChapterRepo
         }
 
         return (new DatabaseTransaction(function () use ($chapter, $parent) {
-            $chapter = $chapter->changeBook($parent->id);
+            $this->parentChanger->changeBook($chapter, $parent->id);
             $chapter->rebuildPermissions();
             Activity::add(ActivityType::CHAPTER_MOVE, $chapter);
 

--- a/app/Entities/Tools/HierarchyTransformer.php
+++ b/app/Entities/Tools/HierarchyTransformer.php
@@ -17,7 +17,8 @@ class HierarchyTransformer
         protected BookRepo $bookRepo,
         protected BookshelfRepo $shelfRepo,
         protected Cloner $cloner,
-        protected TrashCan $trashCan
+        protected TrashCan $trashCan,
+        protected ParentChanger $parentChanger,
     ) {
     }
 
@@ -35,7 +36,7 @@ class HierarchyTransformer
         foreach ($chapter->pages as $page) {
             $page->chapter_id = 0;
             $page->save();
-            $page->changeBook($book->id);
+            $this->parentChanger->changeBook($page, $book->id);
         }
 
         $this->trashCan->destroyEntity($chapter);

--- a/app/Entities/Tools/ParentChanger.php
+++ b/app/Entities/Tools/ParentChanger.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace BookStack\Entities\Tools;
+
+use BookStack\Entities\Models\BookChild;
+use BookStack\Entities\Models\Chapter;
+use BookStack\References\ReferenceUpdater;
+
+class ParentChanger
+{
+    public function __construct(
+        protected SlugGenerator $slugGenerator,
+        protected ReferenceUpdater $referenceUpdater
+    ) {
+    }
+
+    /**
+     * Change the parent book of a chapter or page.
+     */
+    public function changeBook(BookChild $child, int $newBookId): void
+    {
+        $oldUrl = $child->getUrl();
+
+        $child->book_id = $newBookId;
+        $child->unsetRelation('book');
+        $this->slugGenerator->regenerateForEntity($child);
+        $child->save();
+
+        if ($oldUrl !== $child->getUrl()) {
+            $this->referenceUpdater->updateEntityReferences($child, $oldUrl);
+        }
+
+        // Update all child pages if a chapter
+        if ($child instanceof Chapter) {
+            foreach ($child->pages()->withTrashed()->get() as $page) {
+                $this->changeBook($page, $newBookId);
+            }
+        }
+    }
+}

--- a/app/Entities/Tools/SlugGenerator.php
+++ b/app/Entities/Tools/SlugGenerator.php
@@ -5,12 +5,14 @@ namespace BookStack\Entities\Tools;
 use BookStack\App\Model;
 use BookStack\App\SluggableInterface;
 use BookStack\Entities\Models\BookChild;
+use BookStack\Entities\Models\Entity;
+use BookStack\Users\Models\User;
 use Illuminate\Support\Str;
 
 class SlugGenerator
 {
     /**
-     * Generate a fresh slug for the given entity.
+     * Generate a fresh slug for the given item.
      * The slug will be generated so that it doesn't conflict within the same parent item.
      */
     public function generate(SluggableInterface&Model $model, string $slugSource): string
@@ -21,6 +23,26 @@ class SlugGenerator
         }
 
         return $slug;
+    }
+
+    /**
+     * Regenerate the slug for the given entity.
+     */
+    public function regenerateForEntity(Entity $entity): string
+    {
+        $entity->slug = $this->generate($entity, $entity->name);
+
+        return $entity->slug;
+    }
+
+    /**
+     * Regenerate the slug for a user.
+     */
+    public function regenerateForUser(User $user): string
+    {
+        $user->slug = $this->generate($user, $user->name);
+
+        return $user->slug;
     }
 
     /**

--- a/app/Entities/Tools/SlugHistory.php
+++ b/app/Entities/Tools/SlugHistory.php
@@ -2,6 +2,7 @@
 
 namespace BookStack\Entities\Tools;
 
+use BookStack\Entities\Models\BookChild;
 use BookStack\Entities\Models\Entity;
 use Illuminate\Support\Facades\DB;
 
@@ -12,16 +13,25 @@ class SlugHistory
      */
     public function recordForEntity(Entity $entity): void
     {
+        if (!$entity->id || !$entity->slug) {
+            return;
+        }
+
         $latest = $this->getLatestEntryForEntity($entity);
         if ($latest && $latest->slug === $entity->slug && $latest->parent_slug === $entity->getParent()?->slug) {
             return;
+        }
+
+        $parentSlug = null;
+        if ($entity instanceof BookChild) {
+            $parentSlug = $entity->book()->first()?->slug;
         }
 
         $info = [
             'sluggable_type' => $entity->getMorphClass(),
             'sluggable_id'   => $entity->id,
             'slug'           => $entity->slug,
-            'parent_slug'    => $entity->getParent()?->slug,
+            'parent_slug'    => $parentSlug,
             'created_at'     => now(),
             'updated_at'     => now(),
         ];

--- a/app/Entities/Tools/SlugHistory.php
+++ b/app/Entities/Tools/SlugHistory.php
@@ -4,10 +4,16 @@ namespace BookStack\Entities\Tools;
 
 use BookStack\Entities\Models\BookChild;
 use BookStack\Entities\Models\Entity;
-use Illuminate\Support\Facades\DB;
+use BookStack\Entities\Models\SlugHistory as SlugHistoryModel;
+use BookStack\Permissions\PermissionApplicator;
 
 class SlugHistory
 {
+    public function __construct(
+        protected PermissionApplicator $permissions,
+    ) {
+    }
+
     /**
      * Record the current slugs for the given entity.
      */
@@ -17,14 +23,14 @@ class SlugHistory
             return;
         }
 
-        $latest = $this->getLatestEntryForEntity($entity);
-        if ($latest && $latest->slug === $entity->slug && $latest->parent_slug === $entity->getParent()?->slug) {
-            return;
-        }
-
         $parentSlug = null;
         if ($entity instanceof BookChild) {
             $parentSlug = $entity->book()->first()?->slug;
+        }
+
+        $latest = $this->getLatestEntryForEntity($entity);
+        if ($latest && $latest->slug === $entity->slug && $latest->parent_slug === $parentSlug) {
+            return;
         }
 
         $info = [
@@ -32,16 +38,37 @@ class SlugHistory
             'sluggable_id'   => $entity->id,
             'slug'           => $entity->slug,
             'parent_slug'    => $parentSlug,
-            'created_at'     => now(),
-            'updated_at'     => now(),
         ];
 
-        DB::table('slug_history')->insert($info);
+        $entry = new SlugHistoryModel();
+        $entry->forceFill($info);
+        $entry->save();
     }
 
-    protected function getLatestEntryForEntity(Entity $entity): \stdClass|null
+    /**
+     * Find the latest visible entry for an entity which uses the given slug(s) in the history.
+     */
+    public function lookupEntityIdUsingSlugs(string $type, string $slug, string $parentSlug = ''): ?int
     {
-        return DB::table('slug_history')
+        $query = SlugHistoryModel::query()
+            ->where('sluggable_type', '=', $type)
+            ->where('slug', '=', $slug);
+
+        if ($parentSlug) {
+            $query->where('parent_slug', '=', $parentSlug);
+        }
+
+        $query = $this->permissions->restrictEntityRelationQuery($query, 'slug_history', 'sluggable_id', 'sluggable_type');
+
+        /** @var SlugHistoryModel|null $result */
+        $result = $query->orderBy('created_at', 'desc')->first();
+
+        return $result?->sluggable_id;
+    }
+
+    protected function getLatestEntryForEntity(Entity $entity): SlugHistoryModel|null
+    {
+        return SlugHistoryModel::query()
             ->where('sluggable_type', '=', $entity->getMorphClass())
             ->where('sluggable_id', '=', $entity->id)
             ->orderBy('created_at', 'desc')

--- a/app/Entities/Tools/SlugHistory.php
+++ b/app/Entities/Tools/SlugHistory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace BookStack\Entities\Tools;
+
+use BookStack\Entities\Models\Entity;
+use Illuminate\Support\Facades\DB;
+
+class SlugHistory
+{
+    /**
+     * Record the current slugs for the given entity.
+     */
+    public function recordForEntity(Entity $entity): void
+    {
+        $latest = $this->getLatestEntryForEntity($entity);
+        if ($latest && $latest->slug === $entity->slug && $latest->parent_slug === $entity->getParent()?->slug) {
+            return;
+        }
+
+        $info = [
+            'sluggable_type' => $entity->getMorphClass(),
+            'sluggable_id'   => $entity->id,
+            'slug'           => $entity->slug,
+            'parent_slug'    => $entity->getParent()?->slug,
+            'created_at'     => now(),
+            'updated_at'     => now(),
+        ];
+
+        DB::table('slug_history')->insert($info);
+    }
+
+    protected function getLatestEntryForEntity(Entity $entity): \stdClass|null
+    {
+        return DB::table('slug_history')
+            ->where('sluggable_type', '=', $entity->getMorphClass())
+            ->where('sluggable_id', '=', $entity->id)
+            ->orderBy('created_at', 'desc')
+            ->first();
+    }
+}

--- a/app/Entities/Tools/TrashCan.php
+++ b/app/Entities/Tools/TrashCan.php
@@ -388,7 +388,7 @@ class TrashCan
     /**
      * Update entity relations to remove or update outstanding connections.
      */
-    protected function destroyCommonRelations(Entity $entity)
+    protected function destroyCommonRelations(Entity $entity): void
     {
         Activity::removeEntity($entity);
         $entity->views()->delete();
@@ -402,6 +402,7 @@ class TrashCan
         $entity->watches()->delete();
         $entity->referencesTo()->delete();
         $entity->referencesFrom()->delete();
+        $entity->slugHistory()->delete();
 
         if ($entity instanceof HasCoverInterface && $entity->coverInfo()->exists()) {
             $imageService = app()->make(ImageService::class);

--- a/app/Sorting/BookSorter.php
+++ b/app/Sorting/BookSorter.php
@@ -8,12 +8,14 @@ use BookStack\Entities\Models\Chapter;
 use BookStack\Entities\Models\Entity;
 use BookStack\Entities\Models\Page;
 use BookStack\Entities\Queries\EntityQueries;
+use BookStack\Entities\Tools\ParentChanger;
 use BookStack\Permissions\Permission;
 
 class BookSorter
 {
     public function __construct(
         protected EntityQueries $queries,
+        protected ParentChanger $parentChanger,
     ) {
     }
 
@@ -155,7 +157,7 @@ class BookSorter
 
         // Action the required changes
         if ($bookChanged) {
-            $model = $model->changeBook($newBook->id);
+            $this->parentChanger->changeBook($model, $newBook->id);
         }
 
         if ($model instanceof Page && $chapterChanged) {

--- a/app/Users/Models/User.php
+++ b/app/Users/Models/User.php
@@ -11,7 +11,6 @@ use BookStack\Activity\Models\Watch;
 use BookStack\Api\ApiToken;
 use BookStack\App\Model;
 use BookStack\App\SluggableInterface;
-use BookStack\Entities\Tools\SlugGenerator;
 use BookStack\Permissions\Permission;
 use BookStack\Translation\LocaleDefinition;
 use BookStack\Translation\LocaleManager;
@@ -357,15 +356,5 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     public function logDescriptor(): string
     {
         return "({$this->id}) {$this->name}";
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function refreshSlug(): string
-    {
-        $this->slug = app()->make(SlugGenerator::class)->generate($this, $this->name);
-
-        return $this->slug;
     }
 }

--- a/app/Users/UserRepo.php
+++ b/app/Users/UserRepo.php
@@ -5,6 +5,7 @@ namespace BookStack\Users;
 use BookStack\Access\UserInviteException;
 use BookStack\Access\UserInviteService;
 use BookStack\Activity\ActivityType;
+use BookStack\Entities\Tools\SlugGenerator;
 use BookStack\Exceptions\NotifyException;
 use BookStack\Exceptions\UserUpdateException;
 use BookStack\Facades\Activity;
@@ -21,7 +22,8 @@ class UserRepo
 {
     public function __construct(
         protected UserAvatars $userAvatar,
-        protected UserInviteService $inviteService
+        protected UserInviteService $inviteService,
+        protected SlugGenerator $slugGenerator,
     ) {
     }
 
@@ -63,7 +65,7 @@ class UserRepo
         $user->email_confirmed = $emailConfirmed;
         $user->external_auth_id = $data['external_auth_id'] ?? '';
 
-        $user->refreshSlug();
+        $this->slugGenerator->regenerateForUser($user);
         $user->save();
 
         if (!empty($data['language'])) {
@@ -109,7 +111,7 @@ class UserRepo
     {
         if (!empty($data['name'])) {
             $user->name = $data['name'];
-            $user->refreshSlug();
+            $this->slugGenerator->regenerateForUser($user);
         }
 
         if (!empty($data['email']) && $manageUsersAllowed) {

--- a/database/factories/Entities/Models/SlugHistoryFactory.php
+++ b/database/factories/Entities/Models/SlugHistoryFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories\Entities\Models;
+
+use BookStack\Entities\Models\Book;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\BookStack\Entities\Models\SlugHistory>
+ */
+class SlugHistoryFactory extends Factory
+{
+    protected $model = \BookStack\Entities\Models\SlugHistory::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'sluggable_id' => Book::factory(),
+            'sluggable_type' => 'book',
+            'slug' => $this->faker->slug(),
+            'parent_slug' => null,
+        ];
+    }
+}

--- a/database/migrations/2025_11_23_161812_create_slug_history_table.php
+++ b/database/migrations/2025_11_23_161812_create_slug_history_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Create the table for storing slug history
+        Schema::create('slug_history', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('sluggable_type', 10)->index();
+            $table->unsignedBigInteger('sluggable_id')->index();
+            $table->string('slug')->index();
+            $table->string('parent_slug')->nullable()->index();
+            $table->timestamps();
+        });
+
+        // Migrate in slugs from page revisions
+        $revisionSlugQuery = DB::table('page_revisions')
+            ->select([
+                DB::raw('\'page\' as sluggable_type'),
+                'page_id as sluggable_id',
+                'slug',
+                'book_slug as parent_slug',
+                DB::raw('min(created_at) as created_at'),
+                DB::raw('min(updated_at) as updated_at'),
+            ])
+            ->where('type', '=', 'version')
+            ->groupBy(['sluggable_id', 'slug', 'parent_slug']);
+
+        DB::table('slug_history')->insertUsing(
+            ['sluggable_type', 'sluggable_id', 'slug', 'parent_slug', 'created_at', 'updated_at'],
+            $revisionSlugQuery,
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('slug_history');
+    }
+};

--- a/tests/Entity/BookTest.php
+++ b/tests/Entity/BookTest.php
@@ -238,30 +238,6 @@ class BookTest extends TestCase
         $this->assertEquals('list', setting()->getUser($editor, 'books_view_type'));
     }
 
-    public function test_slug_multi_byte_url_safe()
-    {
-        $book = $this->entities->newBook([
-            'name' => 'информация',
-        ]);
-
-        $this->assertEquals('informaciia', $book->slug);
-
-        $book = $this->entities->newBook([
-            'name' => '¿Qué?',
-        ]);
-
-        $this->assertEquals('que', $book->slug);
-    }
-
-    public function test_slug_format()
-    {
-        $book = $this->entities->newBook([
-            'name' => 'PartA / PartB / PartC',
-        ]);
-
-        $this->assertEquals('parta-partb-partc', $book->slug);
-    }
-
     public function test_description_limited_to_specific_html()
     {
         $book = $this->entities->book();

--- a/tests/Entity/PageTest.php
+++ b/tests/Entity/PageTest.php
@@ -269,28 +269,6 @@ class PageTest extends TestCase
         ]);
     }
 
-    public function test_old_page_slugs_redirect_to_new_pages()
-    {
-        $page = $this->entities->page();
-
-        // Need to save twice since revisions are not generated in seeder.
-        $this->asAdmin()->put($page->getUrl(), [
-            'name' => 'super test',
-            'html' => '<p></p>',
-        ]);
-
-        $page->refresh();
-        $pageUrl = $page->getUrl();
-
-        $this->put($pageUrl, [
-            'name' => 'super test page',
-            'html' => '<p></p>',
-        ]);
-
-        $this->get($pageUrl)
-            ->assertRedirect("/books/{$page->book->slug}/page/super-test-page");
-    }
-
     public function test_page_within_chapter_deletion_returns_to_chapter()
     {
         $chapter = $this->entities->chapter();

--- a/tests/Entity/SlugTest.php
+++ b/tests/Entity/SlugTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Entity;
+
+use Tests\TestCase;
+
+class SlugTest extends TestCase
+{
+    public function test_slug_multi_byte_url_safe()
+    {
+        $book = $this->entities->newBook([
+            'name' => 'информация',
+        ]);
+
+        $this->assertEquals('informaciia', $book->slug);
+
+        $book = $this->entities->newBook([
+            'name' => '¿Qué?',
+        ]);
+
+        $this->assertEquals('que', $book->slug);
+    }
+
+    public function test_slug_format()
+    {
+        $book = $this->entities->newBook([
+            'name' => 'PartA / PartB / PartC',
+        ]);
+
+        $this->assertEquals('parta-partb-partc', $book->slug);
+    }
+
+    public function test_old_page_slugs_redirect_to_new_pages()
+    {
+        $page = $this->entities->page();
+
+        // Need to save twice since revisions are not generated in seeder.
+        $this->asAdmin()->put($page->getUrl(), [
+            'name' => 'super test',
+            'html' => '<p></p>',
+        ]);
+
+        $page->refresh();
+        $pageUrl = $page->getUrl();
+
+        $this->put($pageUrl, [
+            'name' => 'super test page',
+            'html' => '<p></p>',
+        ]);
+
+        $this->get($pageUrl)
+            ->assertRedirect("/books/{$page->book->slug}/page/super-test-page");
+    }
+
+    public function test_slugs_recorded_in_history_on_page_update()
+    {
+        $page = $this->entities->page();
+        $this->asAdmin()->put($page->getUrl(), [
+            'name' => 'new slug',
+            'html' => '<p></p>',
+        ]);
+
+        $oldSlug = $page->slug;
+        $page->refresh();
+        $this->assertNotEquals($oldSlug, $page->slug);
+
+        $this->assertDatabaseHas('slug_history', [
+            'sluggable_id' => $page->id,
+            'sluggable_type' => 'page',
+            'slug' => $oldSlug,
+            'parent_slug' => $page->book->slug,
+        ]);
+    }
+
+    public function test_slugs_recorded_in_history_on_chapter_update()
+    {
+        $chapter = $this->entities->chapter();
+        $this->asAdmin()->put($chapter->getUrl(), [
+            'name' => 'new slug',
+        ]);
+
+        $oldSlug = $chapter->slug;
+        $chapter->refresh();
+        $this->assertNotEquals($oldSlug, $chapter->slug);
+
+        $this->assertDatabaseHas('slug_history', [
+            'sluggable_id' => $chapter->id,
+            'sluggable_type' => 'chapter',
+            'slug' => $oldSlug,
+            'parent_slug' => $chapter->book->slug,
+        ]);
+    }
+
+    public function test_slugs_recorded_in_history_on_book_update()
+    {
+        $book = $this->entities->book();
+        $this->asAdmin()->put($book->getUrl(), [
+            'name' => 'new slug',
+        ]);
+
+        $oldSlug = $book->slug;
+        $book->refresh();
+        $this->assertNotEquals($oldSlug, $book->slug);
+
+        $this->assertDatabaseHas('slug_history', [
+            'sluggable_id' => $book->id,
+            'sluggable_type' => 'book',
+            'slug' => $oldSlug,
+            'parent_slug' => null,
+        ]);
+    }
+
+    public function test_slugs_recorded_in_history_on_shelf_update()
+    {
+        $shelf = $this->entities->shelf();
+        $this->asAdmin()->put($shelf->getUrl(), [
+            'name' => 'new slug',
+        ]);
+
+        $oldSlug = $shelf->slug;
+        $shelf->refresh();
+        $this->assertNotEquals($oldSlug, $shelf->slug);
+
+        $this->assertDatabaseHas('slug_history', [
+            'sluggable_id' => $shelf->id,
+            'sluggable_type' => 'bookshelf',
+            'slug' => $oldSlug,
+            'parent_slug' => null,
+        ]);
+    }
+}

--- a/tests/Entity/SlugTest.php
+++ b/tests/Entity/SlugTest.php
@@ -33,23 +33,82 @@ class SlugTest extends TestCase
     public function test_old_page_slugs_redirect_to_new_pages()
     {
         $page = $this->entities->page();
-
-        // Need to save twice since revisions are not generated in seeder.
-        $this->asAdmin()->put($page->getUrl(), [
-            'name' => 'super test',
-            'html' => '<p></p>',
-        ]);
-
-        $page->refresh();
         $pageUrl = $page->getUrl();
 
-        $this->put($pageUrl, [
+        $this->asAdmin()->put($pageUrl, [
             'name' => 'super test page',
             'html' => '<p></p>',
         ]);
 
         $this->get($pageUrl)
             ->assertRedirect("/books/{$page->book->slug}/page/super-test-page");
+    }
+
+    public function test_old_shelf_slugs_redirect_to_new_shelf()
+    {
+        $shelf = $this->entities->shelf();
+        $shelfUrl = $shelf->getUrl();
+
+        $this->asAdmin()->put($shelf->getUrl(), [
+            'name' => 'super test shelf',
+        ]);
+
+        $this->get($shelfUrl)
+            ->assertRedirect("/shelves/super-test-shelf");
+    }
+
+    public function test_old_book_slugs_redirect_to_new_book()
+    {
+        $book = $this->entities->book();
+        $bookUrl = $book->getUrl();
+
+        $this->asAdmin()->put($book->getUrl(), [
+            'name' => 'super test book',
+        ]);
+
+        $this->get($bookUrl)
+            ->assertRedirect("/books/super-test-book");
+    }
+
+    public function test_old_chapter_slugs_redirect_to_new_chapter()
+    {
+        $chapter = $this->entities->chapter();
+        $chapterUrl = $chapter->getUrl();
+
+        $this->asAdmin()->put($chapter->getUrl(), [
+            'name' => 'super test chapter',
+        ]);
+
+        $this->get($chapterUrl)
+            ->assertRedirect("/books/{$chapter->book->slug}/chapter/super-test-chapter");
+    }
+
+    public function test_old_book_slugs_in_page_urls_redirect_to_current_page_url()
+    {
+        $page = $this->entities->page();
+        $book = $page->book;
+        $pageUrl = $page->getUrl();
+
+        $this->asAdmin()->put($book->getUrl(), [
+            'name' => 'super test book',
+        ]);
+
+        $this->get($pageUrl)
+            ->assertRedirect("/books/super-test-book/page/{$page->slug}");
+    }
+
+    public function test_old_book_slugs_in_chapter_urls_redirect_to_current_chapter_url()
+    {
+        $chapter = $this->entities->chapter();
+        $book = $chapter->book;
+        $chapterUrl = $chapter->getUrl();
+
+        $this->asAdmin()->put($book->getUrl(), [
+            'name' => 'super test book',
+        ]);
+
+        $this->get($chapterUrl)
+            ->assertRedirect("/books/super-test-book/chapter/{$chapter->slug}");
     }
 
     public function test_slugs_recorded_in_history_on_page_update()


### PR DESCRIPTION
Adds a purpose-built slug tracking system to note old slugs on changes, so that they can be used for lookup.
We're already doing something similar via page revisions, but this will be a more robust implementation which works for all core content types.

For #5411

### Todo

- [x] Create new table & migrate revision slug data.
- [x] Log shelf slug changes
- [x] Log book slug changes
- [x] Log chapter slug changes
- [x] Log page slug changes
- [x] Add shelf slug handling fallback
- [x] Add book slug handling fallback
- [x] Add chapter slug handling fallback
- [x] Update page slug handling fallback to use this
- [x] Ensure child items can be looked up after parent slug change
- [x] Add testing coverage