### PR TITLE
Fix: Remove validUntil attribute from SAML SP Metadata

### DIFF
--- a/app/Access/Saml2Service.php
+++ b/app/Access/Saml2Service.php
@@ -157,7 +157,7 @@ class Saml2Service
     {
         $toolKit = $this->getToolkit(true);
         $settings = $toolKit->getSettings();
-        $metadata = $settings->getSPMetadata();
+        $metadata = $settings->getSPMetadata(ignoreValidUntil: true);
         $errors = $settings->validateMetadata($metadata);
 
         if (!empty($errors)) {


### PR DESCRIPTION
This PR disables the `validUntil` attribute in the generated SAML Service Provider (SP) metadata.

## Why this is needed
Currently, the underlying `php-saml` library hardcodes the metadata validity (`TIME_VALID`) to **2 days** and caching (`TIME_CACHED`) to **1 week** (Source: [Metadata.php](https://github.com/SAML-Toolkits/php-saml/tree/master/lib/Saml2/Metadata.php)).

In many real-world scenarios, specifically with Identity Providers like Shibboleth, these default windows are too short. This causes the IdP to deny connections or require manual metadata refreshes once the hardcoded time passes.

The `getSPMetadata` function in [Settings.php](https://github.com/SAML-Toolkits/php-saml/blob/master/lib/Saml2/Settings.php) allows for an `$ignoreValidUntil` parameter.

* I have updated the `getSPMetadata` call to set `$ignoreValidUntil` to `true`.
* This removes the `validUntil` timestamp from the XML generated at `<URL>/saml2/metadata`, preventing arbitrary expiration issues.