### PR TITLE
Update "Microsoft URL Rewrite Module for IIS" download link

### DIFF
--- a/public/web.config
+++ b/public/web.config
@@ -1,6 +1,6 @@
 <!--
     Rewrites requires Microsoft URL Rewrite Module for IIS
-    Download: https://www.microsoft.com/en-us/download/details.aspx?id=47337
+    Download: https://www.iis.net/downloads/microsoft/url-rewrite
     Debug Help: https://docs.microsoft.com/en-us/iis/extensions/url-rewrite-module/using-failed-request-tracing-to-trace-rewrite-rules
 -->
 <configuration>


### PR DESCRIPTION
The download link to the *Microsoft URL Rewrite Module for IIS* in the `web.config` file is no longer available.