### PR TITLE
Add some additional resource-based limits

### DIFF
--- a/app/Exports/ZipExports/ZipFileReferenceRule.php
+++ b/app/Exports/ZipExports/ZipFileReferenceRule.php
@@ -13,7 +13,6 @@ class ZipFileReferenceRule implements ValidationRule
     ) {
     }
 
-
     /**
      * @inheritDoc
      */
@@ -21,6 +20,13 @@ class ZipFileReferenceRule implements ValidationRule
     {
         if (!$this->context->zipReader->fileExists($value)) {
             $fail('validation.zip_file')->translate();
+        }
+
+        if (!$this->context->zipReader->fileWithinSizeLimit($value)) {
+            $fail('validation.zip_file_size')->translate([
+                'attribute' => $value,
+                'size' => config('app.upload_limit'),
+            ]);
         }
 
         if (!empty($this->acceptedMimes)) {

--- a/app/Exports/ZipExports/ZipImportRunner.php
+++ b/app/Exports/ZipExports/ZipImportRunner.php
@@ -265,6 +265,12 @@ class ZipImportRunner
 
     protected function zipFileToUploadedFile(string $fileName, ZipExportReader $reader): UploadedFile
     {
+        if (!$reader->fileWithinSizeLimit($fileName)) {
+            throw new ZipImportException([
+                "File $fileName exceeds app upload limit."
+            ]);
+        }
+
         $tempPath = tempnam(sys_get_temp_dir(), 'bszipextract');
         $fileStream = $reader->streamFile($fileName);
         $tempStream = fopen($tempPath, 'wb');

--- a/app/Search/SearchController.php
+++ b/app/Search/SearchController.php
@@ -78,8 +78,9 @@ class SearchController extends Controller
 
         // Search for entities otherwise show most popular
         if ($searchTerm !== false) {
-            $searchTerm .= ' {type:' . implode('|', $entityTypes) . '}';
-            $entities = $this->searchRunner->searchEntities(SearchOptions::fromString($searchTerm), 'all', 1, 20)['results'];
+            $options = SearchOptions::fromString($searchTerm);
+            $options->setFilter('type', implode('|', $entityTypes));
+            $entities = $this->searchRunner->searchEntities($options, 'all', 1, 20)['results'];
         } else {
             $entities = $queryPopular->run(20, 0, $entityTypes);
         }

--- a/app/Search/SearchOptionSet.php
+++ b/app/Search/SearchOptionSet.php
@@ -82,4 +82,12 @@ class SearchOptionSet
         $values = array_values(array_filter($this->options, fn (SearchOption $option) => !$option->negated));
         return new self($values);
     }
+
+    /**
+     * @return self<T>
+     */
+    public function limit(int $limit): self
+    {
+        return new self(array_slice(array_values($this->options), 0, $limit));
+    }
 }

--- a/app/Search/SearchOptions.php
+++ b/app/Search/SearchOptions.php
@@ -35,6 +35,7 @@ class SearchOptions
     {
         $instance = new self();
         $instance->addOptionsFromString($search);
+        $instance->limitOptions();
         return $instance;
     }
 
@@ -86,6 +87,8 @@ class SearchOptions
             $instance->tags = $instance->tags->merge($extras->tags);
             $instance->filters = $instance->filters->merge($extras->filters);
         }
+
+        $instance->limitOptions();
 
         return $instance;
     }
@@ -145,6 +148,25 @@ class SearchOptions
         // Add tags & filters
         $this->tags = $this->tags->merge(new SearchOptionSet($terms['tags']));
         $this->filters = $this->filters->merge(new SearchOptionSet($terms['filters']));
+    }
+
+    /**
+     * Limit the amount of search options to reasonable levels.
+     * Provides higher limits to logged-in users since that signals a slightly
+     * higher level of trust.
+     */
+    protected function limitOptions(): void
+    {
+        $userLoggedIn = !user()->isGuest();
+        $searchLimit = $userLoggedIn ? 10 : 5;
+        $exactLimit = $userLoggedIn ? 4 : 2;
+        $tagLimit = $userLoggedIn ? 8 : 4;
+        $filterLimit = $userLoggedIn ? 10 : 5;
+
+        $this->searches = $this->searches->limit($searchLimit);
+        $this->exacts = $this->exacts->limit($exactLimit);
+        $this->tags = $this->tags->limit($tagLimit);
+        $this->filters = $this->filters->limit($filterLimit);
     }
 
     /**

--- a/lang/en/errors.php
+++ b/lang/en/errors.php
@@ -109,6 +109,7 @@ return [
     'import_zip_cant_read' => 'Could not read ZIP file.',
     'import_zip_cant_decode_data' => 'Could not find and decode ZIP data.json content.',
     'import_zip_no_data' => 'ZIP file data has no expected book, chapter or page content.',
+    'import_zip_data_too_large' => 'ZIP data.json content exceeds the configured application maximum upload size.',
     'import_validation_failed' => 'Import ZIP failed to validate with errors:',
     'import_zip_failed_notification' => 'Failed to import ZIP file.',
     'import_perms_books' => 'You are lacking the required permissions to create books.',

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -106,6 +106,7 @@ return [
     'uploaded'             => 'The file could not be uploaded. The server may not accept files of this size.',
 
     'zip_file' => 'The :attribute needs to reference a file within the ZIP.',
+    'zip_file_size' => 'The file :attribute must not exceed :size MB.',
     'zip_file_mime' => 'The :attribute needs to reference a file of type :validTypes, found :foundType.',
     'zip_model_expected' => 'Data object expected but ":type" found.',
     'zip_unique' => 'The :attribute must be unique for the object type within the ZIP.',

--- a/tests/Search/SearchOptionsTest.php
+++ b/tests/Search/SearchOptionsTest.php
@@ -142,4 +142,53 @@ class SearchOptionsTest extends TestCase
         $this->assertEquals('dino', $options->exacts->all()[0]->value);
         $this->assertTrue($options->exacts->all()[0]->negated);
     }
+
+    public function test_from_string_results_are_count_limited_and_larger_for_logged_in_users()
+    {
+        $terms = [
+            ...array_fill(0, 40, 'cat'),
+            ...array_fill(0, 50, '"bees"'),
+            ...array_fill(0, 50, '{is_template}'),
+            ...array_fill(0, 50, '[a=b]'),
+        ];
+
+        $options = SearchOptions::fromString(implode(' ', $terms));
+
+        $this->assertCount(5, $options->searches->all());
+        $this->assertCount(2, $options->exacts->all());
+        $this->assertCount(4, $options->tags->all());
+        $this->assertCount(5, $options->filters->all());
+
+        $this->asEditor();
+        $options = SearchOptions::fromString(implode(' ', $terms));
+
+        $this->assertCount(10, $options->searches->all());
+        $this->assertCount(4, $options->exacts->all());
+        $this->assertCount(8, $options->tags->all());
+        $this->assertCount(10, $options->filters->all());
+    }
+
+    public function test_from_request_results_are_count_limited_and_larger_for_logged_in_users()
+    {
+        $request = new Request([
+            'search' => str_repeat('hello ', 20),
+            'tags' => array_fill(0, 20, 'a=b'),
+            'extras' => str_repeat('-[b=c] -{viewed_by_me} -"dino"', 20),
+        ]);
+
+        $options = SearchOptions::fromRequest($request);
+
+        $this->assertCount(5, $options->searches->all());
+        $this->assertCount(2, $options->exacts->all());
+        $this->assertCount(4, $options->tags->all());
+        $this->assertCount(5, $options->filters->all());
+
+        $this->asEditor();
+        $options = SearchOptions::fromRequest($request);
+
+        $this->assertCount(10, $options->searches->all());
+        $this->assertCount(4, $options->exacts->all());
+        $this->assertCount(8, $options->tags->all());
+        $this->assertCount(10, $options->filters->all());
+    }
 }


### PR DESCRIPTION
- Limits ZIP import file sizes to the configured `FILE_UPLOAD_SIZE_LIMIT`.
- Limits the amount of search terms which can be used in one search.

### Docs Updates

Update search page to note limits:

```
        $searchLimit = $userLoggedIn ? 10 : 5;
        $exactLimit = $userLoggedIn ? 4 : 2;
        $tagLimit = $userLoggedIn ? 8 : 4;
        $filterLimit = $userLoggedIn ? 10 : 5;
```