### PR TITLE
Fix PDF export heading font fallback

### DIFF
--- a/resources/sass/export-styles.scss
+++ b/resources/sass/export-styles.scss
@@ -64,6 +64,11 @@ body.export-format-pdf {
   font-size: 14px;
   line-height: 1.2;
 
+  // Ensure heading glyph coverage for PDF engines that don't handle CSS vars well.
+  h1, h2, h3, h4, h5, h6 {
+    font-family: 'DejaVu Sans', -apple-system, BlinkMacSystemFont, "Segoe UI", "Oxygen", "Ubuntu", "Roboto", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  }
+
   h1, h2, h3, h4, h5, h6 {
     line-height: 1.2;
   }


### PR DESCRIPTION
PDF exports used the heading font var which in DOMPDF fell back to base fonts lacking Polish glyphs, causing ? in titles. This PR adds a PDF-only heading font fallback to DejaVu Sans for h1-h6. Tested by exporting a page with a Polish title; characters render correctly.


Before
<img width="792" height="386" alt="image" src="https://github.com/user-attachments/assets/e8ad4668-f121-4c6b-b5b1-c75bb1fbeb8a" />
<img width="803" height="406" alt="image" src="https://github.com/user-attachments/assets/63c4cd84-ab8f-4171-977d-76c4f06556f3" />

After
<img width="774" height="417" alt="image" src="https://github.com/user-attachments/assets/b5ab423f-4fd4-4929-a7fc-ef8945998e38" />
<img width="760" height="539" alt="image" src="https://github.com/user-attachments/assets/aae6bfb0-cd5a-4437-b3fc-c2e33a2fd7fd" />
