### PR TITLE
File attachment at Book level #6042

### DIFF
--- a/app/Entities/Models/Book.php
+++ b/app/Entities/Models/Book.php
@@ -5,6 +5,7 @@ namespace BookStack\Entities\Models;
 use BookStack\Entities\Tools\EntityCover;
 use BookStack\Entities\Tools\EntityDefaultTemplate;
 use BookStack\Sorting\SortRule;
+use BookStack\Uploads\Attachment;
 use BookStack\Uploads\Image;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -24,6 +25,7 @@ use Illuminate\Support\Collection;
  * @property \Illuminate\Database\Eloquent\Collection $pages
  * @property \Illuminate\Database\Eloquent\Collection $directPages
  * @property \Illuminate\Database\Eloquent\Collection $shelves
+ * @property \Illuminate\Database\Eloquent\Collection $attachments
  * @property ?SortRule                                $sortRule
  */
 class Book extends Entity implements HasDescriptionInterface, HasCoverInterface, HasDefaultTemplateInterface
@@ -76,6 +78,16 @@ class Book extends Entity implements HasDescriptionInterface, HasCoverInterface,
     public function shelves(): BelongsToMany
     {
         return $this->belongsToMany(Bookshelf::class, 'bookshelves_books', 'book_id', 'bookshelf_id');
+    }
+
+    /**
+     * Get the attachments assigned to this book.
+     */
+    public function attachments(): HasMany
+    {
+        return $this->hasMany(Attachment::class, 'attachable_id')
+            ->where('attachments.attachable_type', 'BookStack\\Entities\\Models\\Book')
+            ->orderBy('order', 'asc');
     }
 
     /**

--- a/app/Uploads/Attachment.php
+++ b/app/Uploads/Attachment.php
@@ -5,6 +5,7 @@ namespace BookStack\Uploads;
 use BookStack\App\Model;
 use BookStack\Entities\Models\Entity;
 use BookStack\Entities\Models\Page;
+use BookStack\Entities\Models\Book;
 use BookStack\Permissions\Models\JointPermission;
 use BookStack\Permissions\PermissionApplicator;
 use BookStack\Users\Models\HasCreatorAndUpdater;
@@ -13,6 +14,7 @@ use BookStack\Users\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
@@ -21,6 +23,10 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string $path
  * @property string $extension
  * @property ?Page  $page
+ * @property ?Book  $book
+ * @property ?Entity $attachable
+ * @property string $attachable_type
+ * @property int    $attachable_id
  * @property bool   $external
  * @property int    $uploaded_to
  * @property User   $updatedBy
@@ -52,17 +58,40 @@ class Attachment extends Model implements OwnableInterface
     }
 
     /**
-     * Get the page this file was uploaded to.
+     * Get the polymorphic entity this file was uploaded to (page or book).
+     */
+    public function attachable(): MorphTo
+    {
+        return $this->morphTo('attachable');
+    }
+
+    /**
+     * Get the page this file was uploaded to (backward compatibility).
      */
     public function page(): BelongsTo
     {
         return $this->belongsTo(Page::class, 'uploaded_to');
     }
 
+    /**
+     * Get the book this file was uploaded to.
+     * Returns null if the attachment is not attached to a book.
+     */
+    public function book(): ?Book
+    {
+        if ($this->attachable_type === 'BookStack\\Entities\\Models\\Book') {
+            return $this->attachable;
+        }
+        return null;
+    }
+
     public function jointPermissions(): HasMany
     {
-        return $this->hasMany(JointPermission::class, 'entity_id', 'uploaded_to')
-            ->where('joint_permissions.entity_type', '=', 'page');
+        return $this->hasMany(JointPermission::class, 'entity_id', 'attachable_id')
+            ->where(function($query) {
+                $query->where('joint_permissions.entity_type', '=', 'page')
+                      ->orWhere('joint_permissions.entity_type', '=', 'book');
+            });
     }
 
     /**
@@ -109,16 +138,18 @@ class Attachment extends Model implements OwnableInterface
     }
 
     /**
-     * Scope the query to those attachments that are visible based upon related page permissions.
+     * Scope the query to those attachments that are visible based upon related entity permissions.
      */
     public function scopeVisible(): Builder
     {
         $permissions = app()->make(PermissionApplicator::class);
 
-        return $permissions->restrictPageRelationQuery(
+        // Use polymorphic relationship restriction for both pages and books
+        return $permissions->restrictEntityRelationQuery(
             self::query(),
             'attachments',
-            'uploaded_to'
+            'attachable_id',
+            'attachable_type'
         );
     }
 }

--- a/app/Uploads/AttachmentService.php
+++ b/app/Uploads/AttachmentService.php
@@ -36,21 +36,33 @@ class AttachmentService
      *
      * @throws FileUploadException
      */
-    public function saveNewUpload(UploadedFile $uploadedFile, int $pageId): Attachment
+    public function saveNewUpload(UploadedFile $uploadedFile, int $entityId, string $entityType = 'page'): Attachment
     {
         $attachmentName = $uploadedFile->getClientOriginalName();
         $attachmentPath = $this->putFileInStorage($uploadedFile);
-        $largestExistingOrder = Attachment::query()->where('uploaded_to', '=', $pageId)->max('order');
+        
+        // Determine the model class
+        $modelClass = $entityType === 'book' 
+            ? 'BookStack\\Entities\\Models\\Book' 
+            : 'BookStack\\Entities\\Models\\Page';
+        
+        // Get max order for the entity using polymorphic relationship
+        $largestExistingOrder = Attachment::query()
+            ->where('attachable_type', $modelClass)
+            ->where('attachable_id', $entityId)
+            ->max('order') ?? 0;
 
         /** @var Attachment $attachment */
         $attachment = Attachment::query()->forceCreate([
-            'name'        => $attachmentName,
-            'path'        => $attachmentPath,
-            'extension'   => $uploadedFile->getClientOriginalExtension(),
-            'uploaded_to' => $pageId,
-            'created_by'  => user()->id,
-            'updated_by'  => user()->id,
-            'order'       => $largestExistingOrder + 1,
+            'name'           => $attachmentName,
+            'path'           => $attachmentPath,
+            'extension'      => $uploadedFile->getClientOriginalExtension(),
+            'uploaded_to'    => $entityType === 'page' ? $entityId : null, // Backward compatibility
+            'attachable_type' => $modelClass,
+            'attachable_id'  => $entityId,
+            'created_by'     => user()->id,
+            'updated_by'     => user()->id,
+            'order'          => $largestExistingOrder + 1,
         ]);
 
         return $attachment;
@@ -83,19 +95,30 @@ class AttachmentService
     /**
      * Save a new File attachment from a given link and name.
      */
-    public function saveNewFromLink(string $name, string $link, int $page_id): Attachment
+    public function saveNewFromLink(string $name, string $link, int $entityId, string $entityType = 'page'): Attachment
     {
-        $largestExistingOrder = Attachment::where('uploaded_to', '=', $page_id)->max('order');
+        // Determine the model class
+        $modelClass = $entityType === 'book' 
+            ? 'BookStack\\Entities\\Models\\Book' 
+            : 'BookStack\\Entities\\Models\\Page';
+        
+        // Get max order for the entity using polymorphic relationship
+        $largestExistingOrder = Attachment::query()
+            ->where('attachable_type', $modelClass)
+            ->where('attachable_id', $entityId)
+            ->max('order') ?? 0;
 
         return Attachment::forceCreate([
-            'name'        => $name,
-            'path'        => $link,
-            'external'    => true,
-            'extension'   => '',
-            'uploaded_to' => $page_id,
-            'created_by'  => user()->id,
-            'updated_by'  => user()->id,
-            'order'       => $largestExistingOrder + 1,
+            'name'           => $name,
+            'path'           => $link,
+            'external'       => true,
+            'extension'      => '',
+            'uploaded_to'    => $entityType === 'page' ? $entityId : null, // Backward compatibility
+            'attachable_type' => $modelClass,
+            'attachable_id'  => $entityId,
+            'created_by'     => user()->id,
+            'updated_by'     => user()->id,
+            'order'          => $largestExistingOrder + 1,
         ]);
     }
 
@@ -104,8 +127,26 @@ class AttachmentService
      */
     public function updateFileOrderWithinPage(array $attachmentOrder, string $pageId)
     {
+        $modelClass = 'BookStack\\Entities\\Models\\Page';
         foreach ($attachmentOrder as $index => $attachmentId) {
-            Attachment::query()->where('uploaded_to', '=', $pageId)
+            Attachment::query()
+                ->where('attachable_type', $modelClass)
+                ->where('attachable_id', '=', $pageId)
+                ->where('id', '=', $attachmentId)
+                ->update(['order' => $index]);
+        }
+    }
+
+    /**
+     * Updates the ordering for a listing of attached files for a book.
+     */
+    public function updateFileOrderWithinBook(array $attachmentOrder, string $bookId)
+    {
+        $modelClass = 'BookStack\\Entities\\Models\\Book';
+        foreach ($attachmentOrder as $index => $attachmentId) {
+            Attachment::query()
+                ->where('attachable_type', $modelClass)
+                ->where('attachable_id', '=', $bookId)
                 ->where('id', '=', $attachmentId)
                 ->update(['order' => $index]);
         }

--- a/app/Uploads/Controllers/AttachmentController.php
+++ b/app/Uploads/Controllers/AttachmentController.php
@@ -4,6 +4,7 @@ namespace BookStack\Uploads\Controllers;
 
 use BookStack\Entities\EntityExistsRule;
 use BookStack\Entities\Queries\PageQueries;
+use BookStack\Entities\Queries\BookQueries;
 use BookStack\Entities\Repos\PageRepo;
 use BookStack\Exceptions\FileUploadException;
 use BookStack\Exceptions\NotFoundException;
@@ -22,6 +23,7 @@ class AttachmentController extends Controller
     public function __construct(
         protected AttachmentService $attachmentService,
         protected PageQueries $pageQueries,
+        protected BookQueries $bookQueries,
         protected PageRepo $pageRepo
     ) {
     }
@@ -35,20 +37,29 @@ class AttachmentController extends Controller
     public function upload(Request $request)
     {
         $this->validate($request, [
-            'uploaded_to' => ['required', 'integer',  new EntityExistsRule('page')],
+            'uploaded_to' => ['required', 'integer'],
+            'entity_type' => ['required', 'string', 'in:page,book'],
             'file'        => array_merge(['required'], $this->attachmentService->getFileValidationRules()),
         ]);
 
-        $pageId = $request->get('uploaded_to');
-        $page = $this->pageQueries->findVisibleByIdOrFail($pageId);
-
-        $this->checkPermission(Permission::AttachmentCreateAll);
-        $this->checkOwnablePermission(Permission::PageUpdate, $page);
+        $entityId = $request->get('uploaded_to');
+        $entityType = $request->get('entity_type', 'page');
+        
+        // Validate entity exists and check permissions
+        if ($entityType === 'book') {
+            $entity = $this->bookQueries->findVisibleByIdOrFail($entityId);
+            $this->checkPermission(Permission::AttachmentCreateAll);
+            $this->checkOwnablePermission(Permission::BookUpdate, $entity);
+        } else {
+            $entity = $this->pageQueries->findVisibleByIdOrFail($entityId);
+            $this->checkPermission(Permission::AttachmentCreateAll);
+            $this->checkOwnablePermission(Permission::PageUpdate, $entity);
+        }
 
         $uploadedFile = $request->file('file');
 
         try {
-            $attachment = $this->attachmentService->saveNewUpload($uploadedFile, $pageId);
+            $attachment = $this->attachmentService->saveNewUpload($uploadedFile, $entityId, $entityType);
         } catch (FileUploadException $e) {
             return response($e->getMessage(), 500);
         }
@@ -69,8 +80,19 @@ class AttachmentController extends Controller
 
         /** @var Attachment $attachment */
         $attachment = Attachment::query()->findOrFail($attachmentId);
-        $this->checkOwnablePermission(Permission::PageView, $attachment->page);
-        $this->checkOwnablePermission(Permission::PageUpdate, $attachment->page);
+        $entity = $attachment->attachable;
+        
+        if (!$entity) {
+            throw new NotFoundException(trans('errors.attachment_not_found'));
+        }
+
+        if ($attachment->attachable_type === 'BookStack\\Entities\\Models\\Book') {
+            $this->checkOwnablePermission(Permission::BookView, $entity);
+            $this->checkOwnablePermission(Permission::BookUpdate, $entity);
+        } else {
+            $this->checkOwnablePermission(Permission::PageView, $entity);
+            $this->checkOwnablePermission(Permission::PageUpdate, $entity);
+        }
         $this->checkOwnablePermission(Permission::AttachmentUpdate, $attachment);
 
         $uploadedFile = $request->file('file');
@@ -91,8 +113,17 @@ class AttachmentController extends Controller
     {
         /** @var Attachment $attachment */
         $attachment = Attachment::query()->findOrFail($attachmentId);
+        $entity = $attachment->attachable;
+        
+        if (!$entity) {
+            throw new NotFoundException(trans('errors.attachment_not_found'));
+        }
 
-        $this->checkOwnablePermission(Permission::PageUpdate, $attachment->page);
+        if ($attachment->attachable_type === 'BookStack\\Entities\\Models\\Book') {
+            $this->checkOwnablePermission(Permission::BookUpdate, $entity);
+        } else {
+            $this->checkOwnablePermission(Permission::PageUpdate, $entity);
+        }
         $this->checkOwnablePermission(Permission::AttachmentCreate, $attachment);
 
         return view('attachments.manager-edit-form', [
@@ -107,6 +138,11 @@ class AttachmentController extends Controller
     {
         /** @var Attachment $attachment */
         $attachment = Attachment::query()->findOrFail($attachmentId);
+        $entity = $attachment->attachable;
+        
+        if (!$entity) {
+            throw new NotFoundException(trans('errors.attachment_not_found'));
+        }
 
         try {
             $this->validate($request, [
@@ -120,8 +156,13 @@ class AttachmentController extends Controller
             ]), 422);
         }
 
-        $this->checkOwnablePermission(Permission::PageView, $attachment->page);
-        $this->checkOwnablePermission(Permission::PageUpdate, $attachment->page);
+        if ($attachment->attachable_type === 'BookStack\\Entities\\Models\\Book') {
+            $this->checkOwnablePermission(Permission::BookView, $entity);
+            $this->checkOwnablePermission(Permission::BookUpdate, $entity);
+        } else {
+            $this->checkOwnablePermission(Permission::PageView, $entity);
+            $this->checkOwnablePermission(Permission::PageUpdate, $entity);
+        }
         $this->checkOwnablePermission(Permission::AttachmentUpdate, $attachment);
 
         $attachment = $this->attachmentService->updateFile($attachment, [
@@ -135,38 +176,55 @@ class AttachmentController extends Controller
     }
 
     /**
-     * Attach a link to a page.
+     * Attach a link to a page or book.
      *
      * @throws NotFoundException
      */
     public function attachLink(Request $request)
     {
-        $pageId = $request->get('attachment_link_uploaded_to');
+        $entityId = $request->get('attachment_link_uploaded_to');
+        $entityType = $request->get('entity_type', 'page');
 
         try {
-            $this->validate($request, [
-                'attachment_link_uploaded_to' => ['required', 'integer',  new EntityExistsRule('page')],
+            $validationRules = [
+                'attachment_link_uploaded_to' => ['required', 'integer'],
                 'attachment_link_name'        => ['required', 'string', 'min:1', 'max:255'],
                 'attachment_link_url'         => ['required', 'string', 'min:1', 'max:2000', 'safe_url'],
-            ]);
+                'entity_type'                => ['required', 'string', 'in:page,book'],
+            ];
+            
+            if ($entityType === 'page') {
+                $validationRules['attachment_link_uploaded_to'][] = new EntityExistsRule('page');
+            } else {
+                $validationRules['attachment_link_uploaded_to'][] = new EntityExistsRule('book');
+            }
+            
+            $this->validate($request, $validationRules);
         } catch (ValidationException $exception) {
             return response()->view('attachments.manager-link-form', array_merge($request->only(['attachment_link_name', 'attachment_link_url']), [
-                'pageId' => $pageId,
+                'entityId' => $entityId,
+                'entityType' => $entityType,
                 'errors' => new MessageBag($exception->errors()),
             ]), 422);
         }
 
-        $page = $this->pageQueries->findVisibleByIdOrFail($pageId);
-
-        $this->checkPermission(Permission::AttachmentCreateAll);
-        $this->checkOwnablePermission(Permission::PageUpdate, $page);
+        if ($entityType === 'book') {
+            $entity = $this->bookQueries->findVisibleByIdOrFail($entityId);
+            $this->checkPermission(Permission::AttachmentCreateAll);
+            $this->checkOwnablePermission(Permission::BookUpdate, $entity);
+        } else {
+            $entity = $this->pageQueries->findVisibleByIdOrFail($entityId);
+            $this->checkPermission(Permission::AttachmentCreateAll);
+            $this->checkOwnablePermission(Permission::PageUpdate, $entity);
+        }
 
         $attachmentName = $request->get('attachment_link_name');
         $link = $request->get('attachment_link_url');
-        $this->attachmentService->saveNewFromLink($attachmentName, $link, intval($pageId));
+        $this->attachmentService->saveNewFromLink($attachmentName, $link, intval($entityId), $entityType);
 
         return view('attachments.manager-link-form', [
-            'pageId' => $pageId,
+            'entityId' => $entityId,
+            'entityType' => $entityType,
         ]);
     }
 
@@ -181,6 +239,20 @@ class AttachmentController extends Controller
 
         return view('attachments.manager-list', [
             'attachments' => $page->attachments->all(),
+        ]);
+    }
+
+    /**
+     * Get the attachments for a specific book.
+     *
+     * @throws NotFoundException
+     */
+    public function listForBook(int $bookId)
+    {
+        $book = $this->bookQueries->findVisibleByIdOrFail($bookId);
+
+        return view('attachments.manager-list', [
+            'attachments' => $book->attachments->all(),
         ]);
     }
 
@@ -205,6 +277,26 @@ class AttachmentController extends Controller
     }
 
     /**
+     * Update the attachment sorting for a book.
+     *
+     * @throws ValidationException
+     * @throws NotFoundException
+     */
+    public function sortForBook(Request $request, int $bookId)
+    {
+        $this->validate($request, [
+            'order' => ['required', 'array'],
+        ]);
+        $book = $this->bookQueries->findVisibleByIdOrFail($bookId);
+        $this->checkOwnablePermission(Permission::BookUpdate, $book);
+
+        $attachmentOrder = $request->get('order');
+        $this->attachmentService->updateFileOrderWithinBook($attachmentOrder, $bookId);
+
+        return response()->json(['message' => trans('entities.attachments_order_updated')]);
+    }
+
+    /**
      * Get an attachment from storage.
      *
      * @throws FileNotFoundException
@@ -214,14 +306,18 @@ class AttachmentController extends Controller
     {
         /** @var Attachment $attachment */
         $attachment = Attachment::query()->findOrFail($attachmentId);
-
-        try {
-            $page = $this->pageQueries->findVisibleByIdOrFail($attachment->uploaded_to);
-        } catch (NotFoundException $exception) {
+        $entity = $attachment->attachable;
+        
+        if (!$entity) {
             throw new NotFoundException(trans('errors.attachment_not_found'));
         }
 
-        $this->checkOwnablePermission(Permission::PageView, $page);
+        // Check permissions based on entity type
+        if ($attachment->attachable_type === 'BookStack\\Entities\\Models\\Book') {
+            $this->checkOwnablePermission(Permission::BookView, $entity);
+        } else {
+            $this->checkOwnablePermission(Permission::PageView, $entity);
+        }
 
         if ($attachment->external) {
             return redirect($attachment->path);

--- a/database/migrations/2026_01_15_100000_add_polymorphic_support_to_attachments.php
+++ b/database/migrations/2026_01_15_100000_add_polymorphic_support_to_attachments.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('attachments', function (Blueprint $table) {
+            // Add new polymorphic columns
+            $table->string('attachable_type')->nullable()->after('uploaded_to');
+            $table->unsignedInteger('attachable_id')->nullable()->after('attachable_type');
+        });
+
+        // Migrate existing data - all current attachments are for pages
+        DB::table('attachments')->update([
+            'attachable_type' => 'BookStack\\Entities\\Models\\Page',
+            'attachable_id' => DB::raw('uploaded_to'),
+        ]);
+
+        Schema::table('attachments', function (Blueprint $table) {
+            // Make uploaded_to nullable for backward compatibility
+            $table->integer('uploaded_to')->nullable()->change();
+            
+            // Add index for polymorphic relationship
+            $table->index(['attachable_type', 'attachable_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Migrate data back to uploaded_to before dropping columns
+        DB::table('attachments')
+            ->where('attachable_type', 'BookStack\\Entities\\Models\\Page')
+            ->update(['uploaded_to' => DB::raw('attachable_id')]);
+
+        Schema::table('attachments', function (Blueprint $table) {
+            $table->dropIndex(['attachable_type', 'attachable_id']);
+            $table->dropColumn(['attachable_type', 'attachable_id']);
+            $table->integer('uploaded_to')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/js/components/attachments.js
+++ b/resources/js/components/attachments.js
@@ -5,12 +5,19 @@ export class Attachments extends Component {
 
     setup() {
         this.container = this.$el;
-        this.pageId = this.$opts.pageId;
+        // Support both old pageId and new entityId/entityType
+        this.entityId = this.$opts.entityId || this.$opts.pageId;
+        this.entityType = this.$opts.entityType || 'page';
         this.editContainer = this.$refs.editContainer;
         this.listContainer = this.$refs.listContainer;
         this.linksContainer = this.$refs.linksContainer;
         this.listPanel = this.$refs.listPanel;
         this.attachLinkButton = this.$refs.attachLinkButton;
+
+        // If listPanel exists, use it; otherwise fall back to listContainer
+        if (!this.listPanel && this.listContainer) {
+            this.listPanel = this.listContainer;
+        }
 
         this.setupListeners();
     }
@@ -50,24 +57,26 @@ export class Attachments extends Component {
         const sectionMap = {
             links: this.linksContainer,
             edit: this.editContainer,
-            list: this.listContainer,
+            list: this.listPanel || this.listContainer,
         };
 
         for (const [name, elem] of Object.entries(sectionMap)) {
-            elem.toggleAttribute('hidden', name !== section);
+            if (elem) {
+                elem.toggleAttribute('hidden', name !== section);
+            }
         }
     }
 
     reloadList() {
         this.stopEdit();
-        window.$http.get(`/attachments/get/page/${this.pageId}`).then(resp => {
+        window.$http.get(`/attachments/get/${this.entityType}/${this.entityId}`).then(resp => {
             this.listPanel.innerHTML = resp.data;
             window.$components.init(this.listPanel);
         });
     }
 
     updateOrder(idOrder) {
-        window.$http.put(`/attachments/sort/page/${this.pageId}`, {order: idOrder}).then(resp => {
+        window.$http.put(`/attachments/sort/${this.entityType}/${this.entityId}`, {order: idOrder}).then(resp => {
             window.$events.emit('success', resp.data.message);
         });
     }
@@ -82,7 +91,16 @@ export class Attachments extends Component {
     }
 
     stopEdit() {
-        this.showSection('list');
+        if (this.listPanel || this.listContainer) {
+            this.showSection('list');
+        }
+        // Hide edit and link containers
+        if (this.editContainer) {
+            this.editContainer.toggleAttribute('hidden', true);
+        }
+        if (this.linksContainer) {
+            this.linksContainer.toggleAttribute('hidden', true);
+        }
     }
 
 }

--- a/resources/views/attachments/manager-link-form.blade.php
+++ b/resources/views/attachments/manager-link-form.blade.php
@@ -1,12 +1,19 @@
 {{--
-@pageId
+@entityId - The ID of the entity (page or book)
+@entityType - The type of entity ('page' or 'book')
+@pageId - Legacy support for pageId (for backward compatibility)
 --}}
+@php
+    $entityId = $entityId ?? $pageId ?? 0;
+    $entityType = $entityType ?? 'page';
+@endphp
 <div component="ajax-form"
      option:ajax-form:url="/attachments/link"
      option:ajax-form:method="post"
      option:ajax-form:response-container="#link-form-container"
      option:ajax-form:success-message="{{ trans('entities.attachments_link_attached') }}">
-    <input type="hidden" name="attachment_link_uploaded_to" value="{{ $pageId }}">
+    <input type="hidden" name="attachment_link_uploaded_to" value="{{ $entityId }}">
+    <input type="hidden" name="entity_type" value="{{ $entityType }}">
     <p class="text-muted small">{{ trans('entities.attachments_explain_link') }}</p>
     <div class="form-group">
         <label for="attachment_link_name">{{ trans('entities.attachments_link_name') }}</label>

--- a/resources/views/attachments/manager.blade.php
+++ b/resources/views/attachments/manager.blade.php
@@ -1,13 +1,20 @@
+@php
+    $entityId = $entity->id ?? $page->id ?? $book->id ?? 0;
+    $entityType = isset($book) ? 'book' : 'page';
+    $uploadUrl = url('/attachments/upload?uploaded_to=' . $entityId . '&entity_type=' . $entityType);
+    $attachments = ($page->attachments ?? $book->attachments ?? collect())->all();
+@endphp
 <div style="display: block;"
      refs="editor-toolbox@tab-content"
      data-tab-content="files"
      component="attachments"
-     option:attachments:page-id="{{ $page->id ?? 0 }}"
+     option:attachments:entity-id="{{ $entityId }}"
+     option:attachments:entity-type="{{ $entityType }}"
      class="toolbox-tab-content">
 
     <h4>{{ trans('entities.attachments') }}</h4>
     <div component="dropzone"
-         option:dropzone:url="{{ url('/attachments/upload?uploaded_to=' . $page->id) }}"
+         option:dropzone:url="{{ $uploadUrl }}"
          option:dropzone:success-message="{{ trans('entities.attachments_file_uploaded') }}"
          option:dropzone:error-message="{{ trans('errors.attachment_upload_error') }}"
          option:dropzone:upload-limit="{{ config('app.upload_limit') }}"
@@ -35,14 +42,18 @@
             <hr>
 
             <div refs="attachments@list-panel">
-                @include('attachments.manager-list', ['attachments' => $page->attachments->all()])
+                @include('attachments.manager-list', ['attachments' => $attachments])
             </div>
 
         </div>
     </div>
 
     <div id="link-form-container" refs="attachments@links-container" hidden class="px-l">
-        @include('attachments.manager-link-form', ['pageId' => $page->id])
+        @include('attachments.manager-link-form', [
+            'entityId' => $entityId,
+            'entityType' => $entityType,
+            'pageId' => $page->id ?? null
+        ])
     </div>
 
     <div id="edit-form-container" refs="attachments@edit-container" hidden class="px-l"></div>

--- a/resources/views/books/parts/show-sidebar-section-attachments.blade.php
+++ b/resources/views/books/parts/show-sidebar-section-attachments.blade.php
@@ -1,0 +1,50 @@
+@if(userCan(\BookStack\Permissions\Permission::BookUpdate, $book) || $book->attachments->count() > 0)
+    <div id="book-attachments" class="mb-l">
+        <h5>{{ trans('entities.attachments') }}</h5>
+        <div class="body">
+            @if(userCan(\BookStack\Permissions\Permission::BookUpdate, $book) && userCan(\BookStack\Permissions\Permission::AttachmentCreateAll))
+                <div component="attachments"
+                     option:attachments:entity-id="{{ $book->id }}"
+                     option:attachments:entity-type="book">
+                    @php
+                        $uploadUrl = url('/attachments/upload?uploaded_to=' . $book->id . '&entity_type=book');
+                    @endphp
+                    <div component="dropzone"
+                         option:dropzone:url="{{ $uploadUrl }}"
+                         option:dropzone:success-message="{{ trans('entities.attachments_file_uploaded') }}"
+                         option:dropzone:error-message="{{ trans('errors.attachment_upload_error') }}"
+                         option:dropzone:upload-limit="{{ config('app.upload_limit') }}"
+                         option:dropzone:upload-limit-message="{{ trans('errors.server_upload_limit') }}"
+                         option:dropzone:zone-text="{{ trans('entities.attachments_dropzone') }}"
+                         option:dropzone:file-accept="*"
+                         option:dropzone:allow-multiple="true"
+                         class="mb-m">
+                        <div refs="dropzone@drop-target" class="relative">
+                            <div class="flex-container-row mb-s">
+                                <button refs="dropzone@select-button" type="button" class="button outline small">{{ trans('entities.attachments_upload') }}</button>
+                                <button refs="attachments@attach-link-button" type="button" class="button outline small">{{ trans('entities.attachments_link') }}</button>
+                            </div>
+                            <p class="text-muted text-small">{{ trans('entities.attachments_upload_drop') }}</p>
+                            <div refs="dropzone@status-area" class="fixed top-right px-m py-m"></div>
+                        </div>
+                    </div>
+
+                    <div refs="attachments@list-container attachments@list-panel">
+                        @include('attachments.manager-list', ['attachments' => $book->attachments->all()])
+                    </div>
+
+                    <div id="link-form-container" refs="attachments@links-container" hidden class="mt-m">
+                        @include('attachments.manager-link-form', [
+                            'entityId' => $book->id,
+                            'entityType' => 'book'
+                        ])
+                    </div>
+
+                    <div id="edit-form-container" refs="attachments@edit-container" hidden class="mt-m"></div>
+                </div>
+            @else
+                @include('attachments.list', ['attachments' => $book->attachments])
+            @endif
+        </div>
+    </div>
+@endif

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -74,6 +74,7 @@
 @section('left')
     @include('entities.search-form', ['label' => trans('entities.books_search_this')])
     @include('books.parts.show-sidebar-section-tags', ['book' => $book])
+    @include('books.parts.show-sidebar-section-attachments', ['book' => $book])
     @include('books.parts.show-sidebar-section-shelves', ['bookParentShelves' => $bookParentShelves])
     @include('books.parts.show-sidebar-section-activity', ['activity' => $activity])
 @stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -165,6 +165,8 @@ Route::middleware('auth')->group(function () {
     Route::get('/attachments/edit/{id}', [UploadControllers\AttachmentController::class, 'getUpdateForm']);
     Route::get('/attachments/get/page/{pageId}', [UploadControllers\AttachmentController::class, 'listForPage']);
     Route::put('/attachments/sort/page/{pageId}', [UploadControllers\AttachmentController::class, 'sortForPage']);
+    Route::get('/attachments/get/book/{bookId}', [UploadControllers\AttachmentController::class, 'listForBook']);
+    Route::put('/attachments/sort/book/{bookId}', [UploadControllers\AttachmentController::class, 'sortForBook']);
     Route::delete('/attachments/{id}', [UploadControllers\AttachmentController::class, 'delete']);
 
     // AJAX routes


### PR DESCRIPTION
feauret: Add file upload support for books

Extend attachment system to support book-level file uploads using polymorphic
relationships. Includes full UI for uploading, managing, and organizing
attachments on book pages with proper permission checks.

- Add polymorphic database migration for attachments
- Update backend models and services for book support
- Add book attachment routes and controller methods
- Implement book attachments UI in sidebar
- Update JavaScript components for entity type handling