### PR TITLE
Add reset MFA button for admin s on user profile edit

### DIFF
--- a/app/Users/Controllers/UserController.php
+++ b/app/Users/Controllers/UserController.php
@@ -208,4 +208,17 @@ class UserController extends Controller
 
         return redirect('/settings/users');
     }
+
+    /**
+     * Reset MFA for the specified user.
+     */
+    public function resetMfa(Request $request, int $id)
+    {
+        $this->checkPermission(Permission::UsersManage);
+        $user = $this->userRepo->getById($id);
+        // Resetear el 2FA del usuario 
+        $user->mfaValues()->delete();
+        session()->flash('success', trans('settings.users_mfa_reset_success', ['userName' => $user->name]));
+        return redirect()->back();
+    }
 }

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -263,6 +263,11 @@ return [
     'users_mfa_desc' => 'Setup multi-factor authentication as an extra layer of security for your user account.',
     'users_mfa_x_methods' => ':count method configured|:count methods configured',
     'users_mfa_configure' => 'Configure Methods',
+    'users_mfa_reset' => 'Reset 2FA',
+    'users_mfa_reset_desc' => 'Reset and clear all configured MFA methods for :userName. They will be prompted to reconfigure on next login.',
+    'users_mfa_reset_confirm' => 'Are you sure you want to reset 2FA for :userName?',
+    'users_mfa_reset_success' => '2FA has been reset for :userName',
+    'users_mfa_reset_error' => 'Failed to reset 2FA for :userName',
 
     // API Tokens
     'user_api_token_create' => 'Create API Token',

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -71,6 +71,26 @@
                 </div>
             </div>
 
+            @if(user()->hasSystemRole('admin'))
+                <div class="mt-xl">
+                    <hr class="my-m">
+                    <div class="grid half gap-xl v-center">
+                        <div>
+                            <strong class="text-neg">{{ trans('settings.users_mfa_reset') }}</strong>
+                            <p class="text-small text-muted">{{ trans('settings.users_mfa_reset_desc', ['userName' => $user->name]) }}</p>
+                        </div>
+                        <div class="text-m-right">
+                            <form action="{{ url("/settings/users/{$user->id}/reset-mfa") }}" method="POST" style="display: inline;">
+                                @csrf
+                                <button type="submit" class="button neg" 
+                                        onclick="return confirm('{{ trans('settings.users_mfa_reset_confirm', ['userName' => $user->name]) }}')">
+                                    {{ trans('settings.users_mfa_reset') }}
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            @endif
         </section>
 
         @if(count($activeSocialDrivers) > 0)

--- a/routes/web.php
+++ b/routes/web.php
@@ -251,6 +251,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/settings/users/{id}', [UserControllers\UserController::class, 'edit']);
     Route::put('/settings/users/{id}', [UserControllers\UserController::class, 'update']);
     Route::delete('/settings/users/{id}', [UserControllers\UserController::class, 'destroy']);
+    Route::post('/settings/users/{id}/reset-mfa', [UserControllers\UserController::class, 'resetMfa']);
 
     // User Account
     Route::get('/my-account', [UserControllers\UserAccountController::class, 'redirect']);


### PR DESCRIPTION
### Summary
This pull request adds a **Reset MFA button** to the user profile edit page, allowing administrators to easily reset a user's multi-factor authentication configuration.

### Motivation
If a user loses access to their MFA device or is unable to complete the authentication process, administrators currently have no quick way to reset MFA from the interface. This feature provides a simple and controlled way for admins to resolve such situations.

### Changes
- Added a **Reset MFA** button in the user profile edit view.
- Implemented a controller method to handle MFA reset for the selected user.
- Restricted the action to users with the appropriate **UsersManage permission**.
- The reset operation removes the user's stored MFA values, forcing them to reconfigure MFA on next login.

### Security
Only administrators with the `UsersManage` permission can perform this action.

### Result
Administrators can quickly reset MFA for users who are locked out due to lost or misconfigured authentication devices, improving support and account recovery workflows.