### PR TITLE
Fix OIDC group-to-role sync for groups containing spaces

### DIFF
--- a/app/Access/GroupSyncService.php
+++ b/app/Access/GroupSyncService.php
@@ -43,7 +43,7 @@ class GroupSyncService
         $cleanIds = [];
 
         foreach ($inputIds as $inputId) {
-            $cleanIds[] = str_replace('\,', ',', trim($inputId));
+            $cleanIds[] = str_replace(' ', '-', str_replace('\,', ',', trim($inputId)));
         }
 
         return $cleanIds;


### PR DESCRIPTION
Fix issue #6021

Normalize spaces to hyphens in parseRoleExternalAuthId() to match the same normalization applied to incoming group names in matchGroupsToSystemsRoles(), fixing group-to-role mapping for groups whose names contain spaces.