### PR TITLE
Add support for attachments on books and chapters

### DIFF
--- a/app/Entities/Models/Book.php
+++ b/app/Entities/Models/Book.php
@@ -5,6 +5,7 @@ namespace BookStack\Entities\Models;
 use BookStack\Entities\Tools\EntityCover;
 use BookStack\Entities\Tools\EntityDefaultTemplate;
 use BookStack\Sorting\SortRule;
+use BookStack\Uploads\Attachment;
 use BookStack\Uploads\Image;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -68,6 +69,16 @@ class Book extends Entity implements HasDescriptionInterface, HasCoverInterface,
     public function chapters(): HasMany
     {
         return $this->hasMany(Chapter::class);
+    }
+
+    /**
+     * Get the attachments assigned directly to this book.
+     */
+    public function attachments(): HasMany
+    {
+        return $this->hasMany(Attachment::class, 'uploaded_to')
+            ->where('uploaded_to_type', '=', Attachment::UPLOAD_TO_BOOK)
+            ->orderBy('order', 'asc');
     }
 
     /**

--- a/app/Entities/Models/Chapter.php
+++ b/app/Entities/Models/Chapter.php
@@ -3,6 +3,7 @@
 namespace BookStack\Entities\Models;
 
 use BookStack\Entities\Tools\EntityDefaultTemplate;
+use BookStack\Uploads\Attachment;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
@@ -30,6 +31,16 @@ class Chapter extends BookChild implements HasDescriptionInterface, HasDefaultTe
     public function pages(string $dir = 'ASC'): HasMany
     {
         return $this->hasMany(Page::class)->orderBy('priority', $dir);
+    }
+
+    /**
+     * Get the attachments assigned directly to this chapter.
+     */
+    public function attachments(): HasMany
+    {
+        return $this->hasMany(Attachment::class, 'uploaded_to')
+            ->where('uploaded_to_type', '=', Attachment::UPLOAD_TO_CHAPTER)
+            ->orderBy('order', 'asc');
     }
 
     /**

--- a/app/Entities/Models/Page.php
+++ b/app/Entities/Models/Page.php
@@ -105,7 +105,9 @@ class Page extends BookChild
      */
     public function attachments(): HasMany
     {
-        return $this->hasMany(Attachment::class, 'uploaded_to')->orderBy('order', 'asc');
+        return $this->hasMany(Attachment::class, 'uploaded_to')
+            ->where('uploaded_to_type', '=', Attachment::UPLOAD_TO_PAGE)
+            ->orderBy('order', 'asc');
     }
 
     /**

--- a/app/Entities/Tools/TrashCan.php
+++ b/app/Entities/Tools/TrashCan.php
@@ -157,6 +157,7 @@ class TrashCan
     protected function destroyBook(Book $book): int
     {
         $count = 0;
+        $attachmentService = app()->make(AttachmentService::class);
         $pages = $book->pages()->withTrashed()->get();
         foreach ($pages as $page) {
             $this->destroyPage($page);
@@ -167,6 +168,10 @@ class TrashCan
         foreach ($chapters as $chapter) {
             $this->destroyChapter($chapter);
             $count++;
+        }
+
+        foreach ($book->attachments as $attachment) {
+            $attachmentService->deleteFile($attachment);
         }
 
         $this->destroyCommonRelations($book);
@@ -185,10 +190,15 @@ class TrashCan
     protected function destroyChapter(Chapter $chapter): int
     {
         $count = 0;
+        $attachmentService = app()->make(AttachmentService::class);
         $pages = $chapter->pages()->withTrashed()->get();
         foreach ($pages as $page) {
             $this->destroyPage($page);
             $count++;
+        }
+
+        foreach ($chapter->attachments as $attachment) {
+            $attachmentService->deleteFile($attachment);
         }
 
         $this->destroyCommonRelations($chapter);

--- a/app/Uploads/Attachment.php
+++ b/app/Uploads/Attachment.php
@@ -3,6 +3,8 @@
 namespace BookStack\Uploads;
 
 use BookStack\App\Model;
+use BookStack\Entities\Models\Book;
+use BookStack\Entities\Models\Chapter;
 use BookStack\Entities\Models\Entity;
 use BookStack\Entities\Models\Page;
 use BookStack\Permissions\Models\JointPermission;
@@ -14,6 +16,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 /**
  * @property int    $id
@@ -33,11 +36,29 @@ class Attachment extends Model implements OwnableInterface
     use HasCreatorAndUpdater;
     use HasFactory;
 
+    public const UPLOAD_TO_PAGE = 'page';
+    public const UPLOAD_TO_CHAPTER = 'chapter';
+    public const UPLOAD_TO_BOOK = 'book';
+
+    public const UPLOAD_TO_ENTITY_TYPES = [
+        self::UPLOAD_TO_PAGE,
+        self::UPLOAD_TO_CHAPTER,
+        self::UPLOAD_TO_BOOK,
+    ];
+
     protected $fillable = ['name', 'order'];
-    protected $hidden = ['path', 'page'];
+    protected $hidden = ['path', 'page', 'uploadedTo'];
     protected $casts = [
         'external' => 'bool',
     ];
+
+    /**
+     * Ensure uploaded target type defaults to page for backward compatibility.
+     */
+    public function getUploadedToTypeAttribute(?string $value): string
+    {
+        return $value ?: self::UPLOAD_TO_PAGE;
+    }
 
     /**
      * Get the downloadable file name for this upload.
@@ -56,13 +77,27 @@ class Attachment extends Model implements OwnableInterface
      */
     public function page(): BelongsTo
     {
-        return $this->belongsTo(Page::class, 'uploaded_to');
+        $relation = $this->belongsTo(Page::class, 'uploaded_to');
+
+        if ($this->uploaded_to_type !== self::UPLOAD_TO_PAGE) {
+            $relation->whereRaw('1 = 0');
+        }
+
+        return $relation;
+    }
+
+    /**
+     * Get the entity this attachment is uploaded to.
+     */
+    public function uploadedTo(): MorphTo
+    {
+        return $this->morphTo(__FUNCTION__, 'uploaded_to_type', 'uploaded_to');
     }
 
     public function jointPermissions(): HasMany
     {
         return $this->hasMany(JointPermission::class, 'entity_id', 'uploaded_to')
-            ->where('joint_permissions.entity_type', '=', 'page');
+            ->where('joint_permissions.entity_type', '=', $this->uploaded_to_type);
     }
 
     /**
@@ -115,10 +150,21 @@ class Attachment extends Model implements OwnableInterface
     {
         $permissions = app()->make(PermissionApplicator::class);
 
-        return $permissions->restrictPageRelationQuery(
-            self::query(),
-            'attachments',
-            'uploaded_to'
-        );
+        return $permissions
+            ->restrictEntityRelationQuery(self::query(), 'attachments', 'uploaded_to', 'uploaded_to_type')
+            ->whereIn('uploaded_to_type', self::UPLOAD_TO_ENTITY_TYPES);
+    }
+
+    /**
+     * Get the target entity class for an upload type.
+     */
+    public static function classForUploadType(string $type): ?string
+    {
+        return match ($type) {
+            self::UPLOAD_TO_PAGE => Page::class,
+            self::UPLOAD_TO_CHAPTER => Chapter::class,
+            self::UPLOAD_TO_BOOK => Book::class,
+            default => null,
+        };
     }
 }

--- a/app/Uploads/AttachmentService.php
+++ b/app/Uploads/AttachmentService.php
@@ -36,18 +36,22 @@ class AttachmentService
      *
      * @throws FileUploadException
      */
-    public function saveNewUpload(UploadedFile $uploadedFile, int $pageId): Attachment
+    public function saveNewUpload(UploadedFile $uploadedFile, int $uploadedToId, string $uploadedToType = Attachment::UPLOAD_TO_PAGE): Attachment
     {
         $attachmentName = $uploadedFile->getClientOriginalName();
         $attachmentPath = $this->putFileInStorage($uploadedFile);
-        $largestExistingOrder = Attachment::query()->where('uploaded_to', '=', $pageId)->max('order');
+        $largestExistingOrder = Attachment::query()
+            ->where('uploaded_to', '=', $uploadedToId)
+            ->where('uploaded_to_type', '=', $uploadedToType)
+            ->max('order');
 
         /** @var Attachment $attachment */
         $attachment = Attachment::query()->forceCreate([
             'name'        => $attachmentName,
             'path'        => $attachmentPath,
             'extension'   => $uploadedFile->getClientOriginalExtension(),
-            'uploaded_to' => $pageId,
+            'uploaded_to' => $uploadedToId,
+            'uploaded_to_type' => $uploadedToType,
             'created_by'  => user()->id,
             'updated_by'  => user()->id,
             'order'       => $largestExistingOrder + 1,
@@ -83,16 +87,20 @@ class AttachmentService
     /**
      * Save a new File attachment from a given link and name.
      */
-    public function saveNewFromLink(string $name, string $link, int $page_id): Attachment
+    public function saveNewFromLink(string $name, string $link, int $uploadedToId, string $uploadedToType = Attachment::UPLOAD_TO_PAGE): Attachment
     {
-        $largestExistingOrder = Attachment::where('uploaded_to', '=', $page_id)->max('order');
+        $largestExistingOrder = Attachment::query()
+            ->where('uploaded_to', '=', $uploadedToId)
+            ->where('uploaded_to_type', '=', $uploadedToType)
+            ->max('order');
 
         return Attachment::forceCreate([
             'name'        => $name,
             'path'        => $link,
             'external'    => true,
             'extension'   => '',
-            'uploaded_to' => $page_id,
+            'uploaded_to' => $uploadedToId,
+            'uploaded_to_type' => $uploadedToType,
             'created_by'  => user()->id,
             'updated_by'  => user()->id,
             'order'       => $largestExistingOrder + 1,
@@ -102,10 +110,11 @@ class AttachmentService
     /**
      * Updates the ordering for a listing of attached files.
      */
-    public function updateFileOrderWithinPage(array $attachmentOrder, string $pageId)
+    public function updateFileOrderWithinEntity(array $attachmentOrder, string $uploadedToId, string $uploadedToType = Attachment::UPLOAD_TO_PAGE)
     {
         foreach ($attachmentOrder as $index => $attachmentId) {
-            Attachment::query()->where('uploaded_to', '=', $pageId)
+            Attachment::query()->where('uploaded_to', '=', $uploadedToId)
+                ->where('uploaded_to_type', '=', $uploadedToType)
                 ->where('id', '=', $attachmentId)
                 ->update(['order' => $index]);
         }

--- a/app/Uploads/Controllers/AttachmentApiController.php
+++ b/app/Uploads/Controllers/AttachmentApiController.php
@@ -2,8 +2,8 @@
 
 namespace BookStack\Uploads\Controllers;
 
-use BookStack\Entities\EntityExistsRule;
-use BookStack\Entities\Queries\PageQueries;
+use BookStack\Entities\Models\Entity;
+use BookStack\Entities\Queries\EntityQueries;
 use BookStack\Exceptions\FileUploadException;
 use BookStack\Http\ApiController;
 use BookStack\Permissions\Permission;
@@ -12,13 +12,14 @@ use BookStack\Uploads\AttachmentService;
 use Exception;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 
 class AttachmentApiController extends ApiController
 {
     public function __construct(
         protected AttachmentService $attachmentService,
-        protected PageQueries $pageQueries,
+        protected EntityQueries $entityQueries,
     ) {
     }
 
@@ -30,7 +31,7 @@ class AttachmentApiController extends ApiController
     public function list()
     {
         return $this->apiListingResponse(Attachment::visible(), [
-            'id', 'name', 'extension', 'uploaded_to', 'external', 'order', 'created_at', 'updated_at', 'created_by', 'updated_by',
+            'id', 'name', 'extension', 'uploaded_to', 'uploaded_to_type', 'external', 'order', 'created_at', 'updated_at', 'created_by', 'updated_by',
         ]);
     }
 
@@ -50,18 +51,20 @@ class AttachmentApiController extends ApiController
         $this->checkPermission(Permission::AttachmentCreateAll);
         $requestData = $this->validate($request, $this->rules()['create']);
 
-        $pageId = $request->get('uploaded_to');
-        $page = $this->pageQueries->findVisibleByIdOrFail($pageId);
-        $this->checkOwnablePermission(Permission::PageUpdate, $page);
+        $uploadedToId = intval($request->get('uploaded_to'));
+        $uploadedToType = $requestData['uploaded_to_type'] ?? Attachment::UPLOAD_TO_PAGE;
+        $target = $this->findVisibleUploadTarget($uploadedToType, $uploadedToId);
+        $this->checkUploadTargetPermission($target, 'update');
 
         if ($request->hasFile('file')) {
             $uploadedFile = $request->file('file');
-            $attachment = $this->attachmentService->saveNewUpload($uploadedFile, $page->id);
+            $attachment = $this->attachmentService->saveNewUpload($uploadedFile, $uploadedToId, $uploadedToType);
         } else {
             $attachment = $this->attachmentService->saveNewFromLink(
                 $requestData['name'],
                 $requestData['link'],
-                $page->id
+                $uploadedToId,
+                $uploadedToType
             );
         }
 
@@ -132,15 +135,17 @@ class AttachmentApiController extends ApiController
         /** @var Attachment $attachment */
         $attachment = Attachment::visible()->findOrFail($id);
 
-        $page = $attachment->page;
+        $uploadedToType = $requestData['uploaded_to_type'] ?? $attachment->uploaded_to_type;
+        $uploadedToId = $requestData['uploaded_to'] ?? $attachment->uploaded_to;
+
+        $target = $this->findVisibleUploadTarget($uploadedToType, intval($uploadedToId));
         if ($requestData['uploaded_to'] ?? false) {
-            $pageId = $request->get('uploaded_to');
-            $page = $this->pageQueries->findVisibleByIdOrFail($pageId);
             $attachment->uploaded_to = $requestData['uploaded_to'];
+            $attachment->uploaded_to_type = $uploadedToType;
         }
 
-        $this->checkOwnablePermission(Permission::PageView, $page);
-        $this->checkOwnablePermission(Permission::PageUpdate, $page);
+        $this->checkUploadTargetPermission($target, 'view');
+        $this->checkUploadTargetPermission($target, 'update');
         $this->checkOwnablePermission(Permission::AttachmentUpdate, $attachment);
 
         if ($request->hasFile('file')) {
@@ -174,16 +179,52 @@ class AttachmentApiController extends ApiController
         return [
             'create' => [
                 'name'        => ['required', 'string', 'min:1', 'max:255'],
-                'uploaded_to' => ['required', 'integer', new EntityExistsRule('page')],
+                'uploaded_to' => ['required', 'integer'],
+                'uploaded_to_type' => ['nullable', 'string', Rule::in(Attachment::UPLOAD_TO_ENTITY_TYPES)],
                 'file'        => array_merge(['required_without:link'], $this->attachmentService->getFileValidationRules()),
                 'link'        => ['required_without:file', 'string', 'min:1', 'max:2000', 'safe_url'],
             ],
             'update' => [
                 'name'        => ['string', 'min:1', 'max:255'],
-                'uploaded_to' => ['integer', new EntityExistsRule('page')],
+                'uploaded_to' => ['integer', 'required_with:uploaded_to_type'],
+                'uploaded_to_type' => ['string', Rule::in(Attachment::UPLOAD_TO_ENTITY_TYPES), 'required_with:uploaded_to'],
                 'file'        => $this->attachmentService->getFileValidationRules(),
                 'link'        => ['string', 'min:1', 'max:2000', 'safe_url'],
             ],
         ];
+    }
+
+    protected function findVisibleUploadTarget(string $type, int $id): Entity
+    {
+        if (!in_array($type, Attachment::UPLOAD_TO_ENTITY_TYPES)) {
+            abort(404, trans('errors.attachment_not_found'));
+        }
+
+        $target = $this->entityQueries->findVisibleById($type, $id);
+
+        if ($target === null) {
+            abort(404, trans('errors.attachment_not_found'));
+        }
+
+        return $target;
+    }
+
+    protected function checkUploadTargetPermission(Entity $entity, string $action): void
+    {
+        $permission = match ([$entity->getMorphClass(), $action]) {
+            [Attachment::UPLOAD_TO_PAGE, 'view'] => Permission::PageView,
+            [Attachment::UPLOAD_TO_PAGE, 'update'] => Permission::PageUpdate,
+            [Attachment::UPLOAD_TO_CHAPTER, 'view'] => Permission::ChapterView,
+            [Attachment::UPLOAD_TO_CHAPTER, 'update'] => Permission::ChapterUpdate,
+            [Attachment::UPLOAD_TO_BOOK, 'view'] => Permission::BookView,
+            [Attachment::UPLOAD_TO_BOOK, 'update'] => Permission::BookUpdate,
+            default => null,
+        };
+
+        if ($permission === null) {
+            abort(404, trans('errors.attachment_not_found'));
+        }
+
+        $this->checkOwnablePermission($permission, $entity);
     }
 }

--- a/app/Uploads/Controllers/AttachmentController.php
+++ b/app/Uploads/Controllers/AttachmentController.php
@@ -2,9 +2,8 @@
 
 namespace BookStack\Uploads\Controllers;
 
-use BookStack\Entities\EntityExistsRule;
-use BookStack\Entities\Queries\PageQueries;
-use BookStack\Entities\Repos\PageRepo;
+use BookStack\Entities\Models\Entity;
+use BookStack\Entities\Queries\EntityQueries;
 use BookStack\Exceptions\FileUploadException;
 use BookStack\Exceptions\NotFoundException;
 use BookStack\Http\Controller;
@@ -15,14 +14,14 @@ use Exception;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Support\MessageBag;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 
 class AttachmentController extends Controller
 {
     public function __construct(
         protected AttachmentService $attachmentService,
-        protected PageQueries $pageQueries,
-        protected PageRepo $pageRepo
+        protected EntityQueries $entityQueries,
     ) {
     }
 
@@ -35,20 +34,22 @@ class AttachmentController extends Controller
     public function upload(Request $request)
     {
         $this->validate($request, [
-            'uploaded_to' => ['required', 'integer',  new EntityExistsRule('page')],
+            'uploaded_to' => ['required', 'integer'],
+            'uploaded_to_type' => ['nullable', 'string', Rule::in(Attachment::UPLOAD_TO_ENTITY_TYPES)],
             'file'        => array_merge(['required'], $this->attachmentService->getFileValidationRules()),
         ]);
 
-        $pageId = $request->get('uploaded_to');
-        $page = $this->pageQueries->findVisibleByIdOrFail($pageId);
+        $uploadedToId = intval($request->get('uploaded_to'));
+        $uploadedToType = $request->get('uploaded_to_type', Attachment::UPLOAD_TO_PAGE);
+        $target = $this->findVisibleUploadTarget($uploadedToType, $uploadedToId);
 
         $this->checkPermission(Permission::AttachmentCreateAll);
-        $this->checkOwnablePermission(Permission::PageUpdate, $page);
+        $this->checkUploadTargetPermission($target, 'update');
 
         $uploadedFile = $request->file('file');
 
         try {
-            $attachment = $this->attachmentService->saveNewUpload($uploadedFile, $pageId);
+            $attachment = $this->attachmentService->saveNewUpload($uploadedFile, $uploadedToId, $uploadedToType);
         } catch (FileUploadException $e) {
             return response($e->getMessage(), 500);
         }
@@ -69,8 +70,9 @@ class AttachmentController extends Controller
 
         /** @var Attachment $attachment */
         $attachment = Attachment::query()->findOrFail($attachmentId);
-        $this->checkOwnablePermission(Permission::PageView, $attachment->page);
-        $this->checkOwnablePermission(Permission::PageUpdate, $attachment->page);
+        $target = $this->findVisibleUploadTarget($attachment->uploaded_to_type, $attachment->uploaded_to);
+        $this->checkUploadTargetPermission($target, 'view');
+        $this->checkUploadTargetPermission($target, 'update');
         $this->checkOwnablePermission(Permission::AttachmentUpdate, $attachment);
 
         $uploadedFile = $request->file('file');
@@ -92,7 +94,8 @@ class AttachmentController extends Controller
         /** @var Attachment $attachment */
         $attachment = Attachment::query()->findOrFail($attachmentId);
 
-        $this->checkOwnablePermission(Permission::PageUpdate, $attachment->page);
+        $target = $this->findVisibleUploadTarget($attachment->uploaded_to_type, $attachment->uploaded_to);
+        $this->checkUploadTargetPermission($target, 'update');
         $this->checkOwnablePermission(Permission::AttachmentCreate, $attachment);
 
         return view('attachments.manager-edit-form', [
@@ -120,8 +123,9 @@ class AttachmentController extends Controller
             ]), 422);
         }
 
-        $this->checkOwnablePermission(Permission::PageView, $attachment->page);
-        $this->checkOwnablePermission(Permission::PageUpdate, $attachment->page);
+        $target = $this->findVisibleUploadTarget($attachment->uploaded_to_type, $attachment->uploaded_to);
+        $this->checkUploadTargetPermission($target, 'view');
+        $this->checkUploadTargetPermission($target, 'update');
         $this->checkOwnablePermission(Permission::AttachmentUpdate, $attachment);
 
         $attachment = $this->attachmentService->updateFile($attachment, [
@@ -135,52 +139,58 @@ class AttachmentController extends Controller
     }
 
     /**
-     * Attach a link to a page.
+    * Attach a link to an entity.
      *
      * @throws NotFoundException
      */
     public function attachLink(Request $request)
     {
-        $pageId = $request->get('attachment_link_uploaded_to');
+        $uploadedToId = intval($request->get('attachment_link_uploaded_to'));
+        $uploadedToType = $request->get('attachment_link_uploaded_to_type', Attachment::UPLOAD_TO_PAGE);
 
         try {
             $this->validate($request, [
-                'attachment_link_uploaded_to' => ['required', 'integer',  new EntityExistsRule('page')],
+                'attachment_link_uploaded_to' => ['required', 'integer'],
+                'attachment_link_uploaded_to_type' => ['nullable', 'string', Rule::in(Attachment::UPLOAD_TO_ENTITY_TYPES)],
                 'attachment_link_name'        => ['required', 'string', 'min:1', 'max:255'],
                 'attachment_link_url'         => ['required', 'string', 'min:1', 'max:2000', 'safe_url'],
             ]);
         } catch (ValidationException $exception) {
             return response()->view('attachments.manager-link-form', array_merge($request->only(['attachment_link_name', 'attachment_link_url']), [
-                'pageId' => $pageId,
+                'uploadedToId' => $uploadedToId,
+                'uploadedToType' => $uploadedToType,
                 'errors' => new MessageBag($exception->errors()),
             ]), 422);
         }
 
-        $page = $this->pageQueries->findVisibleByIdOrFail($pageId);
+        $target = $this->findVisibleUploadTarget($uploadedToType, $uploadedToId);
 
         $this->checkPermission(Permission::AttachmentCreateAll);
-        $this->checkOwnablePermission(Permission::PageUpdate, $page);
+        $this->checkUploadTargetPermission($target, 'update');
 
         $attachmentName = $request->get('attachment_link_name');
         $link = $request->get('attachment_link_url');
-        $this->attachmentService->saveNewFromLink($attachmentName, $link, intval($pageId));
+        $this->attachmentService->saveNewFromLink($attachmentName, $link, $uploadedToId, $uploadedToType);
 
         return view('attachments.manager-link-form', [
-            'pageId' => $pageId,
+            'uploadedToId' => $uploadedToId,
+            'uploadedToType' => $uploadedToType,
         ]);
     }
 
     /**
-     * Get the attachments for a specific page.
+    * Get the attachments for a specific upload target entity.
      *
      * @throws NotFoundException
      */
-    public function listForPage(int $pageId)
+    public function listForEntity(string $entityType, int $entityId)
     {
-        $page = $this->pageQueries->findVisibleByIdOrFail($pageId);
+        $entity = $this->findVisibleUploadTarget($entityType, $entityId);
+        $attachments = $entity->attachments()->get();
 
         return view('attachments.manager-list', [
-            'attachments' => $page->attachments->all(),
+            'attachments' => $attachments,
+            'allowInsertLinks' => $entityType === Attachment::UPLOAD_TO_PAGE,
         ]);
     }
 
@@ -190,16 +200,16 @@ class AttachmentController extends Controller
      * @throws ValidationException
      * @throws NotFoundException
      */
-    public function sortForPage(Request $request, int $pageId)
+    public function sortForEntity(Request $request, string $entityType, int $entityId)
     {
         $this->validate($request, [
             'order' => ['required', 'array'],
         ]);
-        $page = $this->pageQueries->findVisibleByIdOrFail($pageId);
-        $this->checkOwnablePermission(Permission::PageUpdate, $page);
+        $entity = $this->findVisibleUploadTarget($entityType, $entityId);
+        $this->checkUploadTargetPermission($entity, 'update');
 
         $attachmentOrder = $request->get('order');
-        $this->attachmentService->updateFileOrderWithinPage($attachmentOrder, $pageId);
+        $this->attachmentService->updateFileOrderWithinEntity($attachmentOrder, (string) $entityId, $entityType);
 
         return response()->json(['message' => trans('entities.attachments_order_updated')]);
     }
@@ -214,14 +224,8 @@ class AttachmentController extends Controller
     {
         /** @var Attachment $attachment */
         $attachment = Attachment::query()->findOrFail($attachmentId);
-
-        try {
-            $page = $this->pageQueries->findVisibleByIdOrFail($attachment->uploaded_to);
-        } catch (NotFoundException $exception) {
-            throw new NotFoundException(trans('errors.attachment_not_found'));
-        }
-
-        $this->checkOwnablePermission(Permission::PageView, $page);
+        $target = $this->findVisibleUploadTarget($attachment->uploaded_to_type, $attachment->uploaded_to);
+        $this->checkUploadTargetPermission($target, 'view');
 
         if ($attachment->external) {
             return redirect($attachment->path);
@@ -251,5 +255,39 @@ class AttachmentController extends Controller
         $this->attachmentService->deleteFile($attachment);
 
         return response()->json(['message' => trans('entities.attachments_deleted')]);
+    }
+
+    protected function findVisibleUploadTarget(string $type, int $id): Entity
+    {
+        if (!in_array($type, Attachment::UPLOAD_TO_ENTITY_TYPES)) {
+            throw new NotFoundException(trans('errors.attachment_not_found'));
+        }
+
+        $target = $this->entityQueries->findVisibleById($type, $id);
+
+        if ($target === null) {
+            throw new NotFoundException(trans('errors.attachment_not_found'));
+        }
+
+        return $target;
+    }
+
+    protected function checkUploadTargetPermission(Entity $entity, string $action): void
+    {
+        $permission = match ([$entity->getMorphClass(), $action]) {
+            [Attachment::UPLOAD_TO_PAGE, 'view'] => Permission::PageView,
+            [Attachment::UPLOAD_TO_PAGE, 'update'] => Permission::PageUpdate,
+            [Attachment::UPLOAD_TO_CHAPTER, 'view'] => Permission::ChapterView,
+            [Attachment::UPLOAD_TO_CHAPTER, 'update'] => Permission::ChapterUpdate,
+            [Attachment::UPLOAD_TO_BOOK, 'view'] => Permission::BookView,
+            [Attachment::UPLOAD_TO_BOOK, 'update'] => Permission::BookUpdate,
+            default => null,
+        };
+
+        if ($permission === null) {
+            throw new NotFoundException(trans('errors.attachment_not_found'));
+        }
+
+        $this->checkOwnablePermission($permission, $entity);
     }
 }

--- a/database/factories/Uploads/AttachmentFactory.php
+++ b/database/factories/Uploads/AttachmentFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories\Uploads;
 
 use BookStack\Entities\Models\Page;
+use BookStack\Uploads\Attachment;
 use BookStack\Users\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -31,6 +32,7 @@ class AttachmentFactory extends Factory
             'extension' => '',
             'external' => true,
             'uploaded_to' => Page::factory(),
+            'uploaded_to_type' => Attachment::UPLOAD_TO_PAGE,
             'created_by' => User::factory(),
             'updated_by' => User::factory(),
             'order' => 0,

--- a/database/migrations/2026_03_26_000001_add_uploaded_to_type_to_attachments_table.php
+++ b/database/migrations/2026_03_26_000001_add_uploaded_to_type_to_attachments_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('attachments', function (Blueprint $table) {
+            $table->string('uploaded_to_type', 20)->default('page')->after('uploaded_to');
+            $table->index(['uploaded_to_type', 'uploaded_to']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('attachments', function (Blueprint $table) {
+            $table->dropIndex('attachments_uploaded_to_type_uploaded_to_index');
+            $table->dropColumn('uploaded_to_type');
+        });
+    }
+};

--- a/resources/js/components/attachments.js
+++ b/resources/js/components/attachments.js
@@ -5,7 +5,8 @@ export class Attachments extends Component {
 
     setup() {
         this.container = this.$el;
-        this.pageId = this.$opts.pageId;
+        this.uploadedToId = this.$opts.uploadedToId;
+        this.uploadedToType = this.$opts.uploadedToType;
         this.editContainer = this.$refs.editContainer;
         this.listContainer = this.$refs.listContainer;
         this.linksContainer = this.$refs.linksContainer;
@@ -60,14 +61,14 @@ export class Attachments extends Component {
 
     reloadList() {
         this.stopEdit();
-        window.$http.get(`/attachments/get/page/${this.pageId}`).then(resp => {
+        window.$http.get(`/attachments/get/${this.uploadedToType}/${this.uploadedToId}`).then(resp => {
             this.listPanel.innerHTML = resp.data;
             window.$components.init(this.listPanel);
         });
     }
 
     updateOrder(idOrder) {
-        window.$http.put(`/attachments/sort/page/${this.pageId}`, {order: idOrder}).then(resp => {
+        window.$http.put(`/attachments/sort/${this.uploadedToType}/${this.uploadedToId}`, {order: idOrder}).then(resp => {
             window.$events.emit('success', resp.data.message);
         });
     }

--- a/resources/views/attachments/manager-link-form.blade.php
+++ b/resources/views/attachments/manager-link-form.blade.php
@@ -1,12 +1,14 @@
 {{--
-@pageId
+@uploadedToId
+@uploadedToType
 --}}
 <div component="ajax-form"
      option:ajax-form:url="/attachments/link"
      option:ajax-form:method="post"
      option:ajax-form:response-container="#link-form-container"
      option:ajax-form:success-message="{{ trans('entities.attachments_link_attached') }}">
-    <input type="hidden" name="attachment_link_uploaded_to" value="{{ $pageId }}">
+    <input type="hidden" name="attachment_link_uploaded_to" value="{{ $uploadedToId }}">
+    <input type="hidden" name="attachment_link_uploaded_to_type" value="{{ $uploadedToType }}">
     <p class="text-muted small">{{ trans('entities.attachments_explain_link') }}</p>
     <div class="form-group">
         <label for="attachment_link_name">{{ trans('entities.attachments_link_name') }}</label>

--- a/resources/views/attachments/manager-list.blade.php
+++ b/resources/views/attachments/manager-list.blade.php
@@ -11,11 +11,13 @@
                 <a href="{{ $attachment->getUrl() }}" target="_blank" rel="noopener">{{ $attachment->name }}</a>
             </div>
             <div class="flex-fill justify-flex-end">
-                <button component="event-emit-select"
-                        option:event-emit-select:name="insert"
-                        type="button"
-                        title="{{ trans('entities.attachments_insert_link') }}"
-                        class="drag-card-action text-center text-link">@icon('link')</button>
+                @if($allowInsertLinks ?? true)
+                    <button component="event-emit-select"
+                            option:event-emit-select:name="insert"
+                            type="button"
+                            title="{{ trans('entities.attachments_insert_link') }}"
+                            class="drag-card-action text-center text-link">@icon('link')</button>
+                @endif
                 @if(userCan(\BookStack\Permissions\Permission::AttachmentUpdate, $attachment))
                     <button component="event-emit-select"
                             option:event-emit-select:name="edit"

--- a/resources/views/attachments/manager.blade.php
+++ b/resources/views/attachments/manager.blade.php
@@ -2,12 +2,13 @@
      refs="editor-toolbox@tab-content"
      data-tab-content="files"
      component="attachments"
-     option:attachments:page-id="{{ $page->id ?? 0 }}"
+    option:attachments:uploaded-to-id="{{ $uploadedToId }}"
+    option:attachments:uploaded-to-type="{{ $uploadedToType }}"
      class="toolbox-tab-content">
 
     <h4>{{ trans('entities.attachments') }}</h4>
     <div component="dropzone"
-         option:dropzone:url="{{ url('/attachments/upload?uploaded_to=' . $page->id) }}"
+            option:dropzone:url="{{ url('/attachments/upload?uploaded_to=' . $uploadedToId . '&uploaded_to_type=' . $uploadedToType) }}"
          option:dropzone:success-message="{{ trans('entities.attachments_file_uploaded') }}"
          option:dropzone:error-message="{{ trans('errors.attachment_upload_error') }}"
          option:dropzone:upload-limit="{{ config('app.upload_limit') }}"
@@ -35,14 +36,14 @@
             <hr>
 
             <div refs="attachments@list-panel">
-                @include('attachments.manager-list', ['attachments' => $page->attachments->all()])
+                @include('attachments.manager-list', ['attachments' => $attachments, 'allowInsertLinks' => $allowInsertLinks ?? false])
             </div>
 
         </div>
     </div>
 
     <div id="link-form-container" refs="attachments@links-container" hidden class="px-l">
-        @include('attachments.manager-link-form', ['pageId' => $page->id])
+        @include('attachments.manager-link-form', ['uploadedToId' => $uploadedToId, 'uploadedToType' => $uploadedToType])
     </div>
 
     <div id="edit-form-container" refs="attachments@edit-container" hidden class="px-l"></div>

--- a/resources/views/books/parts/form.blade.php
+++ b/resources/views/books/parts/form.blade.php
@@ -43,6 +43,22 @@
     </div>
 </div>
 
+@if(isset($book) && userCan(\BookStack\Permissions\Permission::AttachmentCreateAll))
+    <div class="form-group collapsible" component="collapsible" id="attachments-control">
+        <button refs="collapsible@trigger" type="button" class="collapse-title text-link" aria-expanded="false">
+            <label>{{ trans('entities.attachments') }}</label>
+        </button>
+        <div refs="collapsible@content" class="collapse-content">
+            @include('attachments.manager', [
+                'attachments' => $book->attachments->all(),
+                'uploadedToId' => $book->id,
+                'uploadedToType' => \BookStack\Uploads\Attachment::UPLOAD_TO_BOOK,
+                'allowInsertLinks' => false,
+            ])
+        </div>
+    </div>
+@endif
+
 <div class="form-group text-right">
     <a href="{{ $returnLocation }}" class="button outline">{{ trans('common.cancel') }}</a>
     <button type="submit" class="button">{{ trans('entities.books_save') }}</button>

--- a/resources/views/books/parts/show-sidebar-section-attachments.blade.php
+++ b/resources/views/books/parts/show-sidebar-section-attachments.blade.php
@@ -1,0 +1,6 @@
+@if($book->attachments->count() > 0)
+    <div id="book-attachments" class="mb-l">
+        <h5>{{ trans('entities.attachments') }}</h5>
+        @include('attachments.list', ['attachments' => $book->attachments])
+    </div>
+@endif

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -67,6 +67,7 @@
 @stop
 
 @section('right')
+    @include('books.parts.show-sidebar-section-attachments', ['book' => $book])
     @include('books.parts.show-sidebar-section-details', ['book' => $book, 'watchOptions' => $watchOptions])
     @include('books.parts.show-sidebar-section-actions', ['book' => $book, 'watchOptions' => $watchOptions])
 @stop

--- a/resources/views/chapters/parts/form.blade.php
+++ b/resources/views/chapters/parts/form.blade.php
@@ -27,6 +27,22 @@
     </div>
 </div>
 
+@if(isset($chapter) && userCan(\BookStack\Permissions\Permission::AttachmentCreateAll))
+    <div class="form-group collapsible" component="collapsible" id="attachments-control">
+        <button refs="collapsible@trigger" type="button" class="collapse-title text-link" aria-expanded="false">
+            <label>{{ trans('entities.attachments') }}</label>
+        </button>
+        <div refs="collapsible@content" class="collapse-content">
+            @include('attachments.manager', [
+                'attachments' => $chapter->attachments->all(),
+                'uploadedToId' => $chapter->id,
+                'uploadedToType' => \BookStack\Uploads\Attachment::UPLOAD_TO_CHAPTER,
+                'allowInsertLinks' => false,
+            ])
+        </div>
+    </div>
+@endif
+
 <div class="form-group text-right">
     <a href="{{ isset($chapter) ? $chapter->getUrl() : $book->getUrl() }}" class="button outline">{{ trans('common.cancel') }}</a>
     <button type="submit" class="button">{{ trans('entities.chapters_save') }}</button>

--- a/resources/views/chapters/parts/show-sidebar-section-attachments.blade.php
+++ b/resources/views/chapters/parts/show-sidebar-section-attachments.blade.php
@@ -1,0 +1,6 @@
+@if($chapter->attachments->count() > 0)
+    <div id="chapter-attachments" class="mb-l">
+        <h5>{{ trans('entities.attachments') }}</h5>
+        @include('attachments.list', ['attachments' => $chapter->attachments])
+    </div>
+@endif

--- a/resources/views/chapters/show.blade.php
+++ b/resources/views/chapters/show.blade.php
@@ -63,6 +63,7 @@
 @stop
 
 @section('right')
+    @include('chapters.parts.show-sidebar-section-attachments', ['chapter' => $chapter])
     @include('chapters.parts.show-sidebar-section-details', ['chapter' => $chapter, 'book' => $book, 'watchOptions' => $watchOptions])
     @include('chapters.parts.show-sidebar-section-actions', ['chapter' => $chapter, 'watchOptions' => $watchOptions])
 @stop

--- a/resources/views/pages/parts/editor-toolbox.blade.php
+++ b/resources/views/pages/parts/editor-toolbox.blade.php
@@ -22,7 +22,12 @@
     </div>
 
     @if(userCan(\BookStack\Permissions\Permission::AttachmentCreateAll))
-        @include('attachments.manager', ['page' => $page])
+        @include('attachments.manager', [
+            'attachments' => $page->attachments->all(),
+            'uploadedToId' => $page->id,
+            'uploadedToType' => \BookStack\Uploads\Attachment::UPLOAD_TO_PAGE,
+            'allowInsertLinks' => true,
+        ])
     @endif
 
     <div refs="editor-toolbox@tab-content" data-tab-content="templates" class="toolbox-tab-content">

--- a/routes/web.php
+++ b/routes/web.php
@@ -163,8 +163,14 @@ Route::middleware('auth')->group(function () {
     Route::post('/attachments/link', [UploadControllers\AttachmentController::class, 'attachLink']);
     Route::put('/attachments/{id}', [UploadControllers\AttachmentController::class, 'update']);
     Route::get('/attachments/edit/{id}', [UploadControllers\AttachmentController::class, 'getUpdateForm']);
-    Route::get('/attachments/get/page/{pageId}', [UploadControllers\AttachmentController::class, 'listForPage']);
-    Route::put('/attachments/sort/page/{pageId}', [UploadControllers\AttachmentController::class, 'sortForPage']);
+    Route::get('/attachments/get/{entityType}/{entityId}', [UploadControllers\AttachmentController::class, 'listForEntity']);
+    Route::put('/attachments/sort/{entityType}/{entityId}', [UploadControllers\AttachmentController::class, 'sortForEntity']);
+    Route::get('/attachments/get/page/{entityId}', [UploadControllers\AttachmentController::class, 'listForEntity'])
+        ->defaults('entityType', 'page')
+        ->whereNumber('entityId');
+    Route::put('/attachments/sort/page/{entityId}', [UploadControllers\AttachmentController::class, 'sortForEntity'])
+        ->defaults('entityType', 'page')
+        ->whereNumber('entityId');
     Route::delete('/attachments/{id}', [UploadControllers\AttachmentController::class, 'delete']);
 
     // AJAX routes

--- a/tests/Api/AttachmentsApiTest.php
+++ b/tests/Api/AttachmentsApiTest.php
@@ -78,6 +78,28 @@ class AttachmentsApiTest extends TestCase
         $resp->assertJson(['id' => $newItem->id, 'external' => true, 'name' => $details['name'], 'uploaded_to' => $page->id]);
     }
 
+    public function test_create_endpoint_for_link_attachment_to_chapter()
+    {
+        $this->actingAsApiAdmin();
+        $chapter = $this->entities->chapter();
+
+        $details = [
+            'name' => 'My chapter attachment',
+            'uploaded_to' => $chapter->id,
+            'uploaded_to_type' => Attachment::UPLOAD_TO_CHAPTER,
+            'link' => 'https://cats.example.com/chapter.zip',
+        ];
+
+        $resp = $this->postJson($this->baseEndpoint, $details);
+        $resp->assertStatus(200);
+        $resp->assertJson([
+            'external' => true,
+            'name' => $details['name'],
+            'uploaded_to' => $chapter->id,
+            'uploaded_to_type' => Attachment::UPLOAD_TO_CHAPTER,
+        ]);
+    }
+
     public function test_create_endpoint_for_upload_attachment()
     {
         $this->actingAsApiAdmin();
@@ -363,6 +385,7 @@ class AttachmentsApiTest extends TestCase
         /** @var Attachment $attachment */
         $attachment = $page->attachments()->forceCreate(array_merge([
             'uploaded_to' => $page->id,
+            'uploaded_to_type' => Attachment::UPLOAD_TO_PAGE,
             'name'        => 'test attachment',
             'external'    => true,
             'order'       => 1,

--- a/tests/Helpers/FileProvider.php
+++ b/tests/Helpers/FileProvider.php
@@ -113,11 +113,14 @@ class FileProvider
     /**
      * Uploads an attachment file with the given name.
      */
-    public function uploadAttachmentFile(TestCase $case, string $name, int $uploadedTo = 0): TestResponse
+    public function uploadAttachmentFile(TestCase $case, string $name, int $uploadedTo = 0, string $uploadedToType = Attachment::UPLOAD_TO_PAGE): TestResponse
     {
         $file = $this->uploadedTextFile($name);
 
-        return $case->call('POST', '/attachments/upload', ['uploaded_to' => $uploadedTo], [], ['file' => $file], []);
+        return $case->call('POST', '/attachments/upload', [
+            'uploaded_to' => $uploadedTo,
+            'uploaded_to_type' => $uploadedToType,
+        ], [], ['file' => $file], []);
     }
 
     /**

--- a/tests/Uploads/AttachmentTest.php
+++ b/tests/Uploads/AttachmentTest.php
@@ -111,6 +111,50 @@ class AttachmentTest extends TestCase
         $this->files->deleteAllAttachmentFiles();
     }
 
+    public function test_can_upload_attachment_to_chapter()
+    {
+        $chapter = $this->entities->chapter();
+        $this->asAdmin();
+        $fileName = 'chapter_attachment.txt';
+
+        $upload = $this->files->uploadAttachmentFile($this, $fileName, $chapter->id, Attachment::UPLOAD_TO_CHAPTER);
+        $upload->assertStatus(200);
+        $upload->assertJson([
+            'uploaded_to' => $chapter->id,
+            'uploaded_to_type' => Attachment::UPLOAD_TO_CHAPTER,
+        ]);
+
+        $this->assertDatabaseHas('attachments', [
+            'name' => $fileName,
+            'uploaded_to' => $chapter->id,
+            'uploaded_to_type' => Attachment::UPLOAD_TO_CHAPTER,
+        ]);
+
+        $this->files->deleteAllAttachmentFiles();
+    }
+
+    public function test_can_attach_link_to_book()
+    {
+        $book = $this->entities->book();
+        $this->asAdmin();
+
+        $linkReq = $this->call('POST', 'attachments/link', [
+            'attachment_link_url' => 'https://example.com/book-file.zip',
+            'attachment_link_name' => 'Book ZIP',
+            'attachment_link_uploaded_to' => $book->id,
+            'attachment_link_uploaded_to_type' => Attachment::UPLOAD_TO_BOOK,
+        ]);
+
+        $linkReq->assertStatus(200);
+        $this->assertDatabaseHas('attachments', [
+            'name' => 'Book ZIP',
+            'path' => 'https://example.com/book-file.zip',
+            'uploaded_to' => $book->id,
+            'uploaded_to_type' => Attachment::UPLOAD_TO_BOOK,
+            'external' => true,
+        ]);
+    }
+
     public function test_attaching_long_links_to_a_page()
     {
         $page = $this->entities->page();


### PR DESCRIPTION
## Summary
This PR adds attachment support for chapters and books, in addition to existing page attachments.

I intentionally kept the structure and flow as close as possible to the existing page attachment implementation, to reduce behavioral differences and keep maintenance simple.

## What changed
- Added typed attachment targets (`uploaded_to_type`) so an attachment can belong to a page, chapter, or book.
- Extended attachment creation, listing, sorting, reading, update, and delete flows to resolve permissions by target type.
- Added book/chapter attachment relations and ensured page relations remain explicitly page-scoped.
- Reused the existing attachment manager UI with minimal structural changes and target-aware routing.
- Added sidebar attachment sections for book and chapter show pages.
- Ensured cleanup of chapter/book attachments during permanent deletion paths.
- Added migration and updated/added tests for chapter/book attachment scenarios.

## Testing
- Docker Compose (self-hosted):
  - `docker compose run --rm app sh -lc "php artisan migrate --database=mysql_testing --force && php artisan db:seed --class=DummyContentSeeder --database=mysql_testing --force"`
  - `docker compose run --rm app php artisan test tests/Uploads/AttachmentTest.php tests/Api/AttachmentsApiTest.php --filter="chapter|book"`
- Manual checks:
  - Tested the new attachment flows in Firefox 148.0.2.
  - Verified upload/link behavior on chapter and book edit screens.
  - Verified rendering/access on chapter and book show pages.

Closes #6042.
