### PR TITLE
Allow AWS SDK credential chain for S3 storage

### DIFF
--- a/app/Config/filesystems.php
+++ b/app/Config/filesystems.php
@@ -53,8 +53,13 @@ return [
 
         's3' => [
             'driver'                  => 's3',
-            'key'                     => env('STORAGE_S3_KEY', 'your-key'),
-            'secret'                  => env('STORAGE_S3_SECRET', 'your-secret'),
+            // When STORAGE_S3_KEY / STORAGE_S3_SECRET are unset, default to null
+            // so the AWS SDK falls back to its default credential provider chain
+            // (env vars, ECS/EKS container credentials, EC2 instance profile, ...).
+            // Providing non-null placeholders here would short-circuit the chain
+            // and force every call to use the placeholders as explicit credentials.
+            'key'                     => env('STORAGE_S3_KEY'),
+            'secret'                  => env('STORAGE_S3_SECRET'),
             'region'                  => env('STORAGE_S3_REGION', 'your-region'),
             'bucket'                  => env('STORAGE_S3_BUCKET', 'your-bucket'),
             'endpoint'                => env('STORAGE_S3_ENDPOINT', null),


### PR DESCRIPTION
## Summary

When running BookStack with `STORAGE_TYPE=s3` on infrastructure that provides AWS credentials via the SDK credential chain (EC2 instance profile, ECS task role on Fargate/EC2, EKS IRSA, Lambda execution role, etc.), all S3 operations fail with errors such as:

```
Unable to check existence for: uploads/images/gallery/2026-06/<file>.png
```

even though the environment correctly exposes credentials and the role has full S3+KMS permissions.

## Root cause

`app/Config/filesystems.php` defaulted `STORAGE_S3_KEY` to `'your-key'` and `STORAGE_S3_SECRET` to `'your-secret'`. When these env vars are not set, those literal placeholder strings are handed to the AWS PHP SDK as **explicit** credentials. Because explicit credentials are present, the SDK does not consult its default credential provider chain, and every S3 call fails with `403`, which Flysystem v3 wraps as `UnableToCheckFileExistence`.

The AWS SDK only walks the chain (env vars → container creds → instance metadata → ...) when `key` and `secret` are `null`/absent.

## Change

Default the `key` and `secret` of the `s3` disk to `env('STORAGE_S3_KEY')` / `env('STORAGE_S3_SECRET')` without a fallback (i.e. `null` when unset). Existing setups that set these env vars explicitly are unaffected; IAM-role-based setups now work out of the box.

## Reproduction (before)

1. Deploy BookStack on ECS Fargate with `STORAGE_TYPE=s3`, `STORAGE_S3_BUCKET`, `STORAGE_S3_REGION` set, and no `STORAGE_S3_KEY` / `STORAGE_S3_SECRET`.
2. Attach an IAM task role with the required S3/KMS permissions on the bucket.
3. `POST /api/image-gallery` → HTTP 500, `Unable to check existence for: …`.

## Workaround that confirmed the diagnosis

Setting `STORAGE_S3_KEY=null` and `STORAGE_S3_SECRET=null` (Laravel's `env()` converts the string `"null"` to PHP `null`) makes uploads succeed via the task role. With this PR that workaround is no longer needed.

## Test plan

- [ ] Existing S3 setups with explicit `STORAGE_S3_KEY`/`STORAGE_S3_SECRET` keep working.
- [ ] S3 setups on ECS/EC2 with an IAM role and no explicit credentials now work.
- [ ] Local / `local_secure` storage unaffected.