### PR TITLE
docs: fix typo excecute -> execute

### DIFF
--- a/app/Entities/Controllers/PageRevisionController.php
+++ b/app/Entities/Controllers/PageRevisionController.php
@@ -110,7 +110,7 @@ class PageRevisionController extends Controller
         $prevContent = $prev->html ?? '';
 
         // TODO - Refactor PageContent so we can de-dupe these steps
-        $rawDiff = Diff::excecute($prevContent, $revision->html);
+        $rawDiff = Diff::execute($prevContent, $revision->html);
         $filterConfig = HtmlContentFilterConfig::fromConfigString(config('app.content_filtering'));
         $filter = new HtmlContentFilter($filterConfig);
         $diff = $filter->filterString($rawDiff);


### PR DESCRIPTION
Corrects the misspelling `excecute` -> `execute` in `app/Entities/Controllers/PageRevisionController.php`.

Documentation only, no behaviour change.