### PR TITLE
Lexical fixes for v25.12

### DIFF
--- a/resources/js/wysiwyg/services/shortcuts.ts
+++ b/resources/js/wysiwyg/services/shortcuts.ts
@@ -71,13 +71,17 @@ const actionsByKeys: Record<string, ShortcutAction> = {
         return true;
     },
     'meta+shift+k': (editor, context) => {
-        showLinkSelector(entity => {
-            insertOrUpdateLink(editor, {
-                text: entity.name,
-                title: entity.link,
-                target: '',
-                url: entity.link,
-            });
+        editor.getEditorState().read(() => {
+            const selection = $getSelection();
+            const selectionText = selection?.getTextContent() || '';
+            showLinkSelector(entity => {
+                insertOrUpdateLink(editor, {
+                    text: entity.name,
+                    title: entity.link,
+                    target: '',
+                    url: entity.link,
+                });
+            }, selectionText);
         });
         return true;
     },

--- a/resources/js/wysiwyg/ui/framework/forms.ts
+++ b/resources/js/wysiwyg/ui/framework/forms.ts
@@ -98,6 +98,13 @@ export class EditorForm extends EditorContainerUiElement {
         this.definition = definition;
     }
 
+    focusOnFirst() {
+        const focusable = this.getDOMElement().querySelector('input,select,textarea');
+        if (focusable) {
+            (focusable as HTMLElement).focus();
+        }
+    }
+
     setValues(values: Record<string, string>) {
         for (const name of Object.keys(values)) {
             const field = this.getFieldByName(name);

--- a/resources/js/wysiwyg/ui/framework/modals.ts
+++ b/resources/js/wysiwyg/ui/framework/modals.ts
@@ -14,6 +14,7 @@ export interface EditorFormModalDefinition extends EditorModalDefinition {
 export class EditorFormModal extends EditorContainerUiElement {
     protected definition: EditorFormModalDefinition;
     protected key: string;
+    protected originalFocus: Element|null = null;
 
     constructor(definition: EditorFormModalDefinition, key: string) {
         super([new EditorForm(definition.form)]);
@@ -22,6 +23,7 @@ export class EditorFormModal extends EditorContainerUiElement {
     }
 
     show(defaultValues: Record<string, string>) {
+        this.originalFocus = document.activeElement as Element;
         const dom = this.getDOMElement();
         document.body.append(dom);
 
@@ -31,11 +33,15 @@ export class EditorFormModal extends EditorContainerUiElement {
         form.setOnSuccessfulSubmit(this.hide.bind(this));
 
         this.getContext().manager.setModalActive(this.key, this);
+        form.focusOnFirst();
     }
 
     hide() {
         this.getContext().manager.setModalInactive(this.key);
         this.teardown();
+        if (this.originalFocus instanceof HTMLElement && this.originalFocus.isConnected) {
+            this.originalFocus.focus();
+        }
     }
 
     getForm(): EditorForm {
@@ -65,6 +71,12 @@ export class EditorFormModal extends EditorContainerUiElement {
 
         wrapper.addEventListener('click', event => {
             if (event.target && !modal.contains(event.target as HTMLElement)) {
+                this.hide();
+            }
+        });
+
+        wrapper.addEventListener('keydown', event => {
+            if (event.key === 'Escape') {
                 this.hide();
             }
         });

--- a/resources/js/wysiwyg/utils/links.ts
+++ b/resources/js/wysiwyg/utils/links.ts
@@ -8,7 +8,7 @@ type EditorEntityData = {
 export function showLinkSelector(callback: (entity: EditorEntityData) => any, selectionText?: string) {
     const selector: EntitySelectorPopup = window.$components.first('entity-selector-popup') as EntitySelectorPopup;
     selector.show((entity: EditorEntityData) => callback(entity), {
-        initialValue: selectionText,
+        initialValue: selectionText || '',
         searchEndpoint: '/search/entity-selector',
         entityTypes: 'page,book,chapter,bookshelf',
         entityPermission: 'view',


### PR DESCRIPTION
For #5631

- Updated focus control for popup modal forms to focus on first form-field on show, and restore focus to the editor on hide.
- Fixed `undefined` default search value in link item search selector popup.
- Updated item search selector popup to pre-fill search input with selected text range.